### PR TITLE
Fixes ownerreference breaking reconciliation

### DIFF
--- a/internal/controller/clusterrolebindings.go
+++ b/internal/controller/clusterrolebindings.go
@@ -75,7 +75,7 @@ func newClusterRoleBinding(
 	rb := &rbac.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRoleBinding",
-			APIVersion: "v1",
+			APIVersion: "rbac.authorization.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crbName,

--- a/test/e2e/fixtures/paas_config.yml
+++ b/test/e2e/fixtures/paas_config.yml
@@ -80,4 +80,9 @@ quota_label: q.lbl
 whitelist:
   namespace: wlns
   name: wlname
+rolemappings:
+  default:
+    - admin
+  viewer:
+    - view
 exclude_appset_name: whatever


### PR DESCRIPTION
Fixes https://github.com/belastingdienst/opr-paas/issues/39

<!--- Please provide a general summary of your changes in the title above -->

Setting correct ownerreference in Secrets and Rolebindings to fix broken reconciliation. Also implemented a small refactor with changes a weird return err statement in a situation in which no error occured in the past. This was used to trigger another round of reconciliation but this is now implemented in a correct fashion.

This is mainly tested manually on a test cluster awaiting the e2e tests implemented in https://github.com/belastingdienst/opr-paas/pull/36

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->