### PR TITLE
Refactor wait step in e2e tests

### DIFF
--- a/test/e2e/clusterresourcequota_test.go
+++ b/test/e2e/clusterresourcequota_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
+	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/internal/quota"
 
-	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
 	quotav1 "github.com/openshift/api/quota/v1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -59,11 +59,9 @@ func assertCRQUpdated(ctx context.Context, t *testing.T, cfg *envconf.Config) co
 		"memory": "128Mi",
 	})
 
-	if err := cfg.Client().Resources().Update(ctx, paas); err != nil {
-		t.Fatalf("Failed to update Paas resource: %v", err)
+	if err := updatePaasSync(ctx, cfg, paas); err != nil {
+		t.Fatal(err)
 	}
-
-	waitForOperator()
 
 	crq := getCRQ(ctx, t, cfg)
 
@@ -74,7 +72,7 @@ func assertCRQUpdated(ctx context.Context, t *testing.T, cfg *envconf.Config) co
 }
 
 func assertCRQDeleted(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-	deletePaas(ctx, paasWithQuota, t, cfg)
+	deletePaasSync(ctx, paasWithQuota, t, cfg)
 	crqs := listOrFail(ctx, "", &quotav1.ClusterResourceQuotaList{}, t, cfg)
 
 	assert.Empty(t, crqs.Items)

--- a/test/e2e/groupusers_test.go
+++ b/test/e2e/groupusers_test.go
@@ -84,11 +84,9 @@ func assertGroupCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *envco
 		Users: []string{"bar"},
 	}
 
-	if err := cfg.Client().Resources().Update(ctx, paas); err != nil {
-		t.Fatalf("Failed to update Paas resource: %v", err)
+	if err := updatePaasSync(ctx, cfg, paas); err != nil {
+		t.Fatal(err)
 	}
-
-	waitForOperator()
 
 	group2 := getOrFail(ctx, group2Name, cfg.Namespace(), &userv1.Group{}, t, cfg)
 	whitelist := getOrFail(ctx, "wlname", "wlns", &corev1.ConfigMap{}, t, cfg)
@@ -121,7 +119,7 @@ func assertGroupCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *envco
 }
 
 func assertGroupsDeleted(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-	deletePaas(ctx, paasWithGroups, t, cfg)
+	deletePaasSync(ctx, paasWithGroups, t, cfg)
 	groups := listOrFail(ctx, "", &userv1.GroupList{}, t, cfg)
 
 	assert.Empty(t, groups.Items)

--- a/test/e2e/paas.go
+++ b/test/e2e/paas.go
@@ -1,0 +1,67 @@
+package e2e
+
+// Helper functions for manipulating Paas resources in a test.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+var reconcileStatusRegexp = regexp.MustCompile("^INFO: reconcile for .* succeeded$")
+
+// getPaas retrieves the Paas with the associated name.
+func getPaas(ctx context.Context, name string, t *testing.T, cfg *envconf.Config) *api.Paas {
+	return getOrFail(ctx, name, cfg.Namespace(), &api.Paas{}, t, cfg)
+}
+
+// createPaasSync requests Paas creation and returns once it has reconciled.
+func createPaasSync(ctx context.Context, cfg *envconf.Config, paas *api.Paas) error {
+	if err := cfg.Client().Resources().Create(ctx, paas); err != nil {
+		return fmt.Errorf("failed to create Paas %s: %w", paas.GetName(), err)
+	}
+
+	return waitForPaasReconciliation(ctx, cfg, paas)
+}
+
+// updatePaasSync requests an update to a Paas and returns once the Paas reports successful reconciliation.
+func updatePaasSync(ctx context.Context, cfg *envconf.Config, paas *api.Paas) error {
+	if err := cfg.Client().Resources().Update(ctx, paas); err != nil {
+		return fmt.Errorf("failed to update Paas %s: %w", paas.GetName(), err)
+	}
+
+	return waitForPaasReconciliation(ctx, cfg, paas)
+}
+
+// deletePaasSync deletes the Paas with the associated name.
+func deletePaasSync(ctx context.Context, name string, t *testing.T, cfg *envconf.Config) {
+	paas := &api.Paas{ObjectMeta: metav1.ObjectMeta{Name: name}}
+
+	if err := deleteResourceSync(ctx, cfg, paas); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// waitForPaasReconciliation polls a Paas resource, blocking until the Paas status reports successful reconciliation.
+func waitForPaasReconciliation(ctx context.Context, cfg *envconf.Config, paas *api.Paas) error {
+	waitCond := conditions.New(cfg.Client().Resources()).
+		ResourceMatch(paas, func(object k8s.Object) bool {
+			messages := object.(*api.Paas).Status.Messages
+
+			return reconcileStatusRegexp.MatchString(messages[len(messages)-1])
+		})
+
+	if err := waitForDefaultOpts(ctx, waitCond); err != nil {
+		return fmt.Errorf("failed waiting for Paas %s to be reconciled: %w", paas.GetName(), err)
+	}
+
+	return nil
+}

--- a/test/e2e/steps.go
+++ b/test/e2e/steps.go
@@ -1,0 +1,45 @@
+package e2e
+
+// Reusable step functions for end-to-end tests
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/types"
+)
+
+// createPaasFn accepts a Paas spec object and a name and creates the Paas resource.
+func createPaasFn(name string, paasSpec api.PaasSpec) types.StepFunc {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		paas := &api.Paas{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       paasSpec,
+		}
+
+		if err := createPaasSync(ctx, cfg, paas); err != nil {
+			t.Fatal(err)
+		}
+
+		return ctx
+	}
+}
+
+// teardownPaasFn deletes the Paas if it still exists (e.g. if deleting the Paas is not part of the test steps, or if an
+// earlier assertion failed causing the deletion step to be skipped).
+// Can be called as `.Teardown(teardownPaasFn("paas-name"))`
+func teardownPaasFn(paasName string) types.StepFunc {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		paas := &api.Paas{ObjectMeta: metav1.ObjectMeta{Name: paasName}}
+
+		if cfg.Client().Resources().Delete(ctx, paas) == nil {
+			t.Logf("Paas %s deleted", paasName)
+		}
+
+		return ctx
+	}
+}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -2,76 +2,45 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinerywait "k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
-	"sigs.k8s.io/e2e-framework/pkg/types"
 )
 
-// Duration to pause after Paas creation to wait for reconciliation.
-const waitForOperatorDuration = 1 * time.Second
+const (
+	// Interval for polling k8s to wait for resource changes
+	waitInterval = 1 * time.Second
+	waitTimeout  = 1 * time.Minute
+)
 
-func waitForOperator() {
-	time.Sleep(waitForOperatorDuration)
-}
+// deleteResourceSync requests resource deletion and returns once k8s has successfully deleted it.
+func deleteResourceSync(ctx context.Context, cfg *envconf.Config, obj k8s.Object) error {
+	resources := cfg.Client().Resources()
+	waitCond := conditions.New(resources).ResourceDeleted(obj)
 
-// createPaasFn accepts a Paas spec object and a name and creates the Paas resource.
-func createPaasFn(name string, paasSpec api.PaasSpec) types.StepFunc {
-	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-		paas := &api.Paas{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-			Spec:       paasSpec,
-		}
-
-		if err := cfg.Client().Resources().Create(ctx, paas); err != nil {
-			t.Fatalf("Failed to create Paas resource: %v", err)
-		}
-
-		waitForOperator()
-
-		return ctx
-	}
-}
-
-// teardownPaasFn deletes the Paas if it still exists (e.g. if deleting the Paas is not part of the test steps, or if an
-// earlier assertion failed causing the deletion step to be skipped).
-// Can be called as `.Teardown(teardownPaasFn("paas-name"))`
-func teardownPaasFn(paasName string) types.StepFunc {
-	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-		paas := &api.Paas{ObjectMeta: metav1.ObjectMeta{Name: paasName}}
-
-		if cfg.Client().Resources().Delete(ctx, paas) == nil {
-			t.Logf("Paas %s deleted", paasName)
-		}
-
-		return ctx
-	}
-}
-
-// getPaas retrieves the Paas with the associated name.
-func getPaas(ctx context.Context, name string, t *testing.T, cfg *envconf.Config) *api.Paas {
-	paas := &api.Paas{}
-	getOrFail(ctx, name, cfg.Namespace(), paas, t, cfg)
-
-	return paas
-}
-
-// deletePaas deletes the Paas with the associated name.
-func deletePaas(ctx context.Context, name string, t *testing.T, cfg *envconf.Config) {
-	paas := &api.Paas{ObjectMeta: metav1.ObjectMeta{Name: name}}
-
-	if err := cfg.Client().Resources().Delete(ctx, paas); err != nil {
-		t.Fatalf("Failed to delete Paas: %v", err)
+	if err := resources.Delete(ctx, obj); err != nil {
+		return fmt.Errorf("failed to delete resource %s: %w", obj.GetName(), err)
 	}
 
-	waitForOperator()
+	if err := waitForDefaultOpts(ctx, waitCond); err != nil {
+		return fmt.Errorf("failed waiting for resource %s to be deleted: %w", obj.GetName(), err)
+	}
+
+	return nil
 }
 
+// waitForDefaultOpts calls `wait.For()` with a set of default options.
+func waitForDefaultOpts(ctx context.Context, condition apimachinerywait.ConditionWithContextFunc) error {
+	return wait.For(condition, wait.WithContext(ctx), wait.WithInterval(waitInterval), wait.WithTimeout(waitTimeout))
+}
+
+// getOrFail retrieves a resource from k8s, failing the test if there is an error.
 func getOrFail[T k8s.Object](ctx context.Context, name string, namespace string, obj T, t *testing.T, cfg *envconf.Config) T {
 	if err := cfg.Client().Resources().Get(ctx, name, namespace, obj); err != nil {
 		t.Fatalf("Failed to get resource %s: %v", name, err)
@@ -80,6 +49,7 @@ func getOrFail[T k8s.Object](ctx context.Context, name string, namespace string,
 	return obj
 }
 
+// listOrFail retrieves a resource list from k8s, failing the test if there is an error.
 func listOrFail[L k8s.ObjectList](ctx context.Context, namespace string, obj L, t *testing.T, cfg *envconf.Config) L {
 	if err := cfg.Client().Resources(namespace).List(ctx, obj); err != nil {
 		t.Fatalf("Failed to get resource list: %v", err)


### PR DESCRIPTION
Use the e2e framework's mechanism for polling k8s for changes, as shown in
https://github.com/kubernetes-sigs/e2e-framework/tree/v0.4.0/examples/wait_for_resources

This replaces the previous implementation where each test would need to call `time.Sleep()` to wait an arbitrary amount of time for the operator to apply updates, which is sensitive to environment (a resource-constrained test environment might take longer to apply changes, meaning we need to tune the test suite for the lowest common denominator).

The `wait.For()` functionality from `sigs.k8s.io/e2e-framework` still waits an arbitrary (configurable) amount of time, but implements polling and timeouts and is generally more robust. This PR defines a few helper functions for synchronously creating, deleting, or updating k8s resources via the use of `wait.For()`.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): end-to-end test refactor
