### PR TITLE
ci: building image and pushing to ghcr.io for every release

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,35 @@
+name: Release workflow for building images and adding to ghcr.io
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  image:
+    name: Push Docker image to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: 'Build'
+        run: |
+          docker build -t opr-paas .
+      - name: 'tag and push to ghcr.io'
+        run: |
+          for TAG in latest ${{ github.ref_name }}; do
+            docker tag opr-paas ghcr.io/belastingdienst/opr-paas:${TAG}
+            docker push ghcr.io/belastingdienst/opr-paas:${TAG}
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,7 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN sed -i "s|PAAS_VERSION = .*|PAAS_VERSION = \"$VERSION\"|" internal/version/main.go && \
-    cat internal/version/main.go && \
-    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -v -a -o manager cmd/manager/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -v -a -X "internal.version.Version=$VERSION" -o manager cmd/manager/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, our pipeline does not build images for a new release

## What is the new behavior?

With this PR we introduce building images and adding them to ghcr.io for every release

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**Note** that this requires permissions on the opr-paas package.
**Note** that this also pushes to the opr-paas:latest, which means that releasing earlier versions will cause issues.
