### PR TITLE
chore: add missing plugin for MKDocs

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -43,6 +43,7 @@ jobs:
         run: |
           pip install mkdocs-material
           pip install mkdocs-literate-nav
+          pip install mkdocs-redirects
 
       - name: Build documentation
         env:


### PR DESCRIPTION
Add missing mkdocs-redirects plugin to docs build.

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
