### PR TITLE
fix: do not replace newlines when using inline reencrypt

### DIFF
--- a/cmd/crypttool/reencrypt.go
+++ b/cmd/crypttool/reencrypt.go
@@ -69,8 +69,8 @@ func reencryptFiles(privateKeyFiles string, publicKeyFile string, outputFormat s
 			}
 
 			paas.Spec.SshSecrets[key] = reencrypted
-			// Use replaceAll as same secret can occur multiple times
-			paasAsString = strings.ReplaceAll(paasAsString, secret, reencrypted)
+			// Use replaceAll as same secret can occur multiple times and use TrimSpace to prevent removal of newlines.
+			paasAsString = strings.ReplaceAll(paasAsString, strings.TrimSpace(secret), reencrypted)
 			logrus.Debugf("successfully reencrypted %s.spec.sshSecrets[%s] in file %s", paasName, key, fileName)
 		}
 
@@ -82,8 +82,8 @@ func reencryptFiles(privateKeyFiles string, publicKeyFile string, outputFormat s
 				}
 
 				cap.SetSshSecret(key, reencrypted)
-				// Use replaceAll as same secret can occur multiple times
-				paasAsString = strings.ReplaceAll(paasAsString, secret, reencrypted)
+				// Use replaceAll as same secret can occur multiple times and use TrimSpace to prevent removal of newlines.
+				paasAsString = strings.ReplaceAll(paasAsString, strings.TrimSpace(secret), reencrypted)
 				logrus.Debugf("successfully reencrypted %s.spec.capabilities[%s].sshSecrets[%s] in file %s", paasName, capName, key, fileName)
 			}
 		}


### PR DESCRIPTION
When using `crypttool receencrypt` on a Paas file that stores sshSecrets with a literal block scalar ("|") preserve the newline after the new secret.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Given a Paas object like this:

```yaml
---
apiVersion: cpet.belastingdienst.nl/v1alpha1
kind: Paas
metadata:
  name: my-paas
spec:
  sshSecrets:
    "ssh://git@github.com/belastingdienst/paas.git": |
      2wkeKebCnqgl...L/jDAUmhWG3ng==
  requestor: my-team
[...]
```

...running `crypttool reencrypt --privateKeyFiles priv/ --publicKeyFile publicKey --outputFormat preserved my-paas.yaml` will result in this:

```yaml
---
apiVersion: cpet.belastingdienst.nl/v1alpha1
kind: Paas
metadata:
  name: my-paas
spec:
  sshSecrets:
    "ssh://git@github.com/belastingdienst/paas.git": |
      2wkeKebCnqgl...L/jDAUmhWG3ng==  requestor: my-team
[...]
```


## What is the new behavior?

Given a Paas object like this:

```yaml
---
apiVersion: cpet.belastingdienst.nl/v1alpha1
kind: Paas
metadata:
  name: my-paas
spec:
  sshSecrets:
    "ssh://git@github.com/belastingdienst/paas.git": |
      2wkeKebCnqgl...L/jDAUmhWG3ng==
  requestor: my-team
[...]
```

...running `crypttool reencrypt --privateKeyFiles priv/ --publicKeyFile publicKey --outputFormat preserved my-paas.yaml` will result in this:

```yaml
---
apiVersion: cpet.belastingdienst.nl/v1alpha1
kind: Paas
metadata:
  name: my-paas
spec:
  sshSecrets:
    "ssh://git@github.com/belastingdienst/paas.git": |
      2wkeKebCnqgl...L/jDAUmhWG3ng==
  requestor: my-team
[...]
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->