### PR TITLE
ci: release-drafter refinements: permissions to label issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,13 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
+  #  # pull_request event is required only for autolabeler
+  #  pull_request:
+  #    # Only following types are handled by the action, but one can default to all as well
+  #    types: [opened, reopened, synchronize]
   # pull_request_target event is required for autolabeler to support PRs from forks
-  # pull_request_target:
-  #   types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -24,6 +24,7 @@ jobs:
       # write permission is required for autolabeler
       # otherwise, read permission is required at least
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       # (Optional) GitHub Enterprise requires GHE_HOST variable set


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Actions run from context of remote forks
- Actions for PR's on forks run with lower permissions.

## What is the new behavior?

- Actions run from context of local branches
- Actions for PR's on forks run with higher permissions (using GITHUB_TOKEN)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

