### PR TITLE
ci: Change name of binary to crypttool

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,7 @@ builds:
       - goos: windows
         goarch: arm64
     main: ./cmd/crypttool
+    binary: crypttool
     ldflags:
       - -s -w -X "internal.version.Version={{.Version}}"
 


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Seems like the binary is called opr-paas instead op crypttool

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

