### PR TITLE
test: argoCD end-to-end test

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -158,8 +158,11 @@ jobs:
         timeout-minutes: 20
         run: |
           set -x
+          set +e
           make test-e2e
+          exitcode=$(echo $?)
           killall goreman run stop-all || echo "trouble killing goreman"
           sleep 30
           echo "Operator logs"
           cat /tmp/e2e-server.log
+          exit "$exitcode"

--- a/test/e2e/capability-sso_test.go
+++ b/test/e2e/capability-sso_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
@@ -67,26 +66,10 @@ func assertCapSSOCreated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 
 	// List entries should not be empty
 	require.NoError(t, appSetListEntriesError)
-	assert.NotEmpty(t, applicationSetListEntries)
-
-	// Flag to check if we find a JSON object
-	foundNameTest := false
-
-	for _, jsonString := range applicationSetListEntries {
-		var obj map[string]interface{}
-		err := json.Unmarshal([]byte(jsonString), &obj)
-
-		// Check of json successfully unmarshalled
-		require.NoError(t, err)
-
-		// Check if the JSON object has a "paas" property with value "paasnaam"
-		if paas, ok := obj["paas"]; ok && paas == paasWithCapabilitySSO {
-			foundNameTest = true
-		}
-	}
+	assert.Len(t, applicationSetListEntries, 1)
 
 	// At least one JSON object should have "paas": "paasnaam"
-	assert.True(t, foundNameTest)
+	assert.Equal(t, paasWithCapabilitySSO, applicationSetListEntries[0]["paas"])
 
 	// Check whether the LabelSelector is specific to the paasnaam-sso namespace
 	labelSelector := ssoQuota.Spec.Selector.LabelSelector

--- a/test/e2e/capabilityargocd_test.go
+++ b/test/e2e/capabilityargocd_test.go
@@ -1,0 +1,99 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/quota"
+	argo "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
+
+	quotav1 "github.com/openshift/api/quota/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	paasWithArgo        = "paas-capability-argocd"
+	paasArgoNamespace   = paasWithArgo + "-argocd"
+	paasArgoGitUrl      = "ssh://git@scm/some-repo.git"
+	paasArgoGitPath     = "foo/"
+	paasArgoGitRevision = "main"
+	// String `dummysecret` encrypted with fixtures/crypt/pub/publicKey0
+	paasArgoSecret = "mPNADW4KlAYmiBSXfgyoP6G0h/8prFQNH7VBFXB3xiZ8wij2sRIgKekVUC3N9cHk73wkuewoH2fyM0BH2P1xKvSP4v4wwzq+fJC6qxx+d/lucrfnBHWCpsAr646OVYyoH8Er6PpBrPxM+OXCjVsXhd/8CGA32VzcUKSrAWBVWTgXpJ4/X/9gez865AmZkfFf2WBImYgs5Q/rH/mPP1jxl3WP10g51FLi4XG1qn2XdLRzBKXRKluh+PvMRYgqZ8QKl2Yd2HWj1SkzXrtayB7197r0fQ6t4cwpn8mqy30GQhsw6NEPSkcYakukOX2PYeRIVCwmMl3uEe9X1y7fesQVBMnq1loQJRpd7kBUj6EErnKNZ9Qa8tOXYLMME2tzsaYWz+rxhczCaMv9r55EGBENRB0K6VMY4jfC4NKkcVwgZm182/Z1wzOnPbhSKAoaSYUXVrsNfjuzlvQGJmaNF4onDgJdVpqJxkEH98E3q+NMlSYhIzZDph1RDjHmUm2aoAhx2W9zle+LsOWHLgogPHRwY+N7NRII5SBEnw99miCAQVqHnpEk0uITzny0G5AuoS9aKmVhbUNNR1TgZ6u2dFjrkbnZB0GKilJhVENM+oE8Fbq7Q4Qa9wtk/GK1myPNvY7ARbw1tfvbcpJT/NtKnEKsho/OVzfHn15W3niNVpXrZgs=" //nolint:gosec
+)
+
+func TestCapabilityArgoCD(t *testing.T) {
+	paasSpec := api.PaasSpec{
+		Requestor: "paas-requestor",
+		Quota:     quota.Quotas{},
+		Capabilities: api.PaasCapabilities{
+			ArgoCD: api.PaasArgoCD{
+				Enabled:     true,
+				SshSecrets:  map[string]string{paasArgoGitUrl: paasArgoSecret},
+				GitUrl:      paasArgoGitUrl,
+				GitPath:     paasArgoGitPath,
+				GitRevision: paasArgoGitRevision,
+			},
+		},
+	}
+
+	testenv.Test(
+		t,
+		features.New("ArgoCD Capability").
+			Setup(createPaasFn(paasWithArgo, paasSpec)).
+			Assess("ArgoCD application is created", assertArgoCDCreated).
+			Teardown(teardownPaasFn(paasWithArgo)).
+			Feature(),
+	)
+}
+
+func assertArgoCDCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	argopaasns := getOrFail(ctx, "argocd", paasWithArgo, &api.PaasNS{}, t, cfg)
+	require.NoError(t, waitForPaasNSReconciliation(ctx, cfg, argopaasns), "ArgoCD PaasNS reconciliation succeeds")
+
+	argoAppSet := getOrFail(ctx, "argoas", "asns", &argo.ApplicationSet{}, t, cfg)
+	entries, _ := getApplicationSetListEntries(argoAppSet)
+
+	assert.Len(t, entries, 1, "ApplicationSet contains one List generator")
+	assert.Equal(t, map[string]string{
+		"paas":       paasWithArgo,
+		"requestor":  "paas-requestor",
+		"service":    "paas",
+		"subservice": "capability",
+	}, entries[0], "ApplicationSet List generator contains the correct parameters")
+
+	assert.NotNil(t, getOrFail(ctx, paasArgoNamespace, corev1.NamespaceAll, &corev1.Namespace{}, t, cfg), "ArgoCD namespace created")
+
+	applications := listOrFail(ctx, paasArgoNamespace, &argo.ApplicationList{}, t, cfg).Items
+	assert.Len(t, applications, 1, "An application is present in the ArgoCD namespace")
+	assert.Equal(t, "paas-bootstrap", applications[0].Name)
+	assert.Equal(t, argo.ApplicationSource{
+		RepoURL:        paasArgoGitUrl,
+		Path:           paasArgoGitPath,
+		TargetRevision: paasArgoGitRevision,
+	}, *applications[0].Spec.Source, "Application source matches Git properties from Paas")
+	assert.Equal(t, "whatever", applications[0].Spec.IgnoreDifferences[0].Name, "`exclude_appset_name` configuration is included in IgnoreDifferences")
+
+	secrets := listOrFail(ctx, paasArgoNamespace, &corev1.SecretList{}, t, cfg).Items
+	assert.Len(t, secrets, 1)
+	assert.Equal(t, "dummysecret", string(secrets[0].Data["sshPrivateKey"]), "SSH secret is created in ArgoCD namespace")
+
+	crq := getOrFail(ctx, paasArgoNamespace, corev1.NamespaceAll, &quotav1.ClusterResourceQuota{}, t, cfg)
+	assert.Equal(t, "q.lbl="+paasArgoNamespace, metav1.FormatLabelSelector(crq.Spec.Selector.LabelSelector), "Quota selects ArgoCD namespace via selector set to `quota_label` configuration")
+	assert.Equal(t, corev1.ResourceList{
+		corev1.ResourceLimitsCPU:                                  resource.MustParse("5"),
+		corev1.ResourceRequestsCPU:                                resource.MustParse("1"),
+		corev1.ResourceLimitsMemory:                               resource.MustParse("4Gi"),
+		corev1.ResourceRequestsMemory:                             resource.MustParse("1Gi"),
+		corev1.ResourceRequestsStorage:                            resource.MustParse("0"),
+		"thin.storageclass.storage.k8s.io/persistentvolumeclaims": resource.MustParse("0"),
+	}, crq.Spec.Quota.Hard, "Quota conforms to defaults from Paas config")
+
+	return ctx
+}

--- a/test/e2e/paasns.go
+++ b/test/e2e/paasns.go
@@ -1,0 +1,28 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
+
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+// waitForPaasNSReconciliation polls a PaasNS resource, blocking until the status reports successful reconciliation.
+func waitForPaasNSReconciliation(ctx context.Context, cfg *envconf.Config, paasns *api.PaasNS) error {
+	waitCond := conditions.New(cfg.Client().Resources()).
+		ResourceMatch(paasns, func(object k8s.Object) bool {
+			messages := object.(*api.PaasNS).Status.Messages
+
+			return reconcileStatusRegexp.MatchString(messages[len(messages)-1])
+		})
+
+	if err := waitForDefaultOpts(ctx, waitCond); err != nil {
+		return fmt.Errorf("failed waiting for PaasNS %s to be reconciled: %w", paasns.GetName(), err)
+	}
+
+	return nil
+}

--- a/test/e2e/steps.go
+++ b/test/e2e/steps.go
@@ -36,9 +36,8 @@ func teardownPaasFn(paasName string) types.StepFunc {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		paas := &api.Paas{ObjectMeta: metav1.ObjectMeta{Name: paasName}}
 
-		if cfg.Client().Resources().Delete(ctx, paas) == nil {
-			t.Logf("Paas %s deleted", paasName)
-		}
+		// Paas is deleted synchronously to prevent race conditions between test invocations
+		_ = deleteResourceSync(ctx, cfg, paas)
 
 		return ctx
 	}


### PR DESCRIPTION
Defines new test for the ArgoCD capability. Some of the test specification in https://github.com/belastingdienst/opr-paas/blob/main/docs/development-guide/e2e-test-details.md#capability-argocd sounded slightly unfinished/vague, so there are a couple things I haven't yet addressed. But I can work on those in a follow-up PR.

Also contains a bug-fix for a race condition found by this end-to-end test:
When retrieving secrets for a capability, the PaasNS controller pulls all secrets from the Paas capabilities specification, as well as from the PaasNS spec. But the PaasNS for the capability itself defines its secret based on the capability specification, so this guarantees duplicate secret definitions. The ensuing create-or-update loop iterating over the list of secrets then contains a race condition where the creation of the first secret must be completed by Kubernetes before the second iteration updates it; otherwise the duplicate will attempt to be created resulting in failure. The fix is to deduplicate the secrets list prior to creation or updates.

Lastly, contains a small update to the CI workflow to ensure the operator logs are printed even if the tests fail. Otherwise, the default `set -e` shell configuration would abort the step prior to printing the logs.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): new end-to-end test

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
