### PR TITLE
refactor: retrieve logger from request context

### DIFF
--- a/internal/controller/argo_app.go
+++ b/internal/controller/argo_app.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/log"
 	argo "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -34,7 +35,7 @@ func (r *PaasNSReconciler) EnsureArgoApp(
 		return nil
 	}
 
-	logger := getLogger(ctx, paasns, "ArgoApp", appName)
+	ctx, logger := log.WithAttributes(ctx, "ArgoApp", appName)
 	namespacedName := types.NamespacedName{
 		Namespace: paasns.NamespaceName(),
 		Name:      appName,

--- a/internal/controller/argo_projects.go
+++ b/internal/controller/argo_projects.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/log"
 	argo "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
-	"github.com/go-logr/logr"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,8 +23,8 @@ import (
 func (r *PaasReconciler) EnsureAppProject(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
-	logger logr.Logger,
 ) error {
+	logger := log.Get(ctx)
 	logger.Info("Creating Argo Project")
 	project := r.BackendAppProject(ctx, paas)
 	namespacedName := types.NamespacedName{

--- a/internal/controller/cluster_quotas.go
+++ b/internal/controller/cluster_quotas.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/log"
 	paas_quota "github.com/belastingdienst/opr-paas/internal/quota"
 
-	"github.com/go-logr/logr"
 	quotav1 "github.com/openshift/api/quota/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -227,8 +227,8 @@ func (r *PaasReconciler) FinalizeClusterQuotas(ctx context.Context, paas *v1alph
 func (r *PaasReconciler) ReconcileQuotas(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
-	logger logr.Logger,
 ) (err error) {
+	logger := log.Get(ctx)
 	logger.Info("Creating quotas for PAAS object ")
 	// Create quotas if needed
 	if quotas, err := r.BackendEnabledQuotas(ctx, paas); err != nil {

--- a/internal/controller/groups.go
+++ b/internal/controller/groups.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/log"
 
-	"github.com/go-logr/logr"
 	userv1 "github.com/openshift/api/user/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -208,8 +208,8 @@ func (r *PaasReconciler) FinalizeGroups(
 func (r *PaasReconciler) ReconcileGroups(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
-	logger logr.Logger,
 ) error {
+	logger := log.Get(ctx)
 	logger.Info("Creating groups for PAAS object ")
 	for _, group := range r.BackendGroups(ctx, paas) {
 		if err := r.EnsureGroup(ctx, paas, group); err != nil {

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -11,17 +11,18 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/log"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/belastingdienst/opr-paas/api/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const paasFinalizer = "paas.cpet.belastingdienst.nl/finalizer"
@@ -122,7 +123,7 @@ func (r *PaasReconciler) GetPaas(
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	paas := &v1alpha1.Paas{ObjectMeta: metav1.ObjectMeta{Name: req.Name}}
-	logger := getLogger(ctx, paas, "Paas", req.Name)
+	logger := log.Get(ctx)
 	logger.Info("Reconciling the Paas object")
 	errResult := reconcile.Result{
 		Requeue:      true,
@@ -148,19 +149,19 @@ func (r *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		}
 	}()
 
-	if err := r.ReconcileQuotas(ctx, paas, logger); err != nil {
+	if err := r.ReconcileQuotas(ctx, paas); err != nil {
 		return errResult, err
 	} else if err = r.ReconcileClusterWideQuota(ctx, paas); err != nil {
 		return errResult, err
-	} else if err = r.ReconcilePaasNss(ctx, paas, logger); err != nil {
+	} else if err = r.ReconcilePaasNss(ctx, paas); err != nil {
 		return errResult, err
-	} else if err = r.EnsureAppProject(ctx, paas, logger); err != nil {
+	} else if err = r.EnsureAppProject(ctx, paas); err != nil {
 		return errResult, err
-	} else if err = r.ReconcileGroups(ctx, paas, logger); err != nil {
+	} else if err = r.ReconcileGroups(ctx, paas); err != nil {
 		return errResult, err
 	} else if err = r.EnsureLdapGroups(ctx, paas); err != nil {
 		return errResult, err
-	} else if err = r.ReconcileRolebindings(ctx, paas, logger); err != nil {
+	} else if err = r.ReconcileRolebindings(ctx, paas); err != nil {
 		return errResult, err
 	}
 

--- a/internal/controller/paasnamespaces.go
+++ b/internal/controller/paasnamespaces.go
@@ -10,14 +10,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/log"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func (r *PaasReconciler) GetPaasNs(ctx context.Context, paas *v1alpha1.Paas, name string,
@@ -125,8 +125,8 @@ func (r *PaasReconciler) FinalizePaasNss(ctx context.Context, paas *v1alpha1.Paa
 func (r *PaasReconciler) ReconcilePaasNss(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
-	logger logr.Logger,
 ) error {
+	logger := log.Get(ctx)
 	logger.Info("Creating default namespace to hold PaasNs resources for PAAS object")
 	if ns, err := BackendNamespace(ctx, paas, paas.Name, paas.Name, r.Scheme); err != nil {
 		logger.Error(err, fmt.Sprintf("Failure while defining namespace %s", paas.Name))

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
-	"github.com/go-logr/logr"
+	"github.com/belastingdienst/opr-paas/internal/log"
 
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -184,8 +184,9 @@ func FinalizeRoleBinding(
 func (r *PaasReconciler) ReconcileRolebindings(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
-	logger logr.Logger,
 ) error {
+	logger := log.Get(ctx)
+
 	for _, paasns := range r.pnsFromNs(ctx, paas.ObjectMeta.Name) {
 		roles := make(map[string][]string)
 
@@ -228,8 +229,8 @@ func (r *PaasNSReconciler) ReconcileRolebindings(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 	paasns *v1alpha1.PaasNS,
-	logger logr.Logger,
 ) error {
+	logger := log.Get(ctx)
 	// Creating a list of roles and the groups that should have them, for this namespace
 	roles := make(map[string][]string)
 	for groupName, groupRoles := range paas.Spec.Groups.Filtered(paasns.Spec.Groups).Roles() {

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
-	"github.com/go-logr/logr"
+	"github.com/belastingdienst/opr-paas/internal/log"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -171,8 +171,8 @@ func (r *PaasNSReconciler) ReconcileSecrets(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 	paasns *v1alpha1.PaasNS,
-	logger logr.Logger,
 ) error {
+	logger := log.Get(ctx)
 	// Create argo ssh secrets
 	logger.Info("Creating Ssh secrets")
 	secrets := r.BackendSecrets(ctx, paasns, paas)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,27 @@
+package log
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// Get grabs the logger from the current context
+func Get(ctx context.Context) logr.Logger {
+	return ctrl.LoggerFrom(ctx)
+}
+
+// WithComponent derives a context with a logger namespaced by component name
+func WithComponent(ctx context.Context, component string) (context.Context, logr.Logger) {
+	logger := Get(ctx).WithName(component)
+
+	return ctrl.LoggerInto(ctx, logger), logger
+}
+
+// WithAttributes derives a context with a logger with additional attributes
+func WithAttributes(ctx context.Context, keysAndValues ...any) (context.Context, logr.Logger) {
+	logger := Get(ctx).WithValues(keysAndValues...)
+
+	return ctrl.LoggerInto(ctx, logger), logger
+}


### PR DESCRIPTION
We shouldn't need to pass logger instances around that are already available via the request context. This changeset defines a new interface that simplifies setting and retrieving the logger instance.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
