### PR TITLE
ci: regenerate licenses.md on push to main

### DIFF
--- a/.github/workflows/build-and-commit-licensesmd.yaml
+++ b/.github/workflows/build-and-commit-licensesmd.yaml
@@ -1,0 +1,80 @@
+name: Build and commit LICENSES.md on push to main
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sbom:
+    name: Generate and commit updated LICENSES.md
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/amd64
+        goos: [linux]
+        goarch: [amd64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate SBOM
+        uses: CycloneDX/gh-gomod-generate-sbom@v2
+        with:
+          version: v1
+          # added assert-licenses as required by dependency-track
+          args: mod -licenses -assert-licenses -output sources_${{ matrix.goos }}_${{ matrix.goarch }}.sbom.xml
+        env:
+          GOARCH: ${{ matrix.goarch }}
+          GOOS: ${{ matrix.goos }}
+
+      - name: Generate LICENSES.md
+        uses: mvdkleijn/licenses-action@v1
+        with:
+          sbom: sources_${{ matrix.goos }}_${{ matrix.goarch }}.sbom.xml
+          type: xml
+          filename: LICENSES.md
+          template: |
+            # Licenses
+
+            The following third-party licenses are applicable to this project:
+
+            {{range .SortedKeys}}## {{.}}
+
+            {{range index $.ComponentsByLicense .}}- {{.Name}} ({{.Version}})
+            {{end}}
+            {{end}}
+
+      - name: Commit updated LICENSES.md
+        run: |
+            export TODAY=$( date -u '+%Y-%m-%d' )
+            export DESTINATION_BRANCH="${{ github.ref_name }}"
+            export FILENAME="LICENSES.md"
+            # main branch already exists, so no need to push
+            # git push origin HEAD:refs/heads/${DESTINATION_BRANCH}
+            git fetch origin ${DESTINATION_BRANCH}
+
+            # Check if only one file was changed and it's LICENSES.md
+            CHANGED_FILES=$(git diff --name-only)
+            if [[ $(echo "$CHANGED_FILES" | wc -l) -eq 1 ]] && [[ "$CHANGED_FILES" == "$FILENAME" ]]; then
+            
+              export MESSAGE="chore: regenerate ${FILENAME} for ${TODAY}"
+              export SHA=$( git rev-parse origin/${DESTINATION_BRANCH}:${FILENAME} )
+              export CONTENT=$( base64 -w 0 -i ${FILENAME} )
+
+              # https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents
+              gh api --method PUT \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  /repos/:owner/:repo/contents/$FILENAME \
+                  -f "message=${MESSAGE}" \
+                  -f "content=${CONTENT}" \
+                  -f "encoding=base64" \
+                  -f "branch=${DESTINATION_BRANCH}" \
+                  -f "sha=${SHA}"
+            else
+              echo "Skipping commit to main: either multiple files were changed or the changed file is not LICENSES.md"
+            fi
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a workflow that regenerates LICENSES.md and commits it to main on push to main.

Fixes #10 

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [X] No