### PR TITLE
fix(ci): only build licenses.md based on linux/amd64

### DIFF
--- a/.github/workflows/build-and-release-sbom.yml
+++ b/.github/workflows/build-and-release-sbom.yml
@@ -30,6 +30,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
 
       - name: Generate LICENSES.md
+        if: ${{ matrix.goarch == 'amd64' && matrix.goos == 'linux' }}
         uses: mvdkleijn/licenses-action@v1
         with:
           # We only use the linux_amd64 variant here for generating the LICENSES.md


### PR DESCRIPTION
Correct workflow step to only run on linux/amd64

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
