### PR TITLE
featur: expose checkPaas as a webservice endpoint.

### DIFF
--- a/.github/workflows/build-and-release-images.yml
+++ b/.github/workflows/build-and-release-images.yml
@@ -38,7 +38,7 @@ jobs:
           images: |
             name=ghcr.io/belastingdienst/opr-paas,enable=true
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{raw}}
             type=raw,value=latest
             type=sha
 

--- a/.github/workflows/build-and-release-images.yml
+++ b/.github/workflows/build-and-release-images.yml
@@ -53,7 +53,7 @@ jobs:
           build-args: VERSION=${{ github.ref_name }}
 
       - name: Generate opr-paas image SBOM
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: 'ghcr.io/belastingdienst/opr-paas'
           scan-type: image
@@ -62,6 +62,9 @@ jobs:
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           severity: 'MEDIUM,HIGH,CRITICAL'
           scanners: 'vuln'
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Add SBOM to release
         uses: softprops/action-gh-release@v2
@@ -117,7 +120,7 @@ jobs:
           build-args: VERSION=${{ github.ref_name }}
 
       - name: Generate webservice image SBOM
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: 'ghcr.io/belastingdienst/webservice'
           scan-type: image
@@ -126,6 +129,9 @@ jobs:
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           severity: 'MEDIUM,HIGH,CRITICAL'
           scanners: 'vuln'
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Add SBOM to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-and-release-sbom.yml
+++ b/.github/workflows/build-and-release-sbom.yml
@@ -30,6 +30,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
 
       - name: Generate LICENSES.md
+        if: ${{ matrix.goarch == 'amd64' && matrix.goos == 'linux' }}
         uses: mvdkleijn/licenses-action@v1
         with:
           # We only use the linux_amd64 variant here for generating the LICENSES.md

--- a/.github/workflows/update-trivy-cache.yml
+++ b/.github/workflows/update-trivy-cache.yml
@@ -1,0 +1,39 @@
+# Note: This workflow only updates the cache. You should create a separate workflow
+# for your actual Trivy scans. In your scan workflow, set TRIVY_SKIP_DB_UPDATE=true
+# and TRIVY_SKIP_JAVA_DB_UPDATE=true.
+#
+# src: https://github.com/marketplace/actions/aqua-security-trivy#cache
+name: Update Trivy Cache
+
+on:
+  schedule:
+    - cron: '23 0 * * *'  # Run daily at 23 past midnight UTC (23 chosen randomly)
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-trivy-db:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download and extract the vulnerability DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      - name: Download and extract the Java DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.date.outputs.date }}

--- a/cmd/webservice/check_paas.go
+++ b/cmd/webservice/check_paas.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024, Tax Administration of The Netherlands.
+Licensed under the EUPL 1.2.
+See LICENSE.md for details.
+*/
+
+package main
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+
+	"github.com/belastingdienst/opr-paas/internal/crypt"
+	"github.com/sirupsen/logrus"
+)
+
+// CheckPaas determines whether a Paas can be decrypted using the provided crypt
+// it returns an error containing which secrets cannot be decrypted if any
+func CheckPaas(crypt *crypt.Crypt, paas *v1alpha1.Paas) error {
+	var allErrors []string
+	for key, secret := range paas.Spec.SshSecrets {
+		decrypted, err := crypt.Decrypt(secret)
+		if err != nil {
+			errMessage := fmt.Errorf("%s: .spec.sshSecrets[%s], error: %w.", paas.Name, key, err)
+			logrus.Error(errMessage)
+			allErrors = append(allErrors, errMessage.Error())
+		} else {
+			logrus.Infof("%s: .spec.sshSecrets[%s], checksum: %s, len %d.", paas.Name, key, hashData(decrypted), len(decrypted))
+		}
+	}
+
+	for capName, capability := range paas.Spec.Capabilities.AsMap() {
+		logrus.Debugf("capability name: %s", capability.CapabilityName())
+		for key, secret := range capability.GetSshSecrets() {
+			decrypted, err := crypt.Decrypt(secret)
+			if err != nil {
+				errMessage := fmt.Errorf("%s: .spec.capabilities[%s].sshSecrets[%s], error: %w.", paas.Name, capName, key, err)
+				logrus.Error(errMessage)
+				allErrors = append(allErrors, errMessage.Error())
+			} else {
+				logrus.Infof("%s: .spec.capabilities[%s].sshSecrets[%s], checksum: %s, len %d.", paas.Name, capName, key, hashData(decrypted), len(decrypted))
+			}
+		}
+	}
+	if len(allErrors) > 0 {
+		errorString := strings.Join(allErrors, " , ")
+		return errors.New(errorString)
+	}
+	return nil
+}
+
+func hashData(original []byte) string {
+	sum := sha512.Sum512(original)
+	return hex.EncodeToString(sum[:])
+}

--- a/cmd/webservice/check_paas_test.go
+++ b/cmd/webservice/check_paas_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	v1alpha1 "github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/crypt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCheckPaas(t *testing.T) {
+	// generate private/public keys
+	priv, err := os.CreateTemp("", "private")
+	require.NoError(t, err, "Creating tempfile for private key")
+	defer os.Remove(priv.Name()) // clean up
+
+	pub, err := os.CreateTemp("", "public")
+	require.NoError(t, err, "Creating tempfile for public key")
+	defer os.Remove(pub.Name()) // clean up
+
+	crypt.NewGeneratedCrypt(priv.Name(), pub.Name()) //nolint:errcheck // this is fine in test
+
+	getConfig()
+	_config.PublicKeyPath = pub.Name()
+	_config.PrivateKeyPath = priv.Name()
+	assert.Nil(t, _crypt)
+	rsa := getRsa("paasName")
+
+	encrypted, err := rsa.Encrypt([]byte("My test string"))
+	require.NoError(t, err)
+
+	toBeDecryptedPaas := &v1alpha1.Paas{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "paasName",
+		},
+		Spec: v1alpha1.PaasSpec{
+			SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted},
+			Capabilities: v1alpha1.PaasCapabilities{
+				SSO: v1alpha1.PaasSSO{Enabled: true, SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted}},
+			},
+		},
+	}
+
+	err = CheckPaas(rsa, toBeDecryptedPaas)
+	require.NoError(t, err)
+
+	notTeBeDecryptedPaas := &v1alpha1.Paas{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "paasName",
+		},
+		Spec: v1alpha1.PaasSpec{SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": "bm90RGVjcnlwdGFibGU="}},
+	}
+
+	// Must be able to decrypt this
+	err = CheckPaas(rsa, notTeBeDecryptedPaas)
+	require.Error(t, err)
+
+	partialToBeDecrypedPaas := &v1alpha1.Paas{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "paasName",
+		},
+		Spec: v1alpha1.PaasSpec{
+			SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted},
+			Capabilities: v1alpha1.PaasCapabilities{
+				SSO: v1alpha1.PaasSSO{Enabled: true, SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": "bm90RGVjcnlwdGFibGU="}},
+			},
+		},
+	}
+
+	// Must be able to decrypt this
+	err = CheckPaas(rsa, partialToBeDecrypedPaas)
+	require.Error(t, err)
+}

--- a/cmd/webservice/config.go
+++ b/cmd/webservice/config.go
@@ -16,14 +16,18 @@ import (
 
 const (
 	publicEnv           = "PAAS_PUBLIC_KEY_PATH"
+	privateKeyEnv       = "PAAS_PRIVATE_KEYS_PATH"
 	defaultPublicPath   = "/secrets/paas/publicKey"
+	defaultPrivatePath  = "/secrets/paas/privateKeys"
 	endpointEnv         = "PAAS_ENDPOINT"
 	defaultEndpointPort = 8080
 )
 
 type WSConfig struct {
 	PublicKeyPath string
-	Endpoint      string
+	// comma separated list of privateKeyPaths
+	PrivateKeyPath string
+	Endpoint       string
 }
 
 func formatEndpoint(endpoint string) string {
@@ -69,6 +73,10 @@ func NewWSConfig() WSConfig {
 	config.PublicKeyPath = os.Getenv(publicEnv)
 	if config.PublicKeyPath == "" {
 		config.PublicKeyPath = defaultPublicPath
+	}
+	config.PrivateKeyPath = os.Getenv(privateKeyEnv)
+	if config.PrivateKeyPath == "" {
+		config.PrivateKeyPath = defaultPrivatePath
 	}
 	config.Endpoint = formatEndpoint(os.Getenv(endpointEnv))
 

--- a/cmd/webservice/data.go
+++ b/cmd/webservice/data.go
@@ -6,6 +6,8 @@ See LICENSE.md for details.
 
 package main
 
+import "github.com/belastingdienst/opr-paas/api/v1alpha1"
+
 type RestEncryptInput struct {
 	PaasName string `json:"paas"`
 	Secret   string `json:"secret"`
@@ -15,6 +17,16 @@ type RestEncryptResult struct {
 	PaasName  string `json:"paas"`
 	Encrypted string `json:"encrypted"`
 	Valid     bool   `json:"valid"`
+}
+
+type RestCheckPaasInput struct {
+	Paas v1alpha1.Paas `json:"paas"`
+}
+
+type RestCheckPaasResult struct {
+	PaasName  string `json:"paas"`
+	Decrypted bool   `json:"decrypted"`
+	Error     string `json:"error"`
 }
 
 type RestGenerateInput struct {

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.4
+	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prometheus/client_golang v1.20.4 h1:Tgh3Yr67PaOv/uTqloMsCEdeuFTatm5zIq5+qNN23vI=
-github.com/prometheus/client_golang v1.20.4/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
+github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
+github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
 github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G1dc=

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/belastingdienst/opr-paas
+  newName: ghcr.io/belastingdienst/opr-paas
   newTag: latest
 
 resources:

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
 - name: ghcr.io/belastingdienst/opr-paas
-  newTag: v1.2.3
+  newTag: latest
 
 resources:
 - config

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,64 @@
+# This repository adheres to the publiccode.yml standard by including this
+# metadata file that makes public software easily discoverable.
+# More info at https://github.com/publiccodeyml/publiccode.yml
+
+publiccodeYmlVersion: "0.3"
+
+name: Paas Operator
+url: "https://github.com/belastingdienst/opr-paas"
+softwareType: standalone/other
+releaseDate: "1970-01-01"
+platforms:
+  - kubernetes
+  - openshift
+categories:
+  - agile-project-management
+  - cloud-management
+  - it-development
+  - it-service-management
+  - project-management
+  - resource-management
+  - workflow-management
+developmentStatus: stable
+dependsOn:
+  open:
+    - name: Kubernetes / Openshift
+      optional: false
+description:
+  en:
+    longDescription: >
+      The PaaS operator delivers an opinionated 'Project as a Service' implementation
+      where development teams can request a 'Project as a Service' by defining a PaaS
+      resource.
+      
+      A PaaS resource is used by the operator as an input to create namespaces
+      limited by Cluster Resource Quota's, granting groups permissions and (together
+      with a clusterwide ArgoCD) creating capabilities such as:
+      
+      - a PaaS specific deployment of ArgoCD (continuous deployment);
+      - Tekton (continuous integration);
+      - Grafana (observability); and
+      - KeyCloak (Application level Single Sign On);
+      
+      A PaaS is all a team needs to hit the ground running.
+
+    shortDescription: An operator providing a multi tenancy solution which allows DevOps teams to request a context for their project, called a 'Project as a service'.
+    
+    documentation: https://belastingdienst.github.io/opr-paas/
+    
+    features:
+      - CRUD for Paas K8S Resources
+      - Capabilities management
+
+legal:
+  license: EUPL-1.2
+  mainCopyrightOwner: Tax Administration of The Netherlands (Belastingdienst)
+  repoOwner: Tax Administration of The Netherlands (Belastingdienst)
+
+localisation:
+  availableLanguages:
+    - en
+  localisationReady: false
+
+maintenance:
+  type: internal


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Started with refactoring the checkPaas function from the CLI, was hoping to reuse the singular checkPaas function in the webservice. That of course was not possible as it is a different package. Left the refactoring in place to reduce complexity of the function.

- Adds privateKeysPath to the webservice config
- Adds types for checkPaas request and result
- Adds gin endpoint for checking Paas including appropriate error handling

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->