### PR TITLE
feat: expose checkPaas as a webservice.

### DIFF
--- a/cmd/webservice/check_paas.go
+++ b/cmd/webservice/check_paas.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024, Tax Administration of The Netherlands.
+Licensed under the EUPL 1.2.
+See LICENSE.md for details.
+*/
+
+package main
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+
+	"github.com/belastingdienst/opr-paas/internal/crypt"
+	"github.com/sirupsen/logrus"
+)
+
+// CheckPaas determines whether a Paas can be decrypted using the provided crypt
+// it returns an error containing which secrets cannot be decrypted if any
+func CheckPaas(crypt *crypt.Crypt, paas *v1alpha1.Paas) error {
+	var allErrors []string
+	for key, secret := range paas.Spec.SshSecrets {
+		decrypted, err := crypt.Decrypt(secret)
+		if err != nil {
+			errMessage := fmt.Errorf("%s: .spec.sshSecrets[%s], error: %w.", paas.Name, key, err)
+			logrus.Error(errMessage)
+			allErrors = append(allErrors, errMessage.Error())
+		} else {
+			logrus.Infof("%s: .spec.sshSecrets[%s], checksum: %s, len %d.", paas.Name, key, hashData(decrypted), len(decrypted))
+		}
+	}
+
+	for capName, capability := range paas.Spec.Capabilities.AsMap() {
+		logrus.Debugf("capability name: %s", capability.CapabilityName())
+		for key, secret := range capability.GetSshSecrets() {
+			decrypted, err := crypt.Decrypt(secret)
+			if err != nil {
+				errMessage := fmt.Errorf("%s: .spec.capabilities[%s].sshSecrets[%s], error: %w.", paas.Name, capName, key, err)
+				logrus.Error(errMessage)
+				allErrors = append(allErrors, errMessage.Error())
+			} else {
+				logrus.Infof("%s: .spec.capabilities[%s].sshSecrets[%s], checksum: %s, len %d.", paas.Name, capName, key, hashData(decrypted), len(decrypted))
+			}
+		}
+	}
+	if len(allErrors) > 0 {
+		errorString := strings.Join(allErrors, " , ")
+		return errors.New(errorString)
+	}
+	return nil
+}
+
+func hashData(original []byte) string {
+	sum := sha512.Sum512(original)
+	return hex.EncodeToString(sum[:])
+}

--- a/cmd/webservice/check_paas_test.go
+++ b/cmd/webservice/check_paas_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	v1alpha1 "github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/crypt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCheckPaas(t *testing.T) {
+	// generate private/public keys
+	priv, err := os.CreateTemp("", "private")
+	require.NoError(t, err, "Creating tempfile for private key")
+	defer os.Remove(priv.Name()) // clean up
+
+	pub, err := os.CreateTemp("", "public")
+	require.NoError(t, err, "Creating tempfile for public key")
+	defer os.Remove(pub.Name()) // clean up
+
+	crypt.NewGeneratedCrypt(priv.Name(), pub.Name()) //nolint:errcheck // this is fine in test
+	getConfig()
+	_config.PublicKeyPath = pub.Name()
+	_config.PrivateKeyPath = priv.Name()
+	assert.Nil(t, _crypt)
+	rsa := getRsa("paasName")
+
+	encrypted, err := rsa.Encrypt([]byte("My test string"))
+	require.NoError(t, err)
+
+	toBeDecryptedPaas := &v1alpha1.Paas{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "paasName",
+		},
+		Spec: v1alpha1.PaasSpec{
+			SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted},
+			Capabilities: v1alpha1.PaasCapabilities{
+				SSO: v1alpha1.PaasSSO{Enabled: true, SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted}},
+			},
+		},
+	}
+
+	err = CheckPaas(rsa, toBeDecryptedPaas)
+	require.NoError(t, err)
+
+	notTeBeDecryptedPaas := &v1alpha1.Paas{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "paasName",
+		},
+		Spec: v1alpha1.PaasSpec{SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": "bm90RGVjcnlwdGFibGU="}},
+	}
+
+	// Must be able to decrypt this
+	err = CheckPaas(rsa, notTeBeDecryptedPaas)
+	require.Error(t, err)
+
+	partialToBeDecrypedPaas := &v1alpha1.Paas{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "paasName",
+		},
+		Spec: v1alpha1.PaasSpec{
+			SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted},
+			Capabilities: v1alpha1.PaasCapabilities{
+				SSO: v1alpha1.PaasSSO{Enabled: true, SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": "bm90RGVjcnlwdGFibGU="}},
+			},
+		},
+	}
+
+	// Must be able to decrypt this
+	err = CheckPaas(rsa, partialToBeDecrypedPaas)
+	require.Error(t, err)
+}

--- a/cmd/webservice/config.go
+++ b/cmd/webservice/config.go
@@ -16,14 +16,18 @@ import (
 
 const (
 	publicEnv           = "PAAS_PUBLIC_KEY_PATH"
+	privateKeyEnv       = "PAAS_PRIVATE_KEYS_PATH"
 	defaultPublicPath   = "/secrets/paas/publicKey"
+	defaultPrivatePath  = "/secrets/paas/privateKeys"
 	endpointEnv         = "PAAS_ENDPOINT"
 	defaultEndpointPort = 8080
 )
 
 type WSConfig struct {
 	PublicKeyPath string
-	Endpoint      string
+	// comma separated list of privateKeyPaths
+	PrivateKeyPath string
+	Endpoint       string
 }
 
 func formatEndpoint(endpoint string) string {
@@ -69,6 +73,10 @@ func NewWSConfig() WSConfig {
 	config.PublicKeyPath = os.Getenv(publicEnv)
 	if config.PublicKeyPath == "" {
 		config.PublicKeyPath = defaultPublicPath
+	}
+	config.PrivateKeyPath = os.Getenv(privateKeyEnv)
+	if config.PrivateKeyPath == "" {
+		config.PrivateKeyPath = defaultPrivatePath
 	}
 	config.Endpoint = formatEndpoint(os.Getenv(endpointEnv))
 

--- a/cmd/webservice/data.go
+++ b/cmd/webservice/data.go
@@ -6,6 +6,8 @@ See LICENSE.md for details.
 
 package main
 
+import "github.com/belastingdienst/opr-paas/api/v1alpha1"
+
 type RestEncryptInput struct {
 	PaasName string `json:"paas"`
 	Secret   string `json:"secret"`
@@ -15,6 +17,16 @@ type RestEncryptResult struct {
 	PaasName  string `json:"paas"`
 	Encrypted string `json:"encrypted"`
 	Valid     bool   `json:"valid"`
+}
+
+type RestCheckPaasInput struct {
+	Paas v1alpha1.Paas `json:"paas"`
+}
+
+type RestCheckPaasResult struct {
+	PaasName  string `json:"paas"`
+	Decrypted bool   `json:"decrypted"`
+	Error     string `json:"error"`
 }
 
 type RestGenerateInput struct {

--- a/cmd/webservice/main_test.go
+++ b/cmd/webservice/main_test.go
@@ -11,13 +11,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/internal/crypt"
 	v "github.com/belastingdienst/opr-paas/internal/version"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Helper function for testing
@@ -30,6 +33,9 @@ func performRequest(r http.Handler, method, path string) *httptest.ResponseRecor
 }
 
 func Test_getConfig(t *testing.T) {
+	// Reset config if any test before set config
+	_config = nil
+	_crypt = nil
 	config := getConfig()
 
 	assert.NotNil(t, config)
@@ -55,6 +61,11 @@ func Test_getConfig(t *testing.T) {
 }
 
 func Test_getRSA(t *testing.T) {
+	// Reset config if any test before set config
+	_config = nil
+	_crypt = nil
+	getConfig()
+
 	// generate private/public keys
 	priv, err := os.CreateTemp("", "private")
 	require.NoError(t, err, "Creating tempfile for private key")
@@ -80,6 +91,7 @@ func Test_getRSA(t *testing.T) {
 	// test: non-existing _crypt results in single entry _crypt
 	getConfig()
 	_config.PublicKeyPath = pub.Name()
+	_config.PrivateKeyPath = priv.Name()
 	assert.Nil(t, _crypt)
 	output := getRsa("paasName")
 	assert.Len(t, _crypt, 1)
@@ -158,4 +170,122 @@ func Test_readyz(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, expected["message"], value)
+}
+
+func Test_v1CheckPaas(t *testing.T) {
+	// Reset config if any test before set config
+	_config = nil
+	_crypt = nil
+
+	priv, err := os.CreateTemp("", "private")
+	require.NoError(t, err, "Creating tempfile for private key")
+	defer os.Remove(priv.Name()) // clean up
+
+	pub, err := os.CreateTemp("", "public")
+	require.NoError(t, err, "Creating tempfile for public key")
+	defer os.Remove(pub.Name()) // clean up
+
+	// Set env for ws Config
+	t.Setenv("PAAS_PUBLIC_KEY_PATH", pub.Name())    //nolint:errcheck // this is fine in test
+	t.Setenv("PAAS_PRIVATE_KEYS_PATH", priv.Name()) //nolint:errcheck // this is fine in test
+
+	// Generate keyPair to be used during test
+	crypt.NewGeneratedCrypt(priv.Name(), pub.Name()) //nolint:errcheck // this is fine in test
+
+	// Encrypt secret for test
+	rsa := getRsa("testPaas")
+
+	encrypted, err := rsa.Encrypt([]byte("My test string"))
+	require.NoError(t, err)
+
+	getConfig()
+	router := SetupRouter()
+
+	w := httptest.NewRecorder()
+
+	validRequest := RestCheckPaasInput{
+		Paas: v1alpha1.Paas{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testPaas",
+			},
+			Spec: v1alpha1.PaasSpec{
+				SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted},
+				Capabilities: v1alpha1.PaasCapabilities{
+					SSO: v1alpha1.PaasSSO{Enabled: true, SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted}},
+				},
+			},
+		},
+	}
+	checkPaasJson, _ := json.Marshal(validRequest)
+
+	req, _ := http.NewRequest("POST", "/v1/checkpaas", strings.NewReader(string(checkPaasJson)))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+	response := RestCheckPaasResult{
+		PaasName:  "testPaas",
+		Decrypted: true,
+		Error:     "",
+	}
+	responseJson, _ := json.MarshalIndent(response, "", "    ")
+	assert.Equal(t, string(responseJson), w.Body.String())
+
+	// Reset recorder
+	w = httptest.NewRecorder()
+
+	invalidRequest := RestCheckPaasInput{
+		Paas: v1alpha1.Paas{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testPaas2",
+			},
+			Spec: v1alpha1.PaasSpec{
+				SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": "ZW5jcnlwdGVkCg=="},
+				Capabilities: v1alpha1.PaasCapabilities{
+					SSO: v1alpha1.PaasSSO{Enabled: true, SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted}},
+				},
+			},
+		},
+	}
+	invalidCheckPaasJson, _ := json.Marshal(invalidRequest)
+
+	req2, _ := http.NewRequest("POST", "/v1/checkpaas", strings.NewReader(string(invalidCheckPaasJson)))
+	router.ServeHTTP(w, req2)
+
+	assert.Equal(t, 422, w.Code)
+	response2 := RestCheckPaasResult{
+		PaasName:  "testPaas2",
+		Decrypted: false,
+		Error:     "testPaas2: .spec.sshSecrets[ssh://git@scm/some-repo.git], error: unable to decrypt data with any of the private keys. , testPaas2: .spec.capabilities[sso].sshSecrets[ssh://git@scm/some-repo.git], error: unable to decrypt data with any of the private keys.",
+	}
+	response2Json, _ := json.MarshalIndent(response2, "", "    ")
+	assert.Equal(t, string(response2Json), w.Body.String())
+}
+
+func Test_v1CheckPaasInternalServerError(t *testing.T) {
+	// Reset config if any test before get config
+	_config = nil
+	_crypt = nil
+	getConfig()
+
+	router := SetupRouter()
+
+	w := httptest.NewRecorder()
+
+	validRequest := RestCheckPaasInput{
+		Paas: v1alpha1.Paas{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testPaas",
+			},
+			Spec: v1alpha1.PaasSpec{
+				SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": "ZW5jcnlwdGVkCg=="},
+			},
+		},
+	}
+	checkPaasJson, _ := json.Marshal(validRequest)
+
+	req, _ := http.NewRequest("POST", "/v1/checkpaas", strings.NewReader(string(checkPaasJson)))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 500, w.Code)
+	assert.Equal(t, "", w.Body.String())
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Started with refactoring the checkPaas function from the CLI, was hoping to reuse the singular checkPaas function in the webservice. That of course was not possible as it is a different package. Left the refactoring in place to reduce complexity of the function.

- Adds privateKeysPath to the webservice config
- Adds types for checkPaas request and result
- Adds gin endpoint for checking Paas including appropriate error handling

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->