### PR TITLE
fix: continue reëncrypt if one fails

### DIFF
--- a/cmd/crypttool/paasFile.go
+++ b/cmd/crypttool/paasFile.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
@@ -66,7 +65,7 @@ func writeFile(buffer []byte, path string) error {
 		return err
 	}
 
-	log.Printf("file '%s' successfully updated", path)
+	logrus.Infof("file '%s' successfully updated", path)
 	return nil
 }
 

--- a/cmd/webservice/check_paas_test.go
+++ b/cmd/webservice/check_paas_test.go
@@ -57,7 +57,7 @@ func TestCheckPaas(t *testing.T) {
 	err = CheckPaas(rsa, notTeBeDecryptedPaas)
 	require.Error(t, err)
 
-	partialToBeDecrypedPaas := &v1alpha1.Paas{
+	partialToBeDecryptedPaas := &v1alpha1.Paas{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "paasName",
 		},
@@ -69,7 +69,7 @@ func TestCheckPaas(t *testing.T) {
 		},
 	}
 
-	// Must be able to decrypt this
-	err = CheckPaas(rsa, partialToBeDecrypedPaas)
+	// Must error as it can be partially decrypted
+	err = CheckPaas(rsa, partialToBeDecryptedPaas)
 	require.Error(t, err)
 }


### PR DESCRIPTION
continue reëncrypting if one fails

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- crypttool reëncrypt exits if one reëncryption fails error

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/belastingdienst/opr-paas/issues/18

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- crypttool reëncrypt continues on error

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->