### PR TITLE
chore: Log status in e2e-test wait failures

### DIFF
--- a/test/e2e/paas.go
+++ b/test/e2e/paas.go
@@ -60,7 +60,11 @@ func waitForPaasReconciliation(ctx context.Context, cfg *envconf.Config, paas *a
 		})
 
 	if err := waitForDefaultOpts(ctx, waitCond); err != nil {
-		return fmt.Errorf("failed waiting for Paas %s to be reconciled: %w", paas.GetName(), err)
+		err = cfg.Client().Resources().Get(ctx, paas.GetName(), paas.Namespace, paas)
+		if err != nil {
+			return fmt.Errorf("could not get paas resource which was waited for: %w", err)
+		}
+		return fmt.Errorf("failed waiting for Paas %s to be reconciled: %w and has status block: %v", paas.GetName(), err, paas.Status)
 	}
 
 	return nil

--- a/test/e2e/paasns.go
+++ b/test/e2e/paasns.go
@@ -21,7 +21,11 @@ func waitForPaasNSReconciliation(ctx context.Context, cfg *envconf.Config, paasn
 		})
 
 	if err := waitForDefaultOpts(ctx, waitCond); err != nil {
-		return fmt.Errorf("failed waiting for PaasNS %s to be reconciled: %w", paasns.GetName(), err)
+		err = cfg.Client().Resources().Get(ctx, paasns.GetName(), paasns.Namespace, paasns)
+		if err != nil {
+			return fmt.Errorf("could not get paasns resource which is waited for: %w", err)
+		}
+		return fmt.Errorf("failed waiting for PaasNS %s to be reconciled: %w and has status block: %s", paasns.GetName(), err, paasns.Status)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

An error is thrown when the wait time in an e2e-test wait-for is exceeded. No status is dumped so it is quite hard to determine what was the cause of the object not reconciling.

Fixes: # (issue)

## What is the new behavior?

When a wait time in an e2e-test is exceeded, we log the object status

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->