### PR TITLE
chore: upload e2e test logs on failure

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -78,7 +78,7 @@ jobs:
         with:
           version: v1.60.3
           args: --verbose
- 
+
   code-gen:
     name: Check generated code
     runs-on: ubuntu-22.04
@@ -159,14 +159,14 @@ jobs:
         timeout-minutes: 20
         run: |
           set -x
-          set +e
           make test-e2e
-          exitcode=$(echo $?)
           killall goreman run stop-all || echo "trouble killing goreman"
-          sleep 30
-          echo "Operator logs"
-          cat /tmp/e2e-server.log
-          exit "$exitcode"
+      - name: Upload operator deployment log on failure
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: e2e-operator-logs-${{ github.run_id }}.log
+          path: /tmp/e2e-server.log
+        if: ${{ failure() }}
 
   e2e-test-with-built-image:
     name: Run e2e tests against deployed image

--- a/Makefile
+++ b/Makefile
@@ -138,11 +138,6 @@ setup-e2e: kustomize ## Setup test environment in the K8s cluster specified in ~
 	$(KUSTOMIZE) build test/e2e/manifests/paas-context | kubectl apply -f -
 	# Apply opr-paas crds
 	$(KUSTOMIZE) build manifests/crds | kubectl apply -f -
-	# Create namespace as desired in RBAC
-	kubectl create namespace paas
-	# TODO determine if needed as we don't run the opr in cluster
-	# Apply opr-paas rbac
-	$(KUSTOMIZE) build manifests/rbac | kubectl apply -f -
 
 # Starts operator for e2e tests with fixtures
 .PHONY: start-e2e

--- a/manifests/default/kustomization.yaml
+++ b/manifests/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: paas
+namespace: paas-system
 
 resources:
 - ../config


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Operator logs are dumped to stdout on e2e-test failure

Fixes: # (issue)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Upload operator logs on e2e-test failure
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->