### PR TITLE
chore: Removes duplicate roles from manifests

### DIFF
--- a/manifests/rbac/leader_election_role.yaml
+++ b/manifests/rbac/leader_election_role.yaml
@@ -12,18 +12,6 @@ metadata:
   name: leader-election-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

The leader election role in the manifests folder contains configmap rules which are in the role.yaml file. Those are duplicate.

Fixes: # (issue)

## What is the new behavior?

* Removes configmap rules from rule leader election role. As they are described in the role.yaml

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->