### PR TITLE
ci: Run ci-build on more changes

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -28,13 +28,13 @@ jobs:
       - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275 # v45.0.1
         id: filter
         with:
-          # Any file which is not under docs/ or is not a markdown file is counted as a backend file
+          # Any file which is not under docs/, examples/, or is not a markdown file is counted as a backend file
           files_yaml: |
             backend:
-              - go.mod
-              - go.sum
-              - '**.go'
-              - '.github/workflows/ci-build.yaml'
+              - '!**.md'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!examples/**'
   
   check-go:
     name: Ensure Go modules synchronicity


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Only run ci-build when Go files or the workflow itself is changed. This is too narrow IMHO as for example these changes are not triggering CI: https://github.com/belastingdienst/opr-paas/pull/149

Fixes: # (issue)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Run ci-build workflow on any change which is not docs or the example folder.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->