### PR TITLE
docs: Don't state that the webservice is deployed via install.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 ## Goal
 
-The PaaS operator delivers an opinionated 'Project as a Service' implementation where
-development teams can request a 'Project as a Service' by defining a PaaS resource.
+The Paas operator delivers an opinionated 'Project as a Service' implementation where
+development teams can request a 'Project as a Service' by defining a Paas resource.
 
-A PaaS resource is used by the operator as an input to create namespaces limited
+A Paas resource is used by the operator as an input to create namespaces limited
 by Cluster Resource Quota's, granting groups permissions and (together with a clusterwide
 ArgoCD) creating capabilities such as:
 
-- a PaaS specific deployment of ArgoCD (continuous deployment);
+- a Paas specific deployment of ArgoCD (continuous deployment);
 - Tekton (continuous integration);
 - Grafana (observability); and
 - KeyCloak (Application level Single Sign On);
 
-A PaaS is all a team needs to hit the ground running.
+A Paas is all a team needs to hit the ground running.
 
 ## Quickstart
 
@@ -27,12 +27,12 @@ kubectl apply -f https://github.com/belastingdienst/opr-paas/releases/latest/dow
 This will install the latest release and create:
 
 - a namespace called `paas-system`;
-- 2 CRDs (`PaaS` and `PaasNs`);
+- 2 CRDs (`Paas` and `PaasNs`);
 - a service account, role, role binding, cluster role and cluster role binding for
   all permissions required by the operator;
-- a viewer & an editor cluster role for PaaS and PaasNs resources;
+- a viewer & an editor cluster role for Paas and PaasNs resources;
 - a configmap with all operator configuration options;
-- a deployment running the operator and a deployment running an encryption service;
+- a deployment running the operator;
 
 Feel free to change config as required.
 

--- a/docs/administrators-guide/install.md
+++ b/docs/administrators-guide/install.md
@@ -14,7 +14,7 @@ Deploy the operator using the following command:
 kubectl apply -f https://github.com/belastingdienst/opr-paas/releases/latest/download/install.yaml
 ```
 
-This will install the operator using the install.yaml that was generated for the
+This will install the operator using the `install.yaml` that was generated for the
 latest release. It will create:
 
 - a namespace called `paas-system`;
@@ -25,6 +25,6 @@ latest release. It will create:
   operator config by setting `resourcesNames` in your role.yaml**
 - a viewer & an editor cluster role for Paas and PaasNs resources;
 - a configmap with all operator configuration options;
-- a deployment running the operator and a deployment running an encryption service;
+- a deployment running the operator;
 
 Feel free to change config as required.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Docs state that Paas webservice deployment is part of install.yaml

Relates to: https://github.com/belastingdienst/opr-paas/issues/110

## What is the new behavior?

* Updates docs, removes that the install.yaml will deploy the webservice as it doesn't
* Updates README to match Paas name convention

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->