### PR TITLE
refactor(controller): replace logging statements with zerolog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.3
 toolchain go1.23.0
 
 require (
-	github.com/go-logr/logr v1.4.2
+	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.31.1

--- a/internal/controller/argo_app.go
+++ b/internal/controller/argo_app.go
@@ -34,7 +34,7 @@ func (r *PaasNSReconciler) EnsureArgoApp(
 		return nil
 	}
 
-	ctx = setLogComponent(ctx, "ArgoApp")
+	ctx = setLogComponent(ctx, "argoapp")
 	logger := log.Ctx(ctx)
 	namespacedName := types.NamespacedName{
 		Namespace: paasns.NamespaceName(),

--- a/internal/controller/argo_app.go
+++ b/internal/controller/argo_app.go
@@ -8,11 +8,11 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	argo "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
 
+	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,7 +34,8 @@ func (r *PaasNSReconciler) EnsureArgoApp(
 		return nil
 	}
 
-	logger := getLogger(ctx, paasns, "ArgoApp", appName)
+	ctx = setLogComponent(ctx, "ArgoApp")
+	logger := log.Ctx(ctx)
 	namespacedName := types.NamespacedName{
 		Namespace: paasns.NamespaceName(),
 		Name:      appName,
@@ -46,17 +47,17 @@ func (r *PaasNSReconciler) EnsureArgoApp(
 		paasns.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusAction(v1alpha1.PaasStatusInfo), argoApp, err.Error())
 		return err
 	} else if err := r.Get(ctx, namespacedName, found); err == nil {
-		logger.Info("Argo Application already exists, updating")
+		logger.Info().Msg("Argo Application already exists, updating")
 		patch := client.MergeFrom(found.DeepCopy())
 		found.Spec = argoApp.Spec
 		paasns.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusCreate, found, "succeeded")
 		return r.Patch(ctx, found, patch)
 	} else if !errors.IsNotFound(err) {
-		logger.Error(err, "Could not retrieve info of Argo Application")
+		logger.Err(err).Msg("Could not retrieve info of Argo Application")
 		paasns.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusAction(v1alpha1.PaasStatusInfo), argoApp, err.Error())
 		return err
 	} else {
-		logger.Info("Creating Argo Application")
+		logger.Info().Msg("Creating Argo Application")
 		paasns.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusCreate, argoApp, "succeeded")
 		return r.Create(ctx, argoApp)
 	}
@@ -68,8 +69,8 @@ func (r *PaasNSReconciler) backendArgoApp(
 	paasns *v1alpha1.PaasNS,
 	paas *v1alpha1.Paas,
 ) (*argo.Application, error) {
-	logger := getLogger(ctx, paasns, "ArgoApp", appName)
-	logger.Info(fmt.Sprintf("Defining %s Argo Application", appName))
+	logger := log.Ctx(ctx)
+	logger.Info().Msgf("Defining %s Argo Application", appName)
 
 	namespace := paasns.NamespaceName()
 	argoConfig := paas.Spec.Capabilities["argocd"]
@@ -112,7 +113,7 @@ func (r *PaasNSReconciler) backendArgoApp(
 		},
 	}
 
-	logger.Info("Setting Owner")
+	logger.Info().Msg("Setting Owner")
 	if err := controllerutil.SetControllerReference(paas, app, r.Scheme); err != nil {
 		return app, err
 	}
@@ -127,17 +128,17 @@ func (r *PaasNSReconciler) FinalizeArgoApp(
 		Namespace: paasns.NamespaceName(),
 		Name:      appName,
 	}
-	logger := getLogger(ctx, paasns, "Application", namespacedName.String())
-	logger.Info("Finalizing")
+	logger := log.Ctx(ctx)
+	logger.Info().Msg("Finalizing")
 	obj := &argo.Application{}
 	if err := r.Get(ctx, namespacedName, obj); err != nil && errors.IsNotFound(err) {
-		logger.Info("Does not exist")
+		logger.Info().Msg("Does not exist")
 		return nil
 	} else if err != nil {
-		logger.Info("Error retrieving info: " + err.Error())
+		logger.Err(err).Msg("Error retrieving info")
 		return err
 	} else {
-		logger.Info("Deleting")
+		logger.Info().Msg("Deleting")
 		return r.Delete(ctx, obj)
 	}
 }

--- a/internal/controller/argo_app.go
+++ b/internal/controller/argo_app.go
@@ -47,17 +47,17 @@ func (r *PaasNSReconciler) EnsureArgoApp(
 		paasns.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusAction(v1alpha1.PaasStatusInfo), argoApp, err.Error())
 		return err
 	} else if err := r.Get(ctx, namespacedName, found); err == nil {
-		logger.Info().Msg("Argo Application already exists, updating")
+		logger.Info().Msg("argo Application already exists, updating")
 		patch := client.MergeFrom(found.DeepCopy())
 		found.Spec = argoApp.Spec
 		paasns.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusCreate, found, "succeeded")
 		return r.Patch(ctx, found, patch)
 	} else if !errors.IsNotFound(err) {
-		logger.Err(err).Msg("Could not retrieve info of Argo Application")
+		logger.Err(err).Msg("could not retrieve info of Argo Application")
 		paasns.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusAction(v1alpha1.PaasStatusInfo), argoApp, err.Error())
 		return err
 	} else {
-		logger.Info().Msg("Creating Argo Application")
+		logger.Info().Msg("creating Argo Application")
 		paasns.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusCreate, argoApp, "succeeded")
 		return r.Create(ctx, argoApp)
 	}
@@ -70,7 +70,7 @@ func (r *PaasNSReconciler) backendArgoApp(
 	paas *v1alpha1.Paas,
 ) (*argo.Application, error) {
 	logger := log.Ctx(ctx)
-	logger.Info().Msgf("Defining %s Argo Application", appName)
+	logger.Info().Msgf("defining %s Argo Application", appName)
 
 	namespace := paasns.NamespaceName()
 	argoConfig := paas.Spec.Capabilities["argocd"]
@@ -113,7 +113,7 @@ func (r *PaasNSReconciler) backendArgoApp(
 		},
 	}
 
-	logger.Info().Msg("Setting Owner")
+	logger.Info().Msg("setting Owner")
 	if err := controllerutil.SetControllerReference(paas, app, r.Scheme); err != nil {
 		return app, err
 	}
@@ -129,16 +129,16 @@ func (r *PaasNSReconciler) FinalizeArgoApp(
 		Name:      appName,
 	}
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Finalizing")
+	logger.Info().Msg("finalizing")
 	obj := &argo.Application{}
 	if err := r.Get(ctx, namespacedName, obj); err != nil && errors.IsNotFound(err) {
-		logger.Info().Msg("Does not exist")
+		logger.Info().Msg("does not exist")
 		return nil
 	} else if err != nil {
-		logger.Err(err).Msg("Error retrieving info")
+		logger.Err(err).Msg("error retrieving info")
 		return err
 	} else {
-		logger.Info().Msg("Deleting")
+		logger.Info().Msg("deleting")
 		return r.Delete(ctx, obj)
 	}
 }

--- a/internal/controller/argo_projects.go
+++ b/internal/controller/argo_projects.go
@@ -24,7 +24,7 @@ func (r *PaasReconciler) EnsureAppProject(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) error {
-	ctx = setLogComponent(ctx, "AppProject")
+	ctx = setLogComponent(ctx, "appproject")
 	log.Ctx(ctx).Info().Msg("creating Argo Project")
 	project, err := r.BackendAppProject(ctx, paas)
 	if err != nil {

--- a/internal/controller/argo_projects.go
+++ b/internal/controller/argo_projects.go
@@ -8,26 +8,24 @@ package controller
 
 import (
 	"context"
-	"fmt"
-
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	argo "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
-	"github.com/go-logr/logr"
 
+	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // ensureAppProject ensures AppProject presence in given namespace.
 func (r *PaasReconciler) EnsureAppProject(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
-	logger logr.Logger,
 ) error {
-	logger.Info("Creating Argo Project")
+	ctx = setLogComponent(ctx, "AppProject")
+	log.Ctx(ctx).Info().Msg("Creating Argo Project")
 	project, err := r.BackendAppProject(ctx, paas)
 	if err != nil {
 		return err
@@ -68,20 +66,20 @@ func (r *PaasReconciler) EnsureAppProject(
 
 // FinalizeAppProject finalizes AppProject
 func (r *PaasReconciler) FinalizeAppProject(ctx context.Context, paas *v1alpha1.Paas) error {
-	logger := getLogger(ctx, paas, "AppProject", paas.Name)
-	logger.Info("Finalizing App Project")
+	logger := log.Ctx(ctx)
+	logger.Info().Msg("Finalizing App Project")
 	appProject := &argo.AppProject{}
 	if err := r.Get(ctx, types.NamespacedName{
 		Name:      paas.Name,
 		Namespace: getConfig().AppSetNamespace,
 	}, appProject); err != nil && errors.IsNotFound(err) {
-		logger.Info("App Project already deleted")
+		logger.Info().Msg("App Project already deleted")
 		return nil
 	} else if err != nil {
-		logger.Info("Error retrieving App Project: " + err.Error())
+		logger.Err(err).Msg("Error retrieving App Project")
 		return err
 	} else {
-		logger.Info("Deleting App Project")
+		logger.Info().Msg("Deleting App Project")
 		return r.Delete(ctx, appProject)
 	}
 }
@@ -92,8 +90,8 @@ func (r *PaasReconciler) BackendAppProject(
 	paas *v1alpha1.Paas,
 ) (*argo.AppProject, error) {
 	name := paas.Name
-	logger := getLogger(ctx, paas, "AppProject", name)
-	logger.Info(fmt.Sprintf("Defining %s AppProject", name))
+	logger := log.Ctx(ctx)
+	logger.Info().Msgf("Defining %s AppProject", name)
 	p := &argo.AppProject{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AppProject",
@@ -121,7 +119,7 @@ func (r *PaasReconciler) BackendAppProject(
 		},
 	}
 
-	logger.Info("Setting Owner")
+	logger.Info().Msg("Setting Owner")
 	if err := controllerutil.SetControllerReference(paas, p, r.Scheme); err != nil {
 		return nil, err
 	}

--- a/internal/controller/argo_projects.go
+++ b/internal/controller/argo_projects.go
@@ -25,7 +25,7 @@ func (r *PaasReconciler) EnsureAppProject(
 	paas *v1alpha1.Paas,
 ) error {
 	ctx = setLogComponent(ctx, "AppProject")
-	log.Ctx(ctx).Info().Msg("Creating Argo Project")
+	log.Ctx(ctx).Info().Msg("creating Argo Project")
 	project, err := r.BackendAppProject(ctx, paas)
 	if err != nil {
 		return err
@@ -67,19 +67,19 @@ func (r *PaasReconciler) EnsureAppProject(
 // FinalizeAppProject finalizes AppProject
 func (r *PaasReconciler) FinalizeAppProject(ctx context.Context, paas *v1alpha1.Paas) error {
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Finalizing App Project")
+	logger.Info().Msg("finalizing App Project")
 	appProject := &argo.AppProject{}
 	if err := r.Get(ctx, types.NamespacedName{
 		Name:      paas.Name,
 		Namespace: getConfig().AppSetNamespace,
 	}, appProject); err != nil && errors.IsNotFound(err) {
-		logger.Info().Msg("App Project already deleted")
+		logger.Info().Msg("app Project already deleted")
 		return nil
 	} else if err != nil {
-		logger.Err(err).Msg("Error retrieving App Project")
+		logger.Err(err).Msg("error retrieving App Project")
 		return err
 	} else {
-		logger.Info().Msg("Deleting App Project")
+		logger.Info().Msg("deleting App Project")
 		return r.Delete(ctx, appProject)
 	}
 }
@@ -91,7 +91,7 @@ func (r *PaasReconciler) BackendAppProject(
 ) (*argo.AppProject, error) {
 	name := paas.Name
 	logger := log.Ctx(ctx)
-	logger.Info().Msgf("Defining %s AppProject", name)
+	logger.Info().Msgf("defining %s AppProject", name)
 	p := &argo.AppProject{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AppProject",
@@ -119,7 +119,7 @@ func (r *PaasReconciler) BackendAppProject(
 		},
 	}
 
-	logger.Info().Msg("Setting Owner")
+	logger.Info().Msg("setting Owner")
 	if err := controllerutil.SetControllerReference(paas, p, r.Scheme); err != nil {
 		return nil, err
 	}

--- a/internal/controller/argocd.go
+++ b/internal/controller/argocd.go
@@ -85,7 +85,7 @@ func (r *PaasNSReconciler) EnsureArgoCD(
 	if argo.Spec.RBAC.DefaultPolicy != nil {
 		oldDefaultPolicy = *argo.Spec.RBAC.DefaultPolicy
 	}
-	logger.Info().Msgf("Setting ArgoCD permissions to %s", policy)
+	logger.Info().Msgf("setting ArgoCD permissions to %s", policy)
 	if oldPolicy == policy && oldDefaultPolicy == defaultPolicy && paas.AmIOwner(argo.OwnerReferences) {
 		paasns.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusUpdate, argo, "no changes")
 		return nil
@@ -96,7 +96,7 @@ func (r *PaasNSReconciler) EnsureArgoCD(
 	if err = controllerutil.SetControllerReference(paas, argo, r.GetScheme()); err != nil {
 		return err
 	}
-	logger.Info().Msg("Updating ArgoCD object")
+	logger.Info().Msg("updating ArgoCD object")
 	paasns.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusUpdate, argo, "updating ArgoCD instance")
 	return r.Patch(ctx, argo, patch)
 }

--- a/internal/controller/argocd.go
+++ b/internal/controller/argocd.go
@@ -28,7 +28,7 @@ func (r *PaasNSReconciler) EnsureArgoCD(
 	if paasns.Name != "argocd" {
 		return nil
 	}
-	ctx = setLogComponent(ctx, "ArgoPermissions")
+	ctx = setLogComponent(ctx, "argopermissions")
 	logger := log.Ctx(ctx)
 	paas, _, err := r.paasFromPaasNs(ctx, paasns)
 	if err != nil {

--- a/internal/controller/capabilities.go
+++ b/internal/controller/capabilities.go
@@ -155,7 +155,7 @@ func (r *PaasNSReconciler) EnsureAppSetCap(
 			Namespace: namespacedName.Namespace,
 		},
 	}
-	ctx = setLogComponent(ctx, "AppSet")
+	ctx = setLogComponent(ctx, "appset")
 	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset %s", paasns.Name, namespacedName.String())
 	err = r.Get(ctx, namespacedName, appSet)
 	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
@@ -220,7 +220,7 @@ func (r *PaasNSReconciler) finalizeAppSetCap(
 	// See if AppSet exists raise error if it doesn't
 	as := &appv1.ApplicationSet{}
 	asNamespacedName := getConfig().CapabilityK8sName(paasns.Name)
-	ctx = setLogComponent(ctx, "AppSet")
+	ctx = setLogComponent(ctx, "appset")
 	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset", paasns.Name)
 	err := r.Get(ctx, asNamespacedName, as)
 	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
@@ -256,7 +256,7 @@ func (r *PaasReconciler) finalizeAppSetCap(
 	// See if AppSet exists raise error if it doesn't
 	as := &appv1.ApplicationSet{}
 	asNamespacedName := getConfig().CapabilityK8sName(capability)
-	ctx = setLogComponent(ctx, "AppSet")
+	ctx = setLogComponent(ctx, "appset")
 	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset", capability)
 	err := r.Get(ctx, asNamespacedName, as)
 	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)

--- a/internal/controller/capabilities.go
+++ b/internal/controller/capabilities.go
@@ -156,7 +156,7 @@ func (r *PaasNSReconciler) EnsureAppSetCap(
 		},
 	}
 	ctx = setLogComponent(ctx, "AppSet")
-	log.Ctx(ctx).Info().Msgf("Reconciling %s Applicationset %s", paasns.Name, namespacedName.String())
+	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset %s", paasns.Name, namespacedName.String())
 	err = r.Get(ctx, namespacedName, appSet)
 	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
 	var entries Entries
@@ -221,7 +221,7 @@ func (r *PaasNSReconciler) finalizeAppSetCap(
 	as := &appv1.ApplicationSet{}
 	asNamespacedName := getConfig().CapabilityK8sName(paasns.Name)
 	ctx = setLogComponent(ctx, "AppSet")
-	log.Ctx(ctx).Info().Msgf("Reconciling %s Applicationset", paasns.Name)
+	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset", paasns.Name)
 	err := r.Get(ctx, asNamespacedName, as)
 	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
 	var entries Entries
@@ -257,7 +257,7 @@ func (r *PaasReconciler) finalizeAppSetCap(
 	as := &appv1.ApplicationSet{}
 	asNamespacedName := getConfig().CapabilityK8sName(capability)
 	ctx = setLogComponent(ctx, "AppSet")
-	log.Ctx(ctx).Info().Msgf("Reconciling %s Applicationset", capability)
+	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset", capability)
 	err := r.Get(ctx, asNamespacedName, as)
 	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
 	var entries Entries

--- a/internal/controller/capabilities.go
+++ b/internal/controller/capabilities.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	appv1 "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
+	"github.com/rs/zerolog/log"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -154,8 +155,8 @@ func (r *PaasNSReconciler) EnsureAppSetCap(
 			Namespace: namespacedName.Namespace,
 		},
 	}
-	logger := getLogger(ctx, paasns, "AppSet", namespacedName.String())
-	logger.Info(fmt.Sprintf("Reconciling %s Applicationset %s", paasns.Name, namespacedName.String()))
+	ctx = setLogComponent(ctx, "AppSet")
+	log.Ctx(ctx).Info().Msgf("Reconciling %s Applicationset %s", paasns.Name, namespacedName.String())
 	err = r.Get(ctx, namespacedName, appSet)
 	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
 	var entries Entries
@@ -219,8 +220,8 @@ func (r *PaasNSReconciler) finalizeAppSetCap(
 	// See if AppSet exists raise error if it doesn't
 	as := &appv1.ApplicationSet{}
 	asNamespacedName := getConfig().CapabilityK8sName(paasns.Name)
-	logger := getLogger(ctx, paasns, "AppSet", asNamespacedName.String())
-	logger.Info(fmt.Sprintf("Reconciling %s Applicationset", paasns.Name))
+	ctx = setLogComponent(ctx, "AppSet")
+	log.Ctx(ctx).Info().Msgf("Reconciling %s Applicationset", paasns.Name)
 	err := r.Get(ctx, asNamespacedName, as)
 	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
 	var entries Entries
@@ -255,8 +256,8 @@ func (r *PaasReconciler) finalizeAppSetCap(
 	// See if AppSet exists raise error if it doesn't
 	as := &appv1.ApplicationSet{}
 	asNamespacedName := getConfig().CapabilityK8sName(capability)
-	logger := getLogger(ctx, paas, "AppSet", asNamespacedName.String())
-	logger.Info(fmt.Sprintf("Reconciling %s Applicationset", capability))
+	ctx = setLogComponent(ctx, "AppSet")
+	log.Ctx(ctx).Info().Msgf("Reconciling %s Applicationset", capability)
 	err := r.Get(ctx, asNamespacedName, as)
 	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
 	var entries Entries

--- a/internal/controller/cluster_quotas.go
+++ b/internal/controller/cluster_quotas.go
@@ -77,7 +77,7 @@ func (r *PaasReconciler) backendQuota(
 	} else {
 		quotaName = fmt.Sprintf("%s-%s", paas.ObjectMeta.Name, suffix)
 	}
-	ctx = setLogComponent(ctx, "Quota")
+	ctx = setLogComponent(ctx, "quota")
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("defining quota")
 	// matchLabels := map[string]string{"dcs.itsmoplosgroep": paas.Name}
@@ -172,7 +172,7 @@ func (r *PaasReconciler) BackendUnneededQuotas(
 }
 
 func (r *PaasReconciler) FinalizeClusterQuota(ctx context.Context, paas *v1alpha1.Paas, quotaName string) error {
-	ctx = setLogComponent(ctx, "Quota")
+	ctx = setLogComponent(ctx, "quota")
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("finalizing")
 	obj := &quotav1.ClusterResourceQuota{}
@@ -191,7 +191,7 @@ func (r *PaasReconciler) FinalizeClusterQuota(ctx context.Context, paas *v1alpha
 }
 
 func (r *PaasNSReconciler) FinalizeClusterQuota(ctx context.Context, paasns *v1alpha1.PaasNS) error {
-	ctx = setLogComponent(ctx, "Quota")
+	ctx = setLogComponent(ctx, "quota")
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("finalizing")
 	obj := &quotav1.ClusterResourceQuota{}
@@ -231,7 +231,7 @@ func (r *PaasReconciler) ReconcileQuotas(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) (err error) {
-	ctx = setLogComponent(ctx, "Quota")
+	ctx = setLogComponent(ctx, "quota")
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("creating quotas for PAAS object ")
 	// Create quotas if needed

--- a/internal/controller/cluster_quotas.go
+++ b/internal/controller/cluster_quotas.go
@@ -79,7 +79,7 @@ func (r *PaasReconciler) backendQuota(
 	}
 	ctx = setLogComponent(ctx, "Quota")
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Defining quota")
+	logger.Info().Msg("defining quota")
 	// matchLabels := map[string]string{"dcs.itsmoplosgroep": paas.Name}
 	quota := &quotav1.ClusterResourceQuota{
 		TypeMeta: metav1.TypeMeta{
@@ -104,10 +104,10 @@ func (r *PaasReconciler) backendQuota(
 		},
 	}
 
-	logger.Info().Msg("Setting owner")
+	logger.Info().Msg("setting owner")
 
 	if err := controllerutil.SetControllerReference(paas, quota, r.Scheme); err != nil {
-		logger.Err(err).Msg("Error setting owner")
+		logger.Err(err).Msg("error setting owner")
 	}
 
 	return quota
@@ -174,18 +174,18 @@ func (r *PaasReconciler) BackendUnneededQuotas(
 func (r *PaasReconciler) FinalizeClusterQuota(ctx context.Context, paas *v1alpha1.Paas, quotaName string) error {
 	ctx = setLogComponent(ctx, "Quota")
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Finalizing")
+	logger.Info().Msg("finalizing")
 	obj := &quotav1.ClusterResourceQuota{}
 	if err := r.Get(ctx, types.NamespacedName{
 		Name: quotaName,
 	}, obj); err != nil && errors.IsNotFound(err) {
-		logger.Info().Msg("Does not exist")
+		logger.Info().Msg("does not exist")
 		return nil
 	} else if err != nil {
-		logger.Err(err).Msg("Error retrieving info")
+		logger.Err(err).Msg("error retrieving info")
 		return err
 	} else {
-		logger.Info().Msg("Deleting")
+		logger.Info().Msg("deleting")
 		return r.Delete(ctx, obj)
 	}
 }
@@ -193,18 +193,18 @@ func (r *PaasReconciler) FinalizeClusterQuota(ctx context.Context, paas *v1alpha
 func (r *PaasNSReconciler) FinalizeClusterQuota(ctx context.Context, paasns *v1alpha1.PaasNS) error {
 	ctx = setLogComponent(ctx, "Quota")
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Finalizing")
+	logger.Info().Msg("finalizing")
 	obj := &quotav1.ClusterResourceQuota{}
 	if err := r.Get(ctx, types.NamespacedName{
 		Name: paasns.NamespaceName(),
 	}, obj); err != nil && errors.IsNotFound(err) {
-		logger.Info().Msg("Does not exist")
+		logger.Info().Msg("does not exist")
 		return nil
 	} else if err != nil {
-		logger.Err(err).Msg("Error retrieving info")
+		logger.Err(err).Msg("error retrieving info")
 		return err
 	} else {
-		logger.Info().Msg("Deleting")
+		logger.Info().Msg("deleting")
 		return r.Delete(ctx, obj)
 	}
 }
@@ -233,15 +233,15 @@ func (r *PaasReconciler) ReconcileQuotas(
 ) (err error) {
 	ctx = setLogComponent(ctx, "Quota")
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Creating quotas for PAAS object ")
+	logger.Info().Msg("creating quotas for PAAS object ")
 	// Create quotas if needed
 	if quotas, err := r.BackendEnabledQuotas(ctx, paas); err != nil {
-		logger.Err(err).Msg("Failure while getting list of quotas")
+		logger.Err(err).Msg("failure while getting list of quotas")
 	} else {
 		for _, q := range quotas {
-			logger.Info().Msg("Creating quota " + q.Name + " for PAAS object ")
+			logger.Info().Msg("creating quota " + q.Name + " for PAAS object ")
 			if err := r.EnsureQuota(ctx, paas, q); err != nil {
-				logger.Err(err).Msgf("Failure while creating quota %s", q.ObjectMeta.Name)
+				logger.Err(err).Msgf("failure while creating quota %s", q.ObjectMeta.Name)
 				return err
 			}
 		}
@@ -250,9 +250,9 @@ func (r *PaasReconciler) ReconcileQuotas(
 		return err
 	} else {
 		for _, name := range r.BackendUnneededQuotas(ctx, paas) {
-			logger.Info().Msg("Cleaning quota " + name + " for PAAS object ")
+			logger.Info().Msg("cleaning quota " + name + " for PAAS object ")
 			if err := r.FinalizeClusterQuota(ctx, paas, name); err != nil {
-				logger.Err(err).Msgf("Failure while finalizing quota %s", name)
+				logger.Err(err).Msgf("failure while finalizing quota %s", name)
 				return err
 			}
 		}

--- a/internal/controller/clusterrolebindings.go
+++ b/internal/controller/clusterrolebindings.go
@@ -171,7 +171,7 @@ func (r *PaasNSReconciler) ReconcileExtraClusterRoleBinding(
 		return
 	}
 
-	ctx = setLogComponent(ctx, "ClusterRoleBinding")
+	ctx = setLogComponent(ctx, "clusterrolebinding")
 
 	permissions := capConfig.ExtraPermissions.AsConfigRolesSas(cap.WithExtraPermissions())
 	permissions.Merge(capConfig.DefaultPermissions.AsConfigRolesSas(true))
@@ -200,7 +200,7 @@ func (r *PaasReconciler) FinalizeExtraClusterRoleBindings(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) (err error) {
-	ctx = setLogComponent(ctx, "ClusterRoleBinding")
+	ctx = setLogComponent(ctx, "clusterrolebinding")
 	logger := log.Ctx(ctx)
 	var capRoles []string
 	for _, capConfig := range getConfig().Capabilities {

--- a/internal/controller/clusterrolebindings.go
+++ b/internal/controller/clusterrolebindings.go
@@ -13,13 +13,13 @@ import (
 	"strings"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/rs/zerolog/log"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const crbNameFormat string = "paas-%s"
@@ -53,15 +53,15 @@ func updateClusterRoleBinding(
 	paas *v1alpha1.Paas,
 	crb *rbac.ClusterRoleBinding,
 ) (err error) {
-	logger := getLogger(ctx, paas, "ClusterRoleBinding", crb.Name)
+	logger := log.Ctx(ctx)
 	if len(crb.Subjects) == 0 && crb.ResourceVersion != "" {
-		logger.Info(fmt.Sprintf("Cleaning empty ClusterRoleBinding %s", crb.Name))
+		logger.Info().Msgf("Cleaning empty ClusterRoleBinding %s", crb.Name)
 		return r.Delete(ctx, crb)
 	} else if len(crb.Subjects) != 0 && crb.ResourceVersion == "" {
-		logger.Info(fmt.Sprintf("Creating new ClusterRoleBinding %s", crb.Name))
+		logger.Info().Msgf("Creating new ClusterRoleBinding %s", crb.Name)
 		return r.Create(ctx, crb)
 	} else if len(crb.Subjects) != 0 {
-		logger.Info(fmt.Sprintf("Updating existing ClusterRoleBinding %s", crb.Name))
+		logger.Info().Msgf("Updating existing ClusterRoleBinding %s", crb.Name)
 		return r.Update(ctx, crb)
 	}
 	return nil
@@ -133,26 +133,27 @@ func updateClusterRoleBindingForRemovedSA(
 }
 
 func addOrUpdateCrb(
+	ctx context.Context,
 	paasns *v1alpha1.PaasNS,
 	crb *rbac.ClusterRoleBinding,
 	sas map[string]bool,
-	logger logr.Logger,
 ) (changed bool) {
+	logger := log.Ctx(ctx)
 	crbName := crb.ObjectMeta.Name
 	for sa, add := range sas {
 		if add {
 			if isAdded := addSAToClusterRoleBinding(crb, paasns.NamespaceName(), sa); isAdded {
-				logger.Info(fmt.Sprintf("adding sa %s for ns %s to crb %v", sa, paasns.NamespaceName(), crbName))
+				logger.Info().Msgf("adding sa %s for ns %s to crb %v", sa, paasns.NamespaceName(), crbName)
 				changed = true
 			}
-			logger.Info(fmt.Sprintf("sa %s in ns %s already added to crb %v", sa, paasns.NamespaceName(), crbName))
+			logger.Info().Msgf("sa %s in ns %s already added to crb %v", sa, paasns.NamespaceName(), crbName)
 		} else {
 			nsRe := *regexp.MustCompile(fmt.Sprintf("^%s$", paasns.NamespaceName()))
 			if isRemoved := updateClusterRoleBindingForRemovedSA(crb, nsRe, sa); isRemoved {
-				logger.Info(fmt.Sprintf("deleting sa %s for ns %s from crb %s", sa, paasns.NamespaceName(), crbName))
+				logger.Info().Msgf("deleting sa %s for ns %s from crb %s", sa, paasns.NamespaceName(), crbName)
 				changed = true
 			}
-			logger.Info(fmt.Sprintf("sa %s in ns %s no longer in crb %s", sa, paasns.NamespaceName(), crbName))
+			logger.Info().Msgf("sa %s in ns %s no longer in crb %s", sa, paasns.NamespaceName(), crbName)
 		}
 	}
 	return
@@ -170,7 +171,7 @@ func (r *PaasNSReconciler) ReconcileExtraClusterRoleBinding(
 		return
 	}
 
-	logger := getLogger(ctx, paas, "ClusterRoleBinding", "reconcile")
+	ctx = setLogComponent(ctx, "ClusterRoleBinding")
 
 	permissions := capConfig.ExtraPermissions.AsConfigRolesSas(cap.WithExtraPermissions())
 	permissions.Merge(capConfig.DefaultPermissions.AsConfigRolesSas(true))
@@ -178,7 +179,7 @@ func (r *PaasNSReconciler) ReconcileExtraClusterRoleBinding(
 		if crb, err = getClusterRoleBinding(r.Client, ctx, paas, role); err != nil {
 			return err
 		}
-		if addOrUpdateCrb(paasns, crb, sas, logger) {
+		if addOrUpdateCrb(ctx, paasns, crb, sas) {
 			if err := updateClusterRoleBinding(r.Client, ctx, paas, crb); err != nil {
 				return err
 			}
@@ -199,7 +200,8 @@ func (r *PaasReconciler) FinalizeExtraClusterRoleBindings(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) (err error) {
-	logger := getLogger(ctx, paas, "ClusterRoleBinding", "finalize")
+	ctx = setLogComponent(ctx, "ClusterRoleBinding")
+	logger := log.Ctx(ctx)
 	var capRoles []string
 	for _, capConfig := range getConfig().Capabilities {
 		capRoles = append(capRoles, capConfig.ExtraPermissions.Roles()...)
@@ -212,15 +214,15 @@ func (r *PaasReconciler) FinalizeExtraClusterRoleBindings(
 			return err
 		}
 		nsRe := fmt.Sprintf("^%s-", paas.Name)
-		logger.Info(fmt.Sprintf("subjects before update: %s", strings.Join(subjectsFromCrb(*crb), ", ")))
+		logger.Info().Msgf("subjects before update: %s", strings.Join(subjectsFromCrb(*crb), ", "))
 		changed := updateClusterRoleBindingForRemovedSA(crb,
 			*regexp.MustCompile(nsRe), "")
-		logger.Info(fmt.Sprintf("subjects after update: %s", strings.Join(subjectsFromCrb(*crb), ", ")))
+		logger.Info().Msgf("subjects after update: %s", strings.Join(subjectsFromCrb(*crb), ", "))
 		if !changed {
-			logger.Info("no changes")
+			logger.Info().Msg("no changes")
 			continue
 		}
-		logger.Info(fmt.Sprintf("Updating rolebinding %s after cleaning SA's for '%s'", roleName, nsRe))
+		logger.Info().Msgf("Updating rolebinding %s after cleaning SA's for '%s'", roleName, nsRe)
 		if err := updateClusterRoleBinding(r.Client, ctx, paas, crb); err != nil {
 			return err
 		}

--- a/internal/controller/clusterrolebindings.go
+++ b/internal/controller/clusterrolebindings.go
@@ -55,13 +55,13 @@ func updateClusterRoleBinding(
 ) (err error) {
 	logger := log.Ctx(ctx)
 	if len(crb.Subjects) == 0 && crb.ResourceVersion != "" {
-		logger.Info().Msgf("Cleaning empty ClusterRoleBinding %s", crb.Name)
+		logger.Info().Msgf("cleaning empty ClusterRoleBinding %s", crb.Name)
 		return r.Delete(ctx, crb)
 	} else if len(crb.Subjects) != 0 && crb.ResourceVersion == "" {
-		logger.Info().Msgf("Creating new ClusterRoleBinding %s", crb.Name)
+		logger.Info().Msgf("creating new ClusterRoleBinding %s", crb.Name)
 		return r.Create(ctx, crb)
 	} else if len(crb.Subjects) != 0 {
-		logger.Info().Msgf("Updating existing ClusterRoleBinding %s", crb.Name)
+		logger.Info().Msgf("updating existing ClusterRoleBinding %s", crb.Name)
 		return r.Update(ctx, crb)
 	}
 	return nil
@@ -222,7 +222,7 @@ func (r *PaasReconciler) FinalizeExtraClusterRoleBindings(
 			logger.Info().Msg("no changes")
 			continue
 		}
-		logger.Info().Msgf("Updating rolebinding %s after cleaning SA's for '%s'", roleName, nsRe)
+		logger.Info().Msgf("updating rolebinding %s after cleaning SA's for '%s'", roleName, nsRe)
 		if err := updateClusterRoleBinding(r.Client, ctx, paas, crb); err != nil {
 			return err
 		}

--- a/internal/controller/groups.go
+++ b/internal/controller/groups.go
@@ -64,7 +64,7 @@ func (r *PaasReconciler) EnsureGroup(
 		Name: group.Name,
 	}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info().Msg("Creating the group")
+		logger.Info().Msg("creating the group")
 		// Create the group
 		if err = r.Create(ctx, group); err != nil {
 			// creating the group failed
@@ -77,30 +77,30 @@ func (r *PaasReconciler) EnsureGroup(
 		}
 	} else if err != nil {
 		// Error that isn't due to the group not existing
-		logger.Err(err).Msg("Could not retrieve info on the group")
+		logger.Err(err).Msg("could not retrieve info on the group")
 		paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusFind, group, err.Error())
 		return err
 	}
-	logger.Info().Msg("Updating the group")
+	logger.Info().Msg("updating the group")
 	// All of this is to make the list of users a unique
 	// combined list of users that where and now should be added
 	found.Users = uniqueUsers(found.Users, group.Users)
 	found.Annotations = mergeStringMap(found.Annotations, group.Annotations)
 	if !paas.AmIOwner(found.OwnerReferences) {
-		logger.Info().Msg("Setting owner reference")
+		logger.Info().Msg("setting owner reference")
 		if err := controllerutil.SetOwnerReference(paas, found, r.Scheme); err != nil {
-			logger.Err(err).Msg("Error while setting owner reference")
+			logger.Err(err).Msg("error while setting owner reference")
 		}
 	} else {
-		logger.Info().Msg("Already owner")
+		logger.Info().Msg("already owner")
 	}
 	if err = r.Update(ctx, found); err != nil {
 		// Updating the group failed
-		logger.Err(err).Msg("Updating the group failed")
+		logger.Err(err).Msg("updating the group failed")
 		paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusUpdate, group, err.Error())
 		return err
 	} else {
-		logger.Info().Msg("Group updated")
+		logger.Info().Msg("group updated")
 		// Updating the group was successful
 		paas.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusUpdate, group, "succeeded")
 		return nil
@@ -115,7 +115,7 @@ func (r *PaasReconciler) backendGroup(
 	group v1alpha1.PaasGroup,
 ) (*userv1.Group, error) {
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Defining group")
+	logger.Info().Msg("defining group")
 
 	g := &userv1.Group{
 		TypeMeta: metav1.TypeMeta{
@@ -152,7 +152,7 @@ func (r *PaasReconciler) BackendGroups(
 	logger := log.Ctx(ctx)
 	for key, group := range paas.Spec.Groups {
 		groupName := paas.Spec.Groups.Key2Name(key)
-		logger.Info().Msg("Groupname is " + groupName)
+		logger.Info().Msg("groupname is " + groupName)
 		beGroup, _ := r.backendGroup(ctx, paas, groupName, group)
 		groups = append(groups, beGroup)
 	}
@@ -170,22 +170,22 @@ func (r *PaasReconciler) finalizeGroup(
 	if err := r.Get(ctx, types.NamespacedName{
 		Name: groupName,
 	}, obj); err != nil && errors.IsNotFound(err) {
-		logger.Info().Msg("Group does not exist")
+		logger.Info().Msg("group does not exist")
 		return false, nil
 	} else if err != nil {
-		logger.Info().Msg("Group not deleted. error: " + err.Error())
+		logger.Info().Msg("group not deleted. error: " + err.Error())
 		return false, err
 	} else if !paas.AmIOwner(obj.OwnerReferences) {
-		logger.Info().Msg("Paas is not an owner")
+		logger.Info().Msg("paas is not an owner")
 		return false, nil
 	} else {
-		logger.Info().Msg("Removing PaaS finalizer " + groupName)
+		logger.Info().Msg("removing PaaS finalizer " + groupName)
 		obj.OwnerReferences = paas.WithoutMe(obj.OwnerReferences)
 		if len(obj.OwnerReferences) == 0 {
-			logger.Info().Msg("Deleting " + groupName)
+			logger.Info().Msg("deleting " + groupName)
 			return true, r.Delete(ctx, obj)
 		} else {
-			logger.Info().Msg("Not last reference, skipping deletion for " + groupName)
+			logger.Info().Msg("not last reference, skipping deletion for " + groupName)
 			return false, r.Update(ctx, obj)
 		}
 	}
@@ -212,10 +212,10 @@ func (r *PaasReconciler) ReconcileGroups(
 ) error {
 	ctx = setLogComponent(ctx, "Group")
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Creating groups for PAAS object ")
+	logger.Info().Msg("creating groups for PAAS object ")
 	for _, group := range r.BackendGroups(ctx, paas) {
 		if err := r.EnsureGroup(ctx, paas, group); err != nil {
-			logger.Err(err).Msgf("Failure while creating group %s", group.ObjectMeta.Name)
+			logger.Err(err).Msgf("failure while creating group %s", group.ObjectMeta.Name)
 			return err
 		}
 	}

--- a/internal/controller/groups.go
+++ b/internal/controller/groups.go
@@ -195,7 +195,7 @@ func (r *PaasReconciler) FinalizeGroups(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) (cleaned []string, err error) {
-	ctx = setLogComponent(ctx, "Group")
+	ctx = setLogComponent(ctx, "group")
 	for key, group := range paas.Spec.Groups {
 		if isCleaned, err := r.finalizeGroup(ctx, paas, paas.Spec.Groups.Key2Name(key)); err != nil {
 			return cleaned, err
@@ -210,7 +210,7 @@ func (r *PaasReconciler) ReconcileGroups(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) error {
-	ctx = setLogComponent(ctx, "Group")
+	ctx = setLogComponent(ctx, "group")
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("creating groups for PAAS object ")
 	for _, group := range r.BackendGroups(ctx, paas) {

--- a/internal/controller/ldap_groups.go
+++ b/internal/controller/ldap_groups.go
@@ -48,7 +48,7 @@ func (r *PaasReconciler) EnsureLdapGroups(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) error {
-	ctx = setLogComponent(ctx, "LdapGroup")
+	ctx = setLogComponent(ctx, "ldapgroup")
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("creating ldap groups for PAAS object ")
 	// See if group already exists and create if it doesn't
@@ -110,7 +110,7 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 	ctx context.Context,
 	cleanedLdapQueries []string,
 ) error {
-	ctx = setLogComponent(ctx, "LdapGroup")
+	ctx = setLogComponent(ctx, "ldapgroup")
 	logger := log.Ctx(ctx)
 	// See if group already exists and create if it doesn't
 	cm := &corev1.ConfigMap{}

--- a/internal/controller/ldap_groups.go
+++ b/internal/controller/ldap_groups.go
@@ -50,7 +50,7 @@ func (r *PaasReconciler) EnsureLdapGroups(
 ) error {
 	ctx = setLogComponent(ctx, "LdapGroup")
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Creating ldap groups for PAAS object ")
+	logger.Info().Msg("creating ldap groups for PAAS object ")
 	// See if group already exists and create if it doesn't
 	namespacedName := getConfig().Whitelist
 	cm := &corev1.ConfigMap{
@@ -66,7 +66,7 @@ func (r *PaasReconciler) EnsureLdapGroups(
 	err := r.Get(ctx, namespacedName, cm)
 	gs := paas.Spec.Groups.AsGroups()
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info().Msg("Creating whitelist configmap")
+		logger.Info().Msg("creating whitelist configmap")
 		// Create the ConfigMap
 		if err = r.ensureLdapGroupsConfigMap(ctx, gs.AsString()); err != nil {
 			paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusCreate, cm, err.Error())
@@ -75,28 +75,28 @@ func (r *PaasReconciler) EnsureLdapGroups(
 		}
 		return err
 	} else if err != nil {
-		logger.Err(err).Msg("Could not retrieve whitelist configmap")
+		logger.Err(err).Msg("could not retrieve whitelist configmap")
 		paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusFind, cm, err.Error())
 		// Error that isn't due to the group not existing
 		return err
 	} else if whitelist, exists := cm.Data[whitelistKeyName]; !exists {
-		logger.Info().Msg("Adding whitelist.txt to whitelist configmap")
+		logger.Info().Msg("adding whitelist.txt to whitelist configmap")
 		cm.Data[whitelistKeyName] = gs.AsString()
 	} else {
-		logger.Info().Msgf("Reading group queries from whitelist %v", cm)
+		logger.Info().Msgf("reading group queries from whitelist %v", cm)
 		whitelistGroups := groups.NewGroups()
 		whitelistGroups.AddFromString(whitelist)
-		logger.Info().Msgf("Adding extra groups to whitelist: %v", gs)
+		logger.Info().Msgf("adding extra groups to whitelist: %v", gs)
 		if changed := whitelistGroups.Add(&gs); !changed {
 			// fmt.Printf("configured: %d, combined: %d", l1, l2)
-			logger.Info().Msg("No new info in whitelist")
+			logger.Info().Msg("no new info in whitelist")
 			paas.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusUpdate, cm, "no changes")
 			return nil
 		}
-		logger.Info().Msg("Adding to whitelist configmap")
+		logger.Info().Msg("adding to whitelist configmap")
 		cm.Data[whitelistKeyName] = whitelistGroups.AsString()
 	}
-	logger.Info().Msgf("Updating whitelist configmap: %v", cm)
+	logger.Info().Msgf("updating whitelist configmap: %v", cm)
 	if err = r.Update(ctx, cm); err != nil {
 		paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusUpdate, cm, err.Error())
 	} else {
@@ -135,9 +135,9 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 		for _, query := range cleanedLdapQueries {
 			g := groups.NewGroup(query)
 			if g.Key == "" {
-				logger.Info().Str("query", query).Msg("Could not get key")
+				logger.Info().Str("query", query).Msg("could not get key")
 			} else if gs.DeleteByKey(g.Key) {
-				logger.Info().Msgf("LdapGroup %s removed", g.Key)
+				logger.Info().Msgf("ldapGroup %s removed", g.Key)
 				isChanged = true
 			}
 		}

--- a/internal/controller/ldap_groups.go
+++ b/internal/controller/ldap_groups.go
@@ -8,12 +8,12 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/internal/groups"
-	corev1 "k8s.io/api/core/v1"
 
+	"github.com/rs/zerolog/log"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -48,8 +48,9 @@ func (r *PaasReconciler) EnsureLdapGroups(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) error {
-	logger := getLogger(ctx, paas, "LdapGroup", "")
-	logger.Info("Creating ldap groups for PAAS object ")
+	ctx = setLogComponent(ctx, "LdapGroup")
+	logger := log.Ctx(ctx)
+	logger.Info().Msg("Creating ldap groups for PAAS object ")
 	// See if group already exists and create if it doesn't
 	namespacedName := getConfig().Whitelist
 	cm := &corev1.ConfigMap{
@@ -65,7 +66,7 @@ func (r *PaasReconciler) EnsureLdapGroups(
 	err := r.Get(ctx, namespacedName, cm)
 	gs := paas.Spec.Groups.AsGroups()
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Creating whitelist configmap")
+		logger.Info().Msg("Creating whitelist configmap")
 		// Create the ConfigMap
 		if err = r.ensureLdapGroupsConfigMap(ctx, gs.AsString()); err != nil {
 			paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusCreate, cm, err.Error())
@@ -74,28 +75,28 @@ func (r *PaasReconciler) EnsureLdapGroups(
 		}
 		return err
 	} else if err != nil {
-		logger.Error(err, "Could not retrieve whitelist configmap")
+		logger.Err(err).Msg("Could not retrieve whitelist configmap")
 		paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusFind, cm, err.Error())
 		// Error that isn't due to the group not existing
 		return err
 	} else if whitelist, exists := cm.Data[whitelistKeyName]; !exists {
-		logger.Info("Adding whitelist.txt to whitelist configmap")
+		logger.Info().Msg("Adding whitelist.txt to whitelist configmap")
 		cm.Data[whitelistKeyName] = gs.AsString()
 	} else {
-		logger.Info(fmt.Sprintf("Reading group queries from whitelist %v", cm))
+		logger.Info().Msgf("Reading group queries from whitelist %v", cm)
 		whitelistGroups := groups.NewGroups()
 		whitelistGroups.AddFromString(whitelist)
-		logger.Info(fmt.Sprintf("Adding extra groups to whitelist: %v", gs))
+		logger.Info().Msgf("Adding extra groups to whitelist: %v", gs)
 		if changed := whitelistGroups.Add(&gs); !changed {
 			// fmt.Printf("configured: %d, combined: %d", l1, l2)
-			logger.Info("No new info in whitelist")
+			logger.Info().Msg("No new info in whitelist")
 			paas.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusUpdate, cm, "no changes")
 			return nil
 		}
-		logger.Info("Adding to whitelist configmap")
+		logger.Info().Msg("Adding to whitelist configmap")
 		cm.Data[whitelistKeyName] = whitelistGroups.AsString()
 	}
-	logger.Info(fmt.Sprintf("Updating whitelist configmap: %v", cm))
+	logger.Info().Msgf("Updating whitelist configmap: %v", cm)
 	if err = r.Update(ctx, cm); err != nil {
 		paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusUpdate, cm, err.Error())
 	} else {
@@ -107,25 +108,25 @@ func (r *PaasReconciler) EnsureLdapGroups(
 // ensureLdapGroup ensures Group presence
 func (r *PaasReconciler) FinalizeLdapGroups(
 	ctx context.Context,
-	paas *v1alpha1.Paas,
 	cleanedLdapQueries []string,
 ) error {
-	logger := getLogger(ctx, paas, "LdapGroup", "")
+	ctx = setLogComponent(ctx, "LdapGroup")
+	logger := log.Ctx(ctx)
 	// See if group already exists and create if it doesn't
 	cm := &corev1.ConfigMap{}
 	wlConfigMap := getConfig().Whitelist
 	err := r.Get(ctx, wlConfigMap, cm)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("whitelist configmap does not exist")
+		logger.Info().Msg("whitelist configmap does not exist")
 		// ConfigMap does not exist, so nothing to clean
 		return nil
 	} else if err != nil {
-		logger.Error(err, "error retrieving whitelist configmap")
+		logger.Err(err).Msg("error retrieving whitelist configmap")
 		// Error that isn't due to the group not existing
 		return err
 	} else if whitelist, exists := cm.Data[whitelistKeyName]; !exists {
 		// No whitelist.txt exists in the configmap, so nothing to clean
-		logger.Info(fmt.Sprintf("%s does not exists in whitelist configmap", whitelistKeyName))
+		logger.Info().Msgf("%s does not exists in whitelist configmap", whitelistKeyName)
 		return nil
 	} else {
 		var isChanged bool
@@ -134,9 +135,9 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 		for _, query := range cleanedLdapQueries {
 			g := groups.NewGroup(query)
 			if g.Key == "" {
-				logger.Info("Could not get key", "query", query)
+				logger.Info().Str("query", query).Msg("Could not get key")
 			} else if gs.DeleteByKey(g.Key) {
-				logger.Info(fmt.Sprintf("LdapGroup %s removed", g.Key))
+				logger.Info().Msgf("LdapGroup %s removed", g.Key)
 				isChanged = true
 			}
 		}

--- a/internal/controller/main.go
+++ b/internal/controller/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/belastingdienst/opr-paas/internal/config"
 	"github.com/belastingdienst/opr-paas/internal/crypt"
 
-	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -21,7 +20,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -55,20 +53,6 @@ func getRsa(paas string) *crypt.Crypt {
 		_crypt[paas] = c
 		return c
 	}
-}
-
-func getLogger(
-	ctx context.Context,
-	obj client.Object,
-	kind string,
-	name string,
-) logr.Logger {
-	fields := append(make([]interface{}, 0), obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), "Kind", kind)
-	if name != "" {
-		fields = append(fields, "Name", name)
-	}
-
-	return ctrllog.FromContext(ctx).WithValues(fields...)
 }
 
 // setRequestLogger derives a context with a `zerolog` logger configured for a specific controller.

--- a/internal/controller/main_test.go
+++ b/internal/controller/main_test.go
@@ -13,20 +13,11 @@ package controller
 // Maybe fix later.
 
 import (
-	"context"
 	"os"
 	"testing"
 
-	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestMain_getLogger(t *testing.T) {
-	logger := getLogger(context.Background(), &v1alpha1.Paas{}, "Logger", "test")
-	logger.Info("testing logging")
-	logger = getLogger(context.Background(), &v1alpha1.Paas{}, "Logger", "")
-	logger.Info("testing logging")
-}
 
 func TestMain_getConfig(t *testing.T) {
 	os.Setenv("PAAS_CONFIG", "../../test/manifests/config/paas_config.yml")

--- a/internal/controller/namespaces.go
+++ b/internal/controller/namespaces.go
@@ -87,7 +87,7 @@ func BackendNamespace(
 	quota string,
 	scheme *runtime.Scheme,
 ) (*corev1.Namespace, error) {
-	setLogComponent(ctx, "Namespace")
+	setLogComponent(ctx, "namespace")
 	logger := log.Ctx(ctx)
 	logger.Info().Msgf("defining %s Namespace", name)
 	ns := &corev1.Namespace{

--- a/internal/controller/namespaces.go
+++ b/internal/controller/namespaces.go
@@ -89,7 +89,7 @@ func BackendNamespace(
 ) (*corev1.Namespace, error) {
 	setLogComponent(ctx, "Namespace")
 	logger := log.Ctx(ctx)
-	logger.Info().Msgf("Defining %s Namespace", name)
+	logger.Info().Msgf("defining %s Namespace", name)
 	ns := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Namespace",
@@ -101,19 +101,19 @@ func BackendNamespace(
 		},
 		Spec: corev1.NamespaceSpec{},
 	}
-	logger.Info().Msgf("Setting Quotagroup %s", quota)
+	logger.Info().Msgf("setting Quotagroup %s", quota)
 	ns.ObjectMeta.Labels[getConfig().QuotaLabel] = quota
 
 	argoNameSpace := fmt.Sprintf("%s-argocd", paas.ManagedByPaas())
-	logger.Info().Msg("Setting managed_by_label")
+	logger.Info().Msg("setting managed_by_label")
 	ns.ObjectMeta.Labels[getConfig().ManagedByLabel] = argoNameSpace
 
-	logger.Info().Msg("Setting requestor_label")
+	logger.Info().Msg("setting requestor_label")
 	ns.ObjectMeta.Labels[getConfig().RequestorLabel] = paas.Spec.Requestor
 
-	logger.Info().Str("PaaS", paas.Name).Str("namespace", ns.Name).Msg("Setting Owner")
+	logger.Info().Str("PaaS", paas.Name).Str("namespace", ns.Name).Msg("setting Owner")
 	if err := controllerutil.SetControllerReference(paas, ns, scheme); err != nil {
-		logger.Err(err).Msg("SetControllerReference failure")
+		logger.Err(err).Msg("setControllerReference failure")
 		return nil, err
 	}
 	for _, ref := range ns.OwnerReferences {

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -68,7 +68,7 @@ func (r *PaasReconciler) GetPaas(
 	req ctrl.Request,
 ) (paas *v1alpha1.Paas, err error) {
 	paas = &v1alpha1.Paas{ObjectMeta: metav1.ObjectMeta{Name: req.Name}}
-	ctx = setLogComponent(ctx, "PaaS")
+	ctx = setLogComponent(ctx, "paas")
 	logger := log.Ctx(ctx)
 	err = r.Get(ctx, req.NamespacedName, paas)
 	if err != nil {

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -81,9 +81,9 @@ func (r *PaasReconciler) GetPaas(
 		}
 		return nil, err
 	} else if paas.GetDeletionTimestamp() != nil {
-		logger.Info().Msg("PAAS object marked for deletion")
+		logger.Info().Msg("pAAS object marked for deletion")
 		if controllerutil.ContainsFinalizer(paas, paasFinalizer) {
-			logger.Info().Msg("Finalizing PaaS")
+			logger.Info().Msg("finalizing PaaS")
 			// Run finalization logic for paasFinalizer. If the
 			// finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
@@ -91,30 +91,30 @@ func (r *PaasReconciler) GetPaas(
 				return nil, err
 			}
 
-			logger.Info().Msg("Removing finalizer")
+			logger.Info().Msg("removing finalizer")
 			// Remove paasFinalizer. Once all finalizers have been
 			// removed, the object will be deleted.
 			controllerutil.RemoveFinalizer(paas, paasFinalizer)
 			if err := r.Update(ctx, paas); err != nil {
 				return nil, err
 			}
-			logger.Info().Msg("Finalization finished")
+			logger.Info().Msg("finalization finished")
 		}
 		return nil, nil
 	}
 
 	// Add finalizer for this CR
-	logger.Info().Msg("Adding finalizer for Paas object")
+	logger.Info().Msg("adding finalizer for Paas object")
 	if !controllerutil.ContainsFinalizer(paas, paasFinalizer) {
-		logger.Info().Msg("Paas object has no finalizer yet")
+		logger.Info().Msg("paas object has no finalizer yet")
 		controllerutil.AddFinalizer(paas, paasFinalizer)
-		logger.Info().Msg("Added finalizer for Paas object")
+		logger.Info().Msg("added finalizer for Paas object")
 		if err := r.Update(ctx, paas); err != nil {
-			logger.Info().Msg("Error updating Paas object")
+			logger.Info().Msg("error updating Paas object")
 			logger.Info().Msgf("%v", paas)
 			return nil, err
 		}
-		logger.Info().Msg("Updated Paas object")
+		logger.Info().Msg("updated Paas object")
 	}
 
 	return paas, nil
@@ -191,34 +191,34 @@ func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *PaasReconciler) finalizePaaS(ctx context.Context, paas *v1alpha1.Paas) error {
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Inside PaaS finalizer")
+	logger.Info().Msg("inside PaaS finalizer")
 	if err := r.FinalizeAppSetCaps(ctx, paas); err != nil {
-		logger.Err(err).Msg("AppSet finalizer error")
+		logger.Err(err).Msg("appSet finalizer error")
 		return err
 	} else if err = r.FinalizeAppProject(ctx, paas); err != nil {
-		logger.Err(err).Msg("AppProject finalizer error")
+		logger.Err(err).Msg("appProject finalizer error")
 		return err
 	} else if err = r.FinalizeClusterQuotas(ctx, paas); err != nil {
-		logger.Err(err).Msg("Quota finalizer error")
+		logger.Err(err).Msg("quota finalizer error")
 		return err
 	} else if cleanedLdapQueries, err := r.FinalizeGroups(ctx, paas); err != nil {
 		// The whole idea is that groups (which are resources)
 		// can also be ldapGroups (lines in a field in a configmap)
 		// ldapGroups are only cleaned if the corresponding group is also cleaned
-		logger.Err(err).Msg("Group finalizer error")
+		logger.Err(err).Msg("group finalizer error")
 		if ldapErr := r.FinalizeLdapGroups(ctx, cleanedLdapQueries); ldapErr != nil {
-			logger.Err(ldapErr).Msg("And ldapGroup finalizer error")
+			logger.Err(ldapErr).Msg("and ldapGroup finalizer error")
 		}
 		return err
 	} else if err = r.FinalizeLdapGroups(ctx, cleanedLdapQueries); err != nil {
-		logger.Err(err).Msg("LdapGroup finalizer error")
+		logger.Err(err).Msg("ldapGroup finalizer error")
 		return err
 	} else if err = r.FinalizeExtraClusterRoleBindings(ctx, paas); err != nil {
-		logger.Err(err).Msg("Extra ClusterRoleBindings finalizer error")
+		logger.Err(err).Msg("extra ClusterRoleBindings finalizer error")
 		return err
 	} else if err = r.FinalizeClusterWideQuotas(ctx, paas); err != nil {
 		return err
 	}
-	logger.Info().Msg("PaaS successfully finalized")
+	logger.Info().Msg("paaS successfully finalized")
 	return nil
 }

--- a/internal/controller/paasnamespaces.go
+++ b/internal/controller/paasnamespaces.go
@@ -125,7 +125,7 @@ func (r *PaasReconciler) ReconcilePaasNss(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) error {
-	ctx = setLogComponent(ctx, "PaasNS")
+	ctx = setLogComponent(ctx, "paasns")
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("creating default namespace to hold PaasNs resources for PAAS object")
 	if ns, err := BackendNamespace(ctx, paas, paas.Name, paas.Name, r.Scheme); err != nil {

--- a/internal/controller/paasnamespaces.go
+++ b/internal/controller/paasnamespaces.go
@@ -8,16 +8,15 @@ package controller
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+
+	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func (r *PaasReconciler) GetPaasNs(ctx context.Context, paas *v1alpha1.Paas, name string,
@@ -39,13 +38,13 @@ func (r *PaasReconciler) GetPaasNs(ctx context.Context, paas *v1alpha1.Paas, nam
 			SshSecrets: secrets,
 		},
 	}
-	logger := getLogger(ctx, paas, pns.Kind, name)
-	logger.Info("Defining")
+	logger := log.Ctx(ctx)
+	logger.Info().Msg("Defining")
 	paas.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusCreate,
 		pns, "Setting requestor_label")
 	pns.ObjectMeta.Labels[getConfig().RequestorLabel] = paas.Spec.Requestor
 
-	logger.Info("Setting Owner")
+	logger.Info().Msg("Setting Owner")
 
 	if err := controllerutil.SetControllerReference(paas, pns, r.Scheme); err != nil {
 		return pns, err
@@ -54,8 +53,8 @@ func (r *PaasReconciler) GetPaasNs(ctx context.Context, paas *v1alpha1.Paas, nam
 }
 
 func (r *PaasReconciler) ensurePaasNs(ctx context.Context, paas *v1alpha1.Paas, pns *v1alpha1.PaasNS) error {
-	logger := getLogger(ctx, paas, pns.Kind, pns.Name)
-	logger.Info("Ensuring")
+	logger := log.Ctx(ctx)
+	logger.Info().Msg("Ensuring")
 
 	// See if namespace exists and create if it doesn't
 	found := &v1alpha1.PaasNS{}
@@ -88,13 +87,13 @@ func (r *PaasReconciler) ensurePaasNs(ctx context.Context, paas *v1alpha1.Paas, 
 	found.Spec.Groups = pns.Spec.Groups
 	found.Spec.SshSecrets = pns.Spec.SshSecrets
 	found.ObjectMeta.Labels = pns.ObjectMeta.Labels
-	logger.Info("Updating PaasNs", "PaasNs", pns)
+	logger.Info().Str("PaasNs", pns.Name).Msg("Updating PaasNs")
 	return r.Update(ctx, found)
 }
 
 func (r *PaasReconciler) FinalizePaasNss(ctx context.Context, paas *v1alpha1.Paas) error {
-	logger := getLogger(ctx, paas, "Namespace", "")
-	logger.Info("Finalizing")
+	logger := log.Ctx(ctx)
+	logger.Info().Msg("Finalizing")
 
 	enabledNs := paas.AllEnabledNamespaces()
 
@@ -109,12 +108,12 @@ func (r *PaasReconciler) FinalizePaasNss(ctx context.Context, paas *v1alpha1.Paa
 		pns := pns
 
 		if !paas.AmIOwner(pns.OwnerReferences) {
-			// logger.Info("Skipping finalization", "Namespace", ns.Name, "Reason", "I am not owner")
+			// logger.Info().Msg("Skipping finalization", "Namespace", ns.Name, "Reason", "I am not owner")
 		} else if _, isEnabled := enabledNs[pns.Name]; isEnabled {
-			// logger.Info("Skipping finalization", "Namespace", ns.Name, "Reason", "Should be there")
+			// logger.Info().Msg("Skipping finalization", "Namespace", ns.Name, "Reason", "Should be there")
 		} else if err := r.Delete(ctx, &pns); err != nil {
 			paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusDelete, &pns, err.Error())
-			// logger.Error(err, "Could not delete ns", "Namespace", ns.Name)
+			// logger.Err(err).Msg("Could not delete ns", "Namespace", ns.Name)
 		} else {
 			paas.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusDelete, &pns, "succeeded")
 		}
@@ -125,32 +124,33 @@ func (r *PaasReconciler) FinalizePaasNss(ctx context.Context, paas *v1alpha1.Paa
 func (r *PaasReconciler) ReconcilePaasNss(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
-	logger logr.Logger,
 ) error {
-	logger.Info("Creating default namespace to hold PaasNs resources for PAAS object")
+	ctx = setLogComponent(ctx, "PaasNS")
+	logger := log.Ctx(ctx)
+	logger.Info().Msg("Creating default namespace to hold PaasNs resources for PAAS object")
 	if ns, err := BackendNamespace(ctx, paas, paas.Name, paas.Name, r.Scheme); err != nil {
-		logger.Error(err, fmt.Sprintf("Failure while defining namespace %s", paas.Name))
+		logger.Err(err).Msgf("Failure while defining namespace %s", paas.Name)
 		return err
 	} else if err = EnsureNamespace(r.Client, ctx, paas.Status.AddMessage, paas, ns, r.Scheme); err != nil {
-		logger.Error(err, fmt.Sprintf("Failure while creating namespace %s", paas.Name))
+		logger.Err(err).Msgf("Failure while creating namespace %s", paas.Name)
 		return err
 	} else {
-		logger.Info("Creating PaasNs resources for PAAS object")
+		logger.Info().Msg("Creating PaasNs resources for PAAS object")
 		for nsName := range paas.AllEnabledNamespaces() {
 			pns, err := r.GetPaasNs(ctx, paas, nsName, paas.Spec.Groups.Names(), paas.GetNsSshSecrets(nsName))
 			if err != nil {
-				logger.Error(err, fmt.Sprintf("Failure while creating PaasNs %s",
-					types.NamespacedName{Name: pns.Name, Namespace: pns.Namespace}))
+				logger.Err(err).Msgf("Failure while creating PaasNs %s",
+					types.NamespacedName{Name: pns.Name, Namespace: pns.Namespace})
 				return err
 			}
 			if err = r.ensurePaasNs(ctx, paas, pns); err != nil {
-				logger.Error(err, fmt.Sprintf("Failure while creating PaasNs %s",
-					types.NamespacedName{Name: pns.Name, Namespace: pns.Namespace}))
+				logger.Err(err).Msgf("Failure while creating PaasNs %s",
+					types.NamespacedName{Name: pns.Name, Namespace: pns.Namespace})
 				return err
 			}
 		}
 	}
-	logger.Info("Cleaning obsolete namespaces ")
+	logger.Info().Msg("Cleaning obsolete namespaces ")
 	if err := r.FinalizePaasNss(ctx, paas); err != nil {
 		return err
 	}

--- a/internal/controller/paasns_controller.go
+++ b/internal/controller/paasns_controller.go
@@ -51,7 +51,7 @@ func (pr PaasNSReconciler) GetScheme() *runtime.Scheme {
 
 func (r *PaasNSReconciler) GetPaasNs(ctx context.Context, req ctrl.Request) (paasns *v1alpha1.PaasNS, err error) {
 	paasns = &v1alpha1.PaasNS{}
-	ctx = setLogComponent(ctx, "PaasNS")
+	ctx = setLogComponent(ctx, "paasns")
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("reconciling PaasNs")
 
@@ -281,7 +281,7 @@ func (r *PaasReconciler) pnsFromNs(ctx context.Context, ns string) map[string]v1
 }
 
 func (r *PaasNSReconciler) paasFromPaasNs(ctx context.Context, paasns *v1alpha1.PaasNS) (paas *v1alpha1.Paas, namespaces map[string]int, err error) {
-	ctx = setLogComponent(ctx, "PaasNS")
+	ctx = setLogComponent(ctx, "paasns")
 	logger := log.Ctx(ctx)
 	paas = &v1alpha1.Paas{}
 	if err := r.Get(ctx, types.NamespacedName{Name: paasns.Spec.Paas}, paas); err != nil {
@@ -313,7 +313,7 @@ func (r *PaasNSReconciler) paasFromPaasNs(ctx context.Context, paasns *v1alpha1.
 }
 
 func (r *PaasNSReconciler) finalizePaasNs(ctx context.Context, paasns *v1alpha1.PaasNS) error {
-	ctx = setLogComponent(ctx, "PaasNS")
+	ctx = setLogComponent(ctx, "paasns")
 	logger := log.Ctx(ctx)
 
 	paas, nss, err := r.paasFromPaasNs(ctx, paasns)

--- a/internal/controller/paasns_controller.go
+++ b/internal/controller/paasns_controller.go
@@ -53,7 +53,7 @@ func (r *PaasNSReconciler) GetPaasNs(ctx context.Context, req ctrl.Request) (paa
 	paasns = &v1alpha1.PaasNS{}
 	ctx = setLogComponent(ctx, "PaasNS")
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Reconciling PaasNs")
+	logger.Info().Msg("reconciling PaasNs")
 
 	if err = r.Get(ctx, req.NamespacedName, paasns); err != nil {
 		return nil, client.IgnoreNotFound(err)
@@ -65,16 +65,16 @@ func (r *PaasNSReconciler) GetPaasNs(ctx context.Context, req ctrl.Request) (paa
 			return nil, fmt.Errorf("failed to add finalizer")
 		}
 		if err := r.Update(ctx, paasns); err != nil {
-			logger.Err(err).Msg("Error updating PaasNs")
+			logger.Err(err).Msg("error updating PaasNs")
 			return nil, err
 		}
-		logger.Info().Msg("Added finalizer to PaasNs")
+		logger.Info().Msg("added finalizer to PaasNs")
 	}
 
 	if paasns.GetDeletionTimestamp() != nil {
-		logger.Info().Msg("PaasNS object marked for deletion")
+		logger.Info().Msg("paasNS object marked for deletion")
 		if controllerutil.ContainsFinalizer(paasns, paasNsFinalizer) {
-			logger.Info().Msg("Finalizing PaasNs")
+			logger.Info().Msg("finalizing PaasNs")
 			// Run finalization logic for paasNsFinalizer. If the
 			// finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
@@ -82,13 +82,13 @@ func (r *PaasNSReconciler) GetPaasNs(ctx context.Context, req ctrl.Request) (paa
 				return nil, err
 			}
 
-			logger.Info().Msg("Removing finalizer")
+			logger.Info().Msg("removing finalizer")
 			// Remove paasNsFinalizer. Once all finalizers have been removed, the object will be deleted.
 			controllerutil.RemoveFinalizer(paasns, paasNsFinalizer)
 			if err := r.Update(ctx, paasns); err != nil {
 				return nil, err
 			}
-			logger.Info().Msg("Finalization finished")
+			logger.Info().Msg("finalization finished")
 		}
 		return nil, nil
 	}
@@ -202,7 +202,7 @@ func (r *PaasNSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	logger.Info().Msg("updating PaasNs object status")
 	paasns.Status.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusReconcile, paasns, "succeeded")
-	logger.Info().Msg("PaasNs object successfully reconciled")
+	logger.Info().Msg("paasNs object successfully reconciled")
 
 	return okResult, nil
 }
@@ -327,7 +327,7 @@ func (r *PaasNSReconciler) finalizePaasNs(ctx context.Context, paasns *v1alpha1.
 		return nil
 	}
 
-	logger.Info().Msg("Inside PaasNs finalizer")
+	logger.Info().Msg("inside PaasNs finalizer")
 	if err := r.FinalizeNamespace(ctx, paasns, paas); err != nil {
 		err = fmt.Errorf("cannot remove namespace belonging to PaaS %s: %s", paasns.Spec.Paas, err.Error())
 		return err
@@ -336,12 +336,12 @@ func (r *PaasNSReconciler) finalizePaasNs(ctx context.Context, paasns *v1alpha1.
 		return err
 	}
 	if _, isCapability := paas.Spec.Capabilities[paasns.Name]; isCapability {
-		logger.Info().Msg("PaasNs is a capability, also finalizing Cluster Resource Quota")
+		logger.Info().Msg("paasNs is a capability, also finalizing Cluster Resource Quota")
 		if err := r.FinalizeClusterQuota(ctx, paasns); err != nil {
 			logger.Err(err).Msg(fmt.Sprintf("Failure while finalizing quota %s", paasns.Name))
 			return err
 		}
 	}
-	logger.Info().Msg("PaasNs successfully finalized")
+	logger.Info().Msg("paasNs successfully finalized")
 	return nil
 }

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 
-	"github.com/go-logr/logr"
 	"github.com/rs/zerolog/log"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -53,7 +52,7 @@ func EnsureRoleBinding(
 	statusMessages *v1alpha1.PaasNsStatus,
 	rb *rbac.RoleBinding,
 ) error {
-	logger := getLogger(ctx, paas, "Rolebinding", rb.Name)
+	logger := log.Ctx(ctx)
 	if len(rb.Subjects) < 1 {
 		return FinalizeRoleBinding(ctx, r, statusMessages, rb)
 	}
@@ -66,30 +65,35 @@ func EnsureRoleBinding(
 	err := r.Get(ctx, namespacedName, found)
 	if err != nil && errors.IsNotFound(err) {
 		// Create the rolebinding
-		logger.Info("Creating RoleBinding", "Namespace", rb.Namespace, "Name", rb.Name, "roleRef", rb.RoleRef, "subject", rb.Subjects)
+		logger.Info().
+			Str("Namespace", rb.Namespace).
+			Str("Name", rb.Name).
+			Str("roleRef", rb.RoleRef.Name).
+			Any("subject", rb.Subjects).
+			Msg("Creating RoleBinding")
 		err = r.Create(ctx, rb)
 
 		if err != nil {
 			// Creating the rolebinding failed
-			logger.Error(err, "Error creating rolebinding")
+			logger.Err(err).Msg("Error creating rolebinding")
 			statusMessages.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusCreate, rb, err.Error())
 			return err
 		} else {
 			// Creating the rolebinding was successful and return
-			logger.Info("Created rolebinding")
+			logger.Info().Msg("Created rolebinding")
 			statusMessages.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusCreate, rb, "succeeded")
 			return nil
 		}
 	} else if err != nil {
 		// Error that isn't due to the rolebinding not existing
-		logger.Error(err, "Error getting rolebinding")
+		logger.Err(err).Msg("Error getting rolebinding")
 		statusMessages.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusFind, rb, err.Error())
 		return err
 	}
 	var changed bool
 	if !paas.AmIOwner(found.OwnerReferences) {
 		if err = controllerutil.SetControllerReference(paas, found, r.GetScheme()); err != nil {
-			logger.Error(err, "Error setting rolebinding owner")
+			logger.Err(err).Msg("Error setting rolebinding owner")
 			return err
 		}
 		changed = true
@@ -99,9 +103,14 @@ func EnsureRoleBinding(
 		changed = true
 	}
 	if changed {
-		logger.Info("Updating RoleBinding", "Namespace", rb.Namespace, "Name", rb.Name, "roleRef", rb.RoleRef, "subject", rb.Subjects)
+		logger.Info().
+			Str("Namespace", rb.Namespace).
+			Str("Name", rb.Name).
+			Str("roleRef", rb.RoleRef.Name).
+			Any("subject", rb.Subjects).
+			Msg("Updating RoleBinding")
 		if err = r.Update(ctx, found); err != nil {
-			logger.Error(err, "Error updating rolebinding")
+			logger.Err(err).Msg("Error updating rolebinding")
 			statusMessages.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusUpdate, rb, err.Error())
 			return err
 		}
@@ -121,8 +130,8 @@ func backendRoleBinding(
 	role string,
 	groups []string,
 ) (*rbac.RoleBinding, error) {
-	logger := getLogger(ctx, paas, "RoleBinding", name.String())
-	logger.Info(fmt.Sprintf("Defining %s RoleBinding", name))
+	logger := log.Ctx(ctx)
+	logger.Info().Msgf("Defining %s RoleBinding", name)
 
 	subjects := []rbac.Subject{}
 	for _, g := range groups {
@@ -151,7 +160,7 @@ func backendRoleBinding(
 			Name:     role,
 		},
 	}
-	logger.Info("Setting Owner")
+	logger.Info().Msg("Setting Owner")
 	if err := controllerutil.SetControllerReference(paas, rb, r.GetScheme()); err != nil {
 		return rb, err
 	}
@@ -189,8 +198,9 @@ func FinalizeRoleBinding(
 func (r *PaasReconciler) ReconcileRolebindings(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
-	logger logr.Logger,
 ) error {
+	ctx = setLogComponent(ctx, "RoleBinding")
+	logger := log.Ctx(ctx)
 	for _, paasns := range r.pnsFromNs(ctx, paas.ObjectMeta.Name) {
 		roles := make(map[string][]string)
 
@@ -201,7 +211,7 @@ func (r *PaasReconciler) ReconcileRolebindings(
 				roles[role] = []string{}
 			}
 		}
-		logger.Info("All roles", "Rolebindings map", roles)
+		logger.Info().Any("Rolebindings map", roles).Msg("All roles")
 		for groupName, groupRoles := range paas.Spec.Groups.Filtered(paasns.Spec.Groups).Roles() {
 			for _, mappedRole := range getConfig().RoleMappings.Roles(groupRoles) {
 				if role, exists := roles[mappedRole]; exists {
@@ -211,11 +221,14 @@ func (r *PaasReconciler) ReconcileRolebindings(
 				}
 			}
 		}
-		logger.Info("Creating paas RoleBindings for PAASNS object", "Rolebindings map", roles)
+		logger.Info().Any("Rolebindings map", roles).Msg("Creating paas RoleBindings for PAASNS object")
 		for roleName, groupKeys := range roles {
 			statusMessages := v1alpha1.PaasNsStatus{}
 			rbName := types.NamespacedName{Namespace: paasns.NamespaceName(), Name: fmt.Sprintf("paas-%s", roleName)}
-			logger.Info("Creating Rolebinding", "role", roleName, "groups", groupKeys)
+			logger.Info().
+				Str("role", roleName).
+				Strs("groups", groupKeys).
+				Msg("Creating Rolebinding")
 			rb, _ := backendRoleBinding(ctx, r, paas, rbName, roleName, groupKeys)
 			if err := EnsureRoleBinding(ctx, r, paas, &statusMessages, rb); err != nil {
 				err = fmt.Errorf("failure while creating/updating rolebinding %s/%s: %s", rb.ObjectMeta.Namespace, rb.ObjectMeta.Name, err.Error())
@@ -234,6 +247,8 @@ func (r *PaasNSReconciler) ReconcileRolebindings(
 	paas *v1alpha1.Paas,
 	paasns *v1alpha1.PaasNS,
 ) error {
+	ctx = setLogComponent(ctx, "RoleBinding")
+	logger := log.Ctx(ctx)
 	// Creating a list of roles and the groups that should have them, for this namespace
 	roles := make(map[string][]string)
 	for groupName, groupRoles := range paas.Spec.Groups.Filtered(paasns.Spec.Groups).Roles() {
@@ -245,12 +260,12 @@ func (r *PaasNSReconciler) ReconcileRolebindings(
 			}
 		}
 	}
-	log.Ctx(ctx).Info().
+	logger.Info().
 		Any("Rolebindings map", roles).
 		Msg("creating paas RoleBindings for PAASNS object")
 	for roleName, groupKeys := range roles {
 		rbName := types.NamespacedName{Namespace: paasns.NamespaceName(), Name: fmt.Sprintf("paas-%s", roleName)}
-		log.Ctx(ctx).Info().
+		logger.Info().
 			Str("role", roleName).
 			Strs("groups", groupKeys).
 			Msg("creating Rolebinding")

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -70,30 +70,30 @@ func EnsureRoleBinding(
 			Str("Name", rb.Name).
 			Str("roleRef", rb.RoleRef.Name).
 			Any("subject", rb.Subjects).
-			Msg("Creating RoleBinding")
+			Msg("creating RoleBinding")
 		err = r.Create(ctx, rb)
 
 		if err != nil {
 			// Creating the rolebinding failed
-			logger.Err(err).Msg("Error creating rolebinding")
+			logger.Err(err).Msg("error creating rolebinding")
 			statusMessages.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusCreate, rb, err.Error())
 			return err
 		} else {
 			// Creating the rolebinding was successful and return
-			logger.Info().Msg("Created rolebinding")
+			logger.Info().Msg("created rolebinding")
 			statusMessages.AddMessage(v1alpha1.PaasStatusInfo, v1alpha1.PaasStatusCreate, rb, "succeeded")
 			return nil
 		}
 	} else if err != nil {
 		// Error that isn't due to the rolebinding not existing
-		logger.Err(err).Msg("Error getting rolebinding")
+		logger.Err(err).Msg("error getting rolebinding")
 		statusMessages.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusFind, rb, err.Error())
 		return err
 	}
 	var changed bool
 	if !paas.AmIOwner(found.OwnerReferences) {
 		if err = controllerutil.SetControllerReference(paas, found, r.GetScheme()); err != nil {
-			logger.Err(err).Msg("Error setting rolebinding owner")
+			logger.Err(err).Msg("error setting rolebinding owner")
 			return err
 		}
 		changed = true
@@ -108,9 +108,9 @@ func EnsureRoleBinding(
 			Str("Name", rb.Name).
 			Str("roleRef", rb.RoleRef.Name).
 			Any("subject", rb.Subjects).
-			Msg("Updating RoleBinding")
+			Msg("updating RoleBinding")
 		if err = r.Update(ctx, found); err != nil {
-			logger.Err(err).Msg("Error updating rolebinding")
+			logger.Err(err).Msg("error updating rolebinding")
 			statusMessages.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusUpdate, rb, err.Error())
 			return err
 		}
@@ -131,7 +131,7 @@ func backendRoleBinding(
 	groups []string,
 ) (*rbac.RoleBinding, error) {
 	logger := log.Ctx(ctx)
-	logger.Info().Msgf("Defining %s RoleBinding", name)
+	logger.Info().Msgf("defining %s RoleBinding", name)
 
 	subjects := []rbac.Subject{}
 	for _, g := range groups {
@@ -160,7 +160,7 @@ func backendRoleBinding(
 			Name:     role,
 		},
 	}
-	logger.Info().Msg("Setting Owner")
+	logger.Info().Msg("setting Owner")
 	if err := controllerutil.SetControllerReference(paas, rb, r.GetScheme()); err != nil {
 		return rb, err
 	}
@@ -211,7 +211,7 @@ func (r *PaasReconciler) ReconcileRolebindings(
 				roles[role] = []string{}
 			}
 		}
-		logger.Info().Any("Rolebindings map", roles).Msg("All roles")
+		logger.Info().Any("Rolebindings map", roles).Msg("all roles")
 		for groupName, groupRoles := range paas.Spec.Groups.Filtered(paasns.Spec.Groups).Roles() {
 			for _, mappedRole := range getConfig().RoleMappings.Roles(groupRoles) {
 				if role, exists := roles[mappedRole]; exists {
@@ -221,14 +221,14 @@ func (r *PaasReconciler) ReconcileRolebindings(
 				}
 			}
 		}
-		logger.Info().Any("Rolebindings map", roles).Msg("Creating paas RoleBindings for PAASNS object")
+		logger.Info().Any("Rolebindings map", roles).Msg("creating paas RoleBindings for PAASNS object")
 		for roleName, groupKeys := range roles {
 			statusMessages := v1alpha1.PaasNsStatus{}
 			rbName := types.NamespacedName{Namespace: paasns.NamespaceName(), Name: fmt.Sprintf("paas-%s", roleName)}
 			logger.Info().
 				Str("role", roleName).
 				Strs("groups", groupKeys).
-				Msg("Creating Rolebinding")
+				Msg("creating Rolebinding")
 			rb, _ := backendRoleBinding(ctx, r, paas, rbName, roleName, groupKeys)
 			if err := EnsureRoleBinding(ctx, r, paas, &statusMessages, rb); err != nil {
 				err = fmt.Errorf("failure while creating/updating rolebinding %s/%s: %s", rb.ObjectMeta.Namespace, rb.ObjectMeta.Name, err.Error())

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -199,7 +199,7 @@ func (r *PaasReconciler) ReconcileRolebindings(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) error {
-	ctx = setLogComponent(ctx, "RoleBinding")
+	ctx = setLogComponent(ctx, "rolebinding")
 	logger := log.Ctx(ctx)
 	for _, paasns := range r.pnsFromNs(ctx, paas.ObjectMeta.Name) {
 		roles := make(map[string][]string)
@@ -247,7 +247,7 @@ func (r *PaasNSReconciler) ReconcileRolebindings(
 	paas *v1alpha1.Paas,
 	paasns *v1alpha1.PaasNS,
 ) error {
-	ctx = setLogComponent(ctx, "RoleBinding")
+	ctx = setLogComponent(ctx, "rolebinding")
 	logger := log.Ctx(ctx)
 	// Creating a list of roles and the groups that should have them, for this namespace
 	roles := make(map[string][]string)

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -92,8 +92,8 @@ func (r *PaasNSReconciler) backendSecret(
 	*corev1.Secret,
 	error,
 ) {
-	logger := getLogger(ctx, paasns, "Secret", namespacedName.String())
-	logger.Info("Defining Secret")
+	logger := log.Ctx(ctx)
+	logger.Info().Msg("Defining Secret")
 
 	s := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -113,7 +113,7 @@ func (r *PaasNSReconciler) backendSecret(
 
 	s.Labels["argocd.argoproj.io/secret-type"] = "repo-creds"
 
-	logger.Info("Setting Owner")
+	logger.Info().Msg("Setting Owner")
 
 	err := controllerutil.SetControllerReference(paas, s, r.Scheme)
 	if err != nil {
@@ -173,18 +173,18 @@ func (r *PaasNSReconciler) BackendSecrets(
 
 // deleteObsoleteSecrets deletes any secrets from the existingSecrets which is not listed in the desired secrets.
 func (r *PaasNSReconciler) deleteObsoleteSecrets(ctx context.Context, paas *v1alpha1.Paas, existingSecrets []*corev1.Secret, desiredSecrets []*corev1.Secret) error {
-	logger := getLogger(ctx, paas, "Secret", "test")
-	logger.Info("Deleting obsolete secrets")
+	logger := log.Ctx(ctx)
+	logger.Info().Msg("Deleting obsolete secrets")
 
 	// Delete secrets that are no longer needed
 	for _, existingSecret := range existingSecrets {
 		if !isSecretInDesiredSecrets(existingSecret, desiredSecrets) {
 			// Secret is not in the desired state, delete it
 			if err := r.Delete(ctx, existingSecret); err != nil {
-				logger.Error(err, "Failed to delete Secret", "Secret", existingSecret.Name)
+				logger.Err(err).Str("Secret", existingSecret.Name).Msg("Failed to delete Secret")
 				return err
 			}
-			logger.Info("Deleted obsolete Secret", "Secret", existingSecret.Name)
+			logger.Info().Str("Secret", existingSecret.Name).Msg("Deleted obsolete Secret")
 		}
 	}
 

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -93,7 +93,7 @@ func (r *PaasNSReconciler) backendSecret(
 	error,
 ) {
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Defining Secret")
+	logger.Info().Msg("defining Secret")
 
 	s := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -113,7 +113,7 @@ func (r *PaasNSReconciler) backendSecret(
 
 	s.Labels["argocd.argoproj.io/secret-type"] = "repo-creds"
 
-	logger.Info().Msg("Setting Owner")
+	logger.Info().Msg("setting Owner")
 
 	err := controllerutil.SetControllerReference(paas, s, r.Scheme)
 	if err != nil {
@@ -174,17 +174,17 @@ func (r *PaasNSReconciler) BackendSecrets(
 // deleteObsoleteSecrets deletes any secrets from the existingSecrets which is not listed in the desired secrets.
 func (r *PaasNSReconciler) deleteObsoleteSecrets(ctx context.Context, paas *v1alpha1.Paas, existingSecrets []*corev1.Secret, desiredSecrets []*corev1.Secret) error {
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("Deleting obsolete secrets")
+	logger.Info().Msg("deleting obsolete secrets")
 
 	// Delete secrets that are no longer needed
 	for _, existingSecret := range existingSecrets {
 		if !isSecretInDesiredSecrets(existingSecret, desiredSecrets) {
 			// Secret is not in the desired state, delete it
 			if err := r.Delete(ctx, existingSecret); err != nil {
-				logger.Err(err).Str("Secret", existingSecret.Name).Msg("Failed to delete Secret")
+				logger.Err(err).Str("Secret", existingSecret.Name).Msg("failed to delete Secret")
 				return err
 			}
-			logger.Info().Str("Secret", existingSecret.Name).Msg("Deleted obsolete Secret")
+			logger.Info().Str("Secret", existingSecret.Name).Msg("deleted obsolete Secret")
 		}
 	}
 


### PR DESCRIPTION
Removes our dependency on `logr` and replaces all log statements with the Zerolog API.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #138

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm not super happy with how I've introduced the concept of "components" into our logging usage. The desire was to be able to turn debug-logging on/off per "component", so I introduced the ability to attach a component name to a logging instance and enable debug-logging based on a global filter. But since we store our logger in the request context, this implies that the scope of a "component" is dependent on the call path, which is difficult to reason about. If a group of related functions constitute a "component", then `setLogComponent()` needs to be called at the start of all entrypoints (i.e. functions called from outside the component itself), but the component will also "leak" into any downstream called components that don't themselves use `setLogComponent()`. So to keep the concept of log-able components consistent you need to carefully analyze all code paths, and update usages of `setLogComponent()` if anything changes. That doesn't seem very maintainable to me.

Perhaps we would rather have a component be defined in terms of a given file or package, but you can't update the behaviour of a logger stored in the request context based on something static like the package or file it's used from. At least, not without wrapping every call to `log.Ctx()`, which is what we were trying to get away from by using the Zerolog API directly.

In my opinion, "component"-based logging isn't super necessary and it's better to just add more logging context to distinguish log messages, instead of trying to decide beforehand which messages to turn on or off. The whole point of structured logging is to maximize flexibility for filtering after the fact, and modern logging tools make this very easy. If we want to be able to define components based on something static like package or filename, then we could just turn on [file+line based logging context](https://github.com/rs/zerolog?tab=readme-ov-file#add-file-and-line-number-to-log) and use a regex filter. When developing locally, this is as easy as teeing log output to a second terminal, and grepping for some criteria. I often do something like `make start-e2e | tee /dev/pts/2 | grep 'ERR'` to split log output to two terminals, where the second terminal displays all log output, and the first only shows errors. The same could be done for a particular filename or package.