### PR TITLE
chore(controller): set reconcileID UUID in log context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/internal/controller/main.go
+++ b/internal/controller/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/belastingdienst/opr-paas/internal/crypt"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -72,19 +73,22 @@ func getLogger(
 
 // setRequestLogger derives a context with a `zerolog` logger configured for a specific controller.
 // To be called once per reconciler. All functions within the reconciliation request context can access the logger with `log.Ctx()`.
-func setRequestLogger(ctx context.Context, obj client.Object, scheme *runtime.Scheme, req ctrl.Request) context.Context {
+func setRequestLogger(ctx context.Context, obj client.Object, scheme *runtime.Scheme, req ctrl.Request) (context.Context, *zerolog.Logger) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 	if err != nil {
 		log.Err(err).Msg("failed to retrieve controller group-version-kind")
 
-		return log.Logger.WithContext(ctx)
+		return log.Logger.WithContext(ctx), &log.Logger
 	}
 
-	return log.With().
+	logger := log.With().
 		Any("controller", gvk).
 		Any("object", req.NamespacedName).
-		Logger().
-		WithContext(ctx)
+		Str("reconcileID", uuid.NewString()).
+		Logger()
+	logger.Info().Msg("starting reconciliation")
+
+	return logger.WithContext(ctx), &logger
 }
 
 // SetComponentDebug configures which components will log debug messages regardless of global log level.

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 
-	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -124,9 +123,7 @@ func (r *PaasReconciler) GetPaas(
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	paas := &v1alpha1.Paas{ObjectMeta: metav1.ObjectMeta{Name: req.Name}}
-	ctx = setRequestLogger(ctx, paas, r.Scheme, req)
-	logger := log.Ctx(ctx)
-	logger.Info().Msg("reconciling the Paas object")
+	ctx, logger := setRequestLogger(ctx, paas, r.Scheme, req)
 
 	errResult := reconcile.Result{
 		Requeue:      true,

--- a/internal/controller/paasns_controller.go
+++ b/internal/controller/paasns_controller.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 
-	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -128,9 +127,7 @@ func (r *PaasNSReconciler) GetPaas(ctx context.Context, paasns *v1alpha1.PaasNS)
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *PaasNSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	paasns := &v1alpha1.PaasNS{ObjectMeta: metav1.ObjectMeta{Name: req.Name}}
-	ctx = setRequestLogger(ctx, paasns, r.Scheme, req)
-	logger := log.Ctx(ctx)
-	logger.Info().Msg("reconciling the PaasNs object")
+	ctx, logger := setRequestLogger(ctx, paasns, r.Scheme, req)
 
 	errResult := reconcile.Result{
 		Requeue:      true,


### PR DESCRIPTION
By assigning a unique identifier to every reconciliation process we can easily filter for all log messages pertaining to a particular reconciliation event.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): logging functionality change

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #144

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
