### PR TITLE
chore: remove required from paas.status.quota

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -305,7 +305,7 @@ func (pc *PaasCapability) SetSshSecret(key string, value string) {
 type PaasStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	Messages []string                     `json:"messages,omitempty"`
-	Quota    map[string]paas_quota.Quotas `json:"quotas"`
+	Quota    map[string]paas_quota.Quotas `json:"quotas,omitempty"`
 }
 
 func (ps *PaasStatus) Truncate() {

--- a/manifests/crds/cpet.belastingdienst.nl_paas.yaml
+++ b/manifests/crds/cpet.belastingdienst.nl_paas.yaml
@@ -153,8 +153,6 @@ spec:
                     x-kubernetes-int-or-string: true
                   type: object
                 type: object
-            required:
-            - quotas
             type: object
         type: object
     served: true


### PR DESCRIPTION
* When an error in reconciliation takes place before setting paas.status.quota, updating status throws an error as paas.status.quota is required. This shouldn't be as it is a status block.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

paas.status.quota is a required field.

Fixes: # (issue)

## What is the new behavior?

paas.status.quota is not a required field.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->