### PR TITLE
hotfix: remove less unused secrets

### DIFF
--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -172,7 +172,7 @@ func (r *PaasNSReconciler) BackendSecrets(
 }
 
 // deleteObsoleteSecrets deletes any secrets from the existingSecrets which is not listed in the desired secrets.
-func (r *PaasNSReconciler) deleteObsoleteSecrets(ctx context.Context, paas *v1alpha1.Paas, existingSecrets []*corev1.Secret, desiredSecrets []*corev1.Secret) error {
+func (r *PaasNSReconciler) deleteObsoleteSecrets(ctx context.Context, existingSecrets []*corev1.Secret, desiredSecrets []*corev1.Secret) error {
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("deleting obsolete secrets")
 
@@ -249,7 +249,7 @@ func (r *PaasNSReconciler) ReconcileSecrets(
 	if err != nil {
 		return err
 	}
-	err = r.deleteObsoleteSecrets(ctx, paas, existingSecrets, desiredSecrets)
+	err = r.deleteObsoleteSecrets(ctx, existingSecrets, desiredSecrets)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -201,35 +201,33 @@ func isSecretInDesiredSecrets(secret *corev1.Secret, desiredSecrets []*corev1.Se
 	return false
 }
 
-// getExistingPaasSecrets retrieves all secrets owned by this Paas in it's enabled namespaces
-func (r *PaasNSReconciler) getExistingPaasSecrets(ctx context.Context, paas *v1alpha1.Paas) ([]*corev1.Secret, error) {
+// getExistingSecrets retrieves all secrets owned by this Paas in it's enabled namespaces
+func (r *PaasNSReconciler) getExistingSecrets(ctx context.Context, paas *v1alpha1.Paas, paasns *v1alpha1.PaasNS) ([]*corev1.Secret, error) {
 	var existingSecrets []*corev1.Secret
 	logger := log.Ctx(ctx)
-	// Check in enabled namespaces, as secrets are to be removed when namespace is removed
-	enabledNs := paas.PrefixedAllEnabledNamespaces()
-	for ns := range enabledNs {
-		logger.Info().Msgf("listing obsolete secret in namespace: %s", ns)
-		var secrets corev1.SecretList
-		opts := []client.ListOption{
-			client.InNamespace(ns),
+	// Check in NamespaceName
+	ns := paasns.NamespaceName()
+	logger.Debug().Msgf("listing obsolete secret in namespace: %s", ns)
+	var secrets corev1.SecretList
+	opts := []client.ListOption{
+		client.InNamespace(ns),
+	}
+	err := r.List(ctx, &secrets, opts...)
+	if err != nil {
+		logger.Err(err).Msg("error listing existing secrets")
+		return []*corev1.Secret{}, err
+	}
+	logger.Debug().
+		Str("ns", ns).
+		Int("qty", len(secrets.Items)).
+		Msgf("qty of existing secrets in ns")
+	for _, secret := range secrets.Items {
+		if paas.AmIOwner(secret.OwnerReferences) && strings.HasPrefix(secret.Name, "paas-ssh") {
+			logger.Debug().Msg("existing paas-ssh secret")
+			existingSecrets = append(existingSecrets, &secret)
+			continue
 		}
-		err := r.List(ctx, &secrets, opts...)
-		if err != nil {
-			logger.Err(err).Msg("error listing existing secrets")
-			return []*corev1.Secret{}, err
-		}
-		logger.Info().
-			Str("ns", ns).
-			Int("qty", len(secrets.Items)).
-			Msgf("qty of existing secrets in ns")
-		for _, secret := range secrets.Items {
-			if paas.AmIOwner(secret.OwnerReferences) && strings.HasPrefix(secret.Name, "paas-ssh") {
-				logger.Info().Msg("existing paas-ssh secret")
-				existingSecrets = append(existingSecrets, &secret)
-				continue
-			}
-			logger.Info().Msg("no existing paas-ssh secret")
-		}
+		logger.Debug().Msg("no existing paas-ssh secret")
 	}
 	logger.Info().Int("secrets", len(existingSecrets)).Msg("qty of existing secrets")
 	return existingSecrets, nil
@@ -247,7 +245,7 @@ func (r *PaasNSReconciler) ReconcileSecrets(
 	if err != nil {
 		return err
 	}
-	existingSecrets, err := r.getExistingPaasSecrets(ctx, paas)
+	existingSecrets, err := r.getExistingSecrets(ctx, paas, paasns)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/sshsecrets_test.go
+++ b/test/e2e/sshsecrets_test.go
@@ -32,7 +32,8 @@ func TestSecrets(t *testing.T) {
 		Quota:      make(quota.Quotas),
 		SshSecrets: map[string]string{"ssh://git@scm/some-repo.git": encrypted},
 		Capabilities: api.PaasCapabilities{
-			"sso": api.PaasCapability{Enabled: true, SshSecrets: map[string]string{"ssh://git@scm/some-other-repo.git": encrypted}},
+			"sso":    api.PaasCapability{Enabled: true, SshSecrets: map[string]string{"ssh://git@scm/some-other-repo.git": encrypted}},
+			"tekton": api.PaasCapability{Enabled: true, SshSecrets: map[string]string{}},
 		},
 	}
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When multiple capabilities are enabled, the implementation of #125 removes too much secrets making the operator behaviour unstable.

## What is the new behavior?

Only the secrets in the PaasNs related namespace are listed, in that way, there is no scope beyond one namespace fixing reconciliation of secrets correctly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->