### PR TITLE
fix: Swallow unconfigured capability error

### DIFF
--- a/internal/controller/cluster_quotas.go
+++ b/internal/controller/cluster_quotas.go
@@ -236,6 +236,7 @@ func (r *PaasReconciler) ReconcileQuotas(
 	logger.Info().Msg("creating quotas for Paas")
 	// Create quotas if needed
 	if quotas, err := r.BackendEnabledQuotas(ctx, paas); err != nil {
+		paas.Status.AddMessage(v1alpha1.PaasStatusError, v1alpha1.PaasStatusCreate, paas, err.Error())
 		return err
 	} else {
 		for _, q := range quotas {

--- a/internal/controller/cluster_quotas.go
+++ b/internal/controller/cluster_quotas.go
@@ -233,10 +233,10 @@ func (r *PaasReconciler) ReconcileQuotas(
 ) (err error) {
 	ctx = setLogComponent(ctx, "quota")
 	logger := log.Ctx(ctx)
-	logger.Info().Msg("creating quotas for PAAS object ")
+	logger.Info().Msg("creating quotas for Paas")
 	// Create quotas if needed
 	if quotas, err := r.BackendEnabledQuotas(ctx, paas); err != nil {
-		logger.Err(err).Msg("failure while getting list of quotas")
+		return err
 	} else {
 		for _, q := range quotas {
 			logger.Info().Msg("creating quota " + q.Name + " for PAAS object ")


### PR DESCRIPTION


<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When an unconfigured capability is requested, the code defining quotas throws an error. However, this error is swallowed. This A. does not trigger reconciliation again. and B. nothing is shown in paas.status.messages about the error.

Fixes: # (issue)

## What is the new behavior?

* Pass error back to reconciler when an unconfigured capability is requested.
* Add status message with the error

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->