### PR TITLE
test(e2e): define tests for capability rolebindings

### DIFF
--- a/docs/development-guide/e2e-test-details.md
+++ b/docs/development-guide/e2e-test-details.md
@@ -227,37 +227,58 @@ What we test: creating a `Paas` with the `ArgoCD` capability enabled.
 
 Scenarios:
 
-1. A minimal `Paas` with ArgoCD capability enabled.<br/><br/>
-   **Given** a minimal `Paas` and `ArgoCD` capability configuration,<br/>
-   **when** the minimal `Paas` is created with the `ArgoCD` capability enabled,<br/>
-   **then** the list entry in the applicationset should have been created,<br/>
-   **and** a namespace with the name `paasname-argocd` should have been created,<br/>
-   **and** an ArgoCD Application should have been created in namespaces,<br/>
-   **and** a quota with the name `paasname-argocd` should have been created,<br/>
-   **and** the ArgoCD Application and quota conform to the points below.
+1.  A minimal `Paas` with ArgoCD capability enabled.<br/><br/>
+    **Given** a minimal `Paas` and `ArgoCD` capability configuration,<br/>
+    **when** the minimal `Paas` is created with the `ArgoCD` capability enabled,<br/>
+    **then** the list entry in the applicationset should have been created,<br/>
+    **and** a namespace with the name `paasname-argocd` should have been created,<br/>
+    **and** an ArgoCD Application should have been created in namespaces,<br/>
+    **and** a quota with the name `paasname-argocd` should have been created,<br/>
+    **and** the ArgoCD Application and quota conform to the points below.
 
-   ArgoCD Application points:
+    ArgoCD Application points:
 
-   1. Assess gitUrl, path etc. exist in spec;
-   2. Assess RBAC .. determine how;
-   3. Assess Secrets exist in namespace and in argo...?
-   4. Assess Exclude appset is included in spec as ignoreDiff;
+        Quota points:
+          1. Assess a quota with the name `paasnaam-argocd` was created;
+          2. Assess that the `quota_label` label was used as selector on the quota;
+          3. Assess that the quota selector was set in such a manner so that only the `paasnaam-sso` namespace is selected;
+          4. Assess that the size of the quota equals the size of the default quota specified in the paas_config;
 
-   Quota points:
+    1. Assess gitUrl, path etc. exist in spec;
+    2. Assess RBAC .. determine how;
+    3. Assess Secrets exist in namespace and in argo...?
+    4. Assess Exclude appset is included in spec as ignoreDiff;
 
-   1. Assess a quota with the name `paasnaam-argocd` was created;
-   2. Assess that the `quota_label` label was used as selector on the quota;
-   3. Assess that the quota selector was set in such a manner so that only the `paasnaam-sso` namespace is selected;
-   4. Assess that the size of the quota equals the size of the default quota specified in the paas_config;
+    Quota points:
 
-   !!! Note
-   TODO Assess default_permissions; 1. Rolebindings to service account etc. (TODO: can these RBs be created without the existence of a ServiceAccount?)
+    1. Assess a quota with the name `paasnaam-argocd` was created;
+    2. Assess that the `quota_label` label was used as selector on the quota;
+    3. Assess that the quota selector was set in such a manner so that only the `paasnaam-argocd` namespace is selected;
+    4. Assess that the size of the quota equals the size of the default quota specified in the paas_config;
+
+    Default_permissions points:
+
+    1. Assess that a rolebinding for `monitoring-edit` is created
+    2. Assess that the `monitoring-edit` rolebinding contains the `argo-service-applicationset-controller` service account
+    3. Assess that the `monitoring-edit` rolebinding contains the `argo-service-argocd-application-controller` service account
 
 Post scenarios: reset environment to clean slate.
 
 ### Capability Tekton
 
-Check Quota
+Quota points:
+
+1.  Assess a quota with the name `paasnaam-tekton` was created;
+2.  Assess that the `quota_label` label was used as selector on the quota;
+3.  Assess that the quota selector was set in such a manner so that only the `paasnaam-tekton` namespace is selected;
+4.  Assess that the size of the quota equals the size of the default quota specified in the paas_config;
+
+Default_permissions points:
+
+1.  Assess that a rolebinding for `monitoring-edit` is created
+2.  Assess that the `monitoring-edit` rolebinding contains the `tekton` service account
+3.  Assess that a rolebinding for `alert-routing-edit` is created
+4.  Assess that the `alert-routing-edit` rolebinding contains the `tekton` service account
 
 ### Capability Grafana
 
@@ -300,4 +321,3 @@ Scenarios:
 
 1. Add config for a new cap4 and check that it works as expecten when included in a Paas
 2. Add cap5 in a Paas and check that it does not work when not yet defined in config
-

--- a/docs/development-guide/e2e-test-details.md
+++ b/docs/development-guide/e2e-test-details.md
@@ -238,12 +238,6 @@ Scenarios:
 
     ArgoCD Application points:
 
-        Quota points:
-          1. Assess a quota with the name `paasnaam-argocd` was created;
-          2. Assess that the `quota_label` label was used as selector on the quota;
-          3. Assess that the quota selector was set in such a manner so that only the `paasnaam-sso` namespace is selected;
-          4. Assess that the size of the quota equals the size of the default quota specified in the paas_config;
-
     1. Assess gitUrl, path etc. exist in spec;
     2. Assess RBAC .. determine how;
     3. Assess Secrets exist in namespace and in argo...?

--- a/manifests/config/cm_opr-paas.yaml
+++ b/manifests/config/cm_opr-paas.yaml
@@ -27,11 +27,13 @@ data:
             requests.storage: "0"
             thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
         extra_permissions:
-          roles:
+          argo-service-argocd-application-controller:
+            - admin
+        default_permissions:
+          argo-service-argocd-application-controller:
             - monitoring-edit
-          serviceaccounts:
-            - argo-service-applicationset-controller
-            - argo-service-argocd-application-controller
+          argo-service-applicationset-controller:
+            - monitoring-edit
       tekton:
         applicationset: tektonas
         quotas:
@@ -51,11 +53,12 @@ data:
             requests.storage: "100Gi"
             thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
         extra_permissions:
-          roles:
-            - monitoring-edit
+          pipeline:
+            - admin
+        default_permissions:
+          pipeline:
+            - view
             - alert-routing-edit
-          serviceaccounts:
-            - pipeline
       sso:
         applicationset: ssoas
         quotas:

--- a/test/e2e/capability-tekton_test.go
+++ b/test/e2e/capability-tekton_test.go
@@ -1,0 +1,140 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/quota"
+	argo "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
+
+	quotav1 "github.com/openshift/api/quota/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	paasWithCapabilityTekton = "tpaas"
+	paasTektonNs             = "tpaas-tekton"
+	paasTektonCRQ            = "paas-tekton"
+	TektonApplicationSet     = "tektonas"
+	asTektonNamespace        = "asns"
+)
+
+func TestCapabilityTekton(t *testing.T) {
+	paasSpec := api.PaasSpec{
+		Requestor: "paas-user",
+		Quota:     make(quota.Quotas),
+		Capabilities: api.PaasCapabilities{
+			"tekton": api.PaasCapability{
+				Enabled:          true,
+				ExtraPermissions: false,
+			},
+		},
+	}
+
+	testenv.Test(
+		t,
+		features.New("Capability Tekton").
+			Setup(createPaasFn(paasWithCapabilityTekton, paasSpec)).
+			Assess("is created", assertCapTektonCreated).
+			Assess("is deleted when PaaS is deleted", assertCapTektonDeleted).
+			Assess("has ClusterRoleBindings", assertTektonCRB).
+			Teardown(teardownPaasFn(paasWithCapabilityTekton)).
+			Feature(),
+	)
+}
+
+func assertCapTektonCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	paas := getPaas(ctx, paasWithCapabilityTekton, t, cfg)
+	namespace := getOrFail(ctx, paasWithCapabilityTekton, cfg.Namespace(), &corev1.Namespace{}, t, cfg)
+	applicationSet := getOrFail(ctx, TektonApplicationSet, asTektonNamespace, &argo.ApplicationSet{}, t, cfg)
+	TektonQuota := getOrFail(ctx, paasTektonCRQ, cfg.Namespace(), &quotav1.ClusterResourceQuota{}, t, cfg)
+
+	// ClusterResource is created with the same name as the PaaS
+	assert.Equal(t, paasWithCapabilityTekton, paas.Name)
+
+	// Paas Namespace exist
+	assert.Equal(t, paasWithCapabilityTekton, namespace.Name)
+
+	// Tekton should be enabled
+	assert.True(t, paas.Spec.Capabilities.IsCap("tekton"))
+
+	// ApplicationSet exist
+	assert.NotEmpty(t, applicationSet)
+
+	applicationSetListEntries, appSetListEntriesError := getApplicationSetListEntries(applicationSet)
+
+	// List entries should not be empty
+	require.NoError(t, appSetListEntriesError)
+	assert.Len(t, applicationSetListEntries, 1)
+
+	// At least one JSON object should have "paas": "paasnaam"
+	assert.Equal(t, paasWithCapabilityTekton, applicationSetListEntries[0]["paas"])
+
+	// Check whether the LabelSelector is specific to the paasnaam-Tekton namespace
+	labelSelector := TektonQuota.Spec.Selector.LabelSelector
+	assert.True(t, MatchLabelExists(labelSelector.MatchLabels, "q.lbl", paasTektonCRQ))
+	assert.False(t, MatchLabelExists(labelSelector.MatchLabels, "q.lbl", "wrong-value"))
+	assert.False(t, MatchLabelExists(labelSelector.MatchLabels, "nonexistent.lbl", paasTektonNs))
+
+	// Quota namespace name
+	assert.Equal(t, paasTektonCRQ, TektonQuota.Name)
+
+	return ctx
+}
+
+func assertCapTektonDeleted(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	deletePaasSync(ctx, paasWithCapabilityTekton, t, cfg)
+
+	// Quota is deleted
+	var quotaList quotav1.ClusterResourceQuotaList
+	if err := cfg.Client().Resources().List(ctx, &quotaList); err != nil {
+		t.Fatalf("Failed to retrieve Quota list: %v", err)
+	}
+
+	// Quota list not contains paas
+	assert.NotContains(t, quotaList.Items, paasTektonNs)
+
+	// Namespace is deleted
+	var namespaceList corev1.NamespaceList
+	if err := cfg.Client().Resources().List(ctx, &namespaceList); err != nil {
+		t.Fatalf("Failed to retrieve Namespace list: %v", err)
+	}
+
+	// Namespace list not contains paas
+	assert.NotContains(t, namespaceList.Items, paasWithCapabilityTekton)
+
+	// ApplicationSet is deleted
+	applicationSet := getOrFail(ctx, TektonApplicationSet, asTektonNamespace, &argo.ApplicationSet{}, t, cfg)
+	applicationSetListEntries, appSetListEntriesError := getApplicationSetListEntries(applicationSet)
+
+	// List Entries should be empty
+	require.NoError(t, appSetListEntriesError)
+	assert.Empty(t, applicationSetListEntries)
+
+	return ctx
+}
+
+/*
+1.  Assess that a rolebinding for `monitoring-edit` is created
+2.  Assess that the `monitoring-edit` rolebinding contains the `tekton` service account
+3.  Assess that a rolebinding for `alert-routing-edit` is created
+4.  Assess that the `alert-routing-edit` rolebinding contains the `tekton` service account
+*/
+func assertTektonCRB(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	for _, crbName := range []string{"paas-view", "paas-alert-routing-edit"} {
+		argo_role_binding := getOrFail(ctx, crbName, paasTektonNs, &rbac.ClusterRoleBinding{}, t, cfg)
+		subjects := argo_role_binding.Subjects
+		assert.Len(t, subjects, 1, "ClusterRoleBinding %s contains one subject", crbName)
+		subject := subjects[0]
+		assert.Equal(t, "ServiceAccount", subject.Kind, "Subject is of type ServiceAccount")
+		assert.Equal(t, paasTektonNs, subject.Namespace, "Subject is of type ServiceAccount")
+		assert.Equal(t, "pipeline", subject.Name, "Subject name is tekton")
+	}
+	return ctx
+}

--- a/test/e2e/fixtures/paas_config.yml
+++ b/test/e2e/fixtures/paas_config.yml
@@ -13,13 +13,18 @@ capabilities:
     quotas:
       clusterwide: false
       defaults:
-        limits.cpu: "5"
+        limits.cpu: '5'
         limits.memory: 4Gi
-        requests.cpu: "1"
+        requests.cpu: '1'
         requests.memory: 1Gi
-        requests.storage: "0"
-        thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
+        requests.storage: '0'
+        thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
     extra_permissions:
+      roles:
+        - admin
+      serviceaccounts:
+        - argo-service-argocd-application-controller
+    default_permissions:
       roles:
         - monitoring-edit
       serviceaccounts:
@@ -30,22 +35,27 @@ capabilities:
     quotas:
       clusterwide: true
       min:
-        limits.cpu: "5"
+        limits.cpu: '5'
         limits.memory: 4Gi
       max:
-        requests.cpu: "1"
+        requests.cpu: '1'
         requests.memory: 1Gi
       ratio: 0.1
       defaults:
-        limits.cpu: "5"
+        limits.cpu: '5'
         limits.memory: 8Gi
-        requests.cpu: "1"
+        requests.cpu: '1'
         requests.memory: 2Gi
-        requests.storage: "100Gi"
-        thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
+        requests.storage: '100Gi'
+        thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
     extra_permissions:
       roles:
-        - monitoring-edit
+        - admin
+      serviceaccounts:
+        - pipeline
+    default_permissions:
+      roles:
+        - view
         - alert-routing-edit
       serviceaccounts:
         - pipeline
@@ -53,22 +63,22 @@ capabilities:
     applicationset: ssoas
     quotas:
       defaults:
-        limits.cpu: "1"
+        limits.cpu: '1'
         limits.memory: 512Mi
-        requests.cpu: "100m"
+        requests.cpu: '100m'
         requests.memory: 128Mi
-        requests.storage: "0"
-        thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
+        requests.storage: '0'
+        thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
   grafana:
     applicationset: grafanaas
     quotas:
       defaults:
-        limits.cpu: "2"
+        limits.cpu: '2'
         limits.memory: 2Gi
-        requests.cpu: "500m"
+        requests.cpu: '500m'
         requests.memory: 512Mi
-        requests.storage: "2Gi"
-        thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
+        requests.storage: '2Gi'
+        thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
 debug: false
 decryptKeyPaths:
   - /tmp/paas-e2e/secrets/priv

--- a/test/e2e/fixtures/paas_config.yml
+++ b/test/e2e/fixtures/paas_config.yml
@@ -20,16 +20,13 @@ capabilities:
         requests.storage: '0'
         thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
     extra_permissions:
-      roles:
+      argo-service-argocd-application-controller:
         - admin
-      serviceaccounts:
-        - argo-service-argocd-application-controller
     default_permissions:
-      roles:
+      argo-service-argocd-application-controller:
         - monitoring-edit
-      serviceaccounts:
-        - argo-service-applicationset-controller
-        - argo-service-argocd-application-controller
+      argo-service-applicationset-controller:
+        - monitoring-edit
   tekton:
     applicationset: tektonas
     quotas:
@@ -49,16 +46,12 @@ capabilities:
         requests.storage: '100Gi'
         thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
     extra_permissions:
-      roles:
+      pipeline:
         - admin
-      serviceaccounts:
-        - pipeline
     default_permissions:
-      roles:
+      pipeline:
         - view
         - alert-routing-edit
-      serviceaccounts:
-        - pipeline
   sso:
     applicationset: ssoas
     quotas:


### PR DESCRIPTION
Defines a new end-to-end test for the Tekton capability, to ensure the correct namespace/labels/quota are configured, and amends the ArgoCD capablity test to add assertions for `ClusterRoleBindings`. The Tekton test has the `ExtraPermissions` flag turned off in the Paas, while the ArgoCD test has it enabled. Both capabilities have extra rolebindings configured in the fixtured operator config, so this way we're able to test that 1. the extra permissions rolebindings are added when present, and 2. the boolean `ExtraPermissions` flag in a Paas works as expected.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [x] Other (please describe): new end-to-end tests


## Does this introduce a breaking change?

- [ ] Yes
- [x] No
