### PR TITLE
chore: Cleanup after implementing configurable capabilities

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -248,18 +248,20 @@ func (pcs PaasCapabilities) ResetCapSshSecret(capability string) (err error) {
 	return nil
 }
 
+// TODO: Enabled is a leftover from old capability implementation. Remove with new API.
+
 type PaasCapability struct {
-	// Do we want an ArgoCD namespace, default false
+	// Do we want to use this capability, default false
 	Enabled bool `json:"enabled,omitempty"`
-	// The URL that contains the Applications / Application Sets to be used by this ArgoCD
+	// The URL that contains the Applications / Application Sets to be used by this capability
 	GitUrl string `json:"gitUrl,omitempty"`
-	// The revision of the git repo that contains the Applications / Application Sets to be used by this ArgoCD
+	// The revision of the git repo that contains the Applications / Application Sets to be used by this capability
 	GitRevision string `json:"gitRevision,omitempty"`
-	// the path in the git repo that contains the Applications / Application Sets to be used by this ArgoCD
+	// the path in the git repo that contains the Applications / Application Sets to be used by this capability
 	GitPath string `json:"gitPath,omitempty"`
 	// This project has it's own ClusterResourceQuota settings
 	Quota paas_quota.Quotas `json:"quota,omitempty"`
-	// You can add ssh keys (which is a type of secret) for ArgoCD to use for access to bitBucket
+	// You can add ssh keys (which is a type of secret) for capability to use for access to bitBucket
 	// They must be encrypted with the public key corresponding to the private key deployed together with the PaaS operator
 	SshSecrets map[string]string `json:"sshSecrets,omitempty"`
 	// You can enable extra permissions for the service accounts beloning to this capability
@@ -274,10 +276,6 @@ func (pc *PaasCapability) WithExtraPermissions() bool {
 
 func (pc *PaasCapability) IsEnabled() bool {
 	return pc.Enabled
-}
-
-func (pc *PaasCapability) CapabilityName() string {
-	return "argocd"
 }
 
 func (pc *PaasCapability) SetDefaults() {

--- a/cmd/crypttool/check_paas.go
+++ b/cmd/crypttool/check_paas.go
@@ -46,7 +46,7 @@ func checkPaasFiles(privateKeyFiles string, files []string) error {
 		}
 
 		for capName, cap := range paas.Spec.Capabilities {
-			logrus.Debugf("cap name: %s", cap.CapabilityName())
+			logrus.Debugf("cap name: %s", capName)
 			for key, secret := range cap.GetSshSecrets() {
 				if decrypted, err := srcCrypt.Decrypt(secret); err != nil {
 					logrus.Errorf("%s: { .spec.capabilities[%s].sshSecrets[%s] } > { error: %e }", fileName, capName, key, err)
@@ -85,7 +85,7 @@ func CheckPaas(crypt *crypt.Crypt, paas *v1alpha1.Paas, fileName string) error {
 	}
 
 	for capName, capability := range paas.Spec.Capabilities {
-		logrus.Debugf("capability name: %s", capability.CapabilityName())
+		logrus.Debugf("capability name: %s", capName)
 		for key, secret := range capability.GetSshSecrets() {
 			decrypted, err := crypt.Decrypt(secret)
 			if err != nil {

--- a/cmd/webservice/check_paas.go
+++ b/cmd/webservice/check_paas.go
@@ -35,7 +35,7 @@ func CheckPaas(crypt *crypt.Crypt, paas *v1alpha1.Paas) error {
 	}
 
 	for capName, capability := range paas.Spec.Capabilities {
-		logrus.Debugf("capability name: %s", capability.CapabilityName())
+		logrus.Debugf("capability name: %s", capName)
 		for key, secret := range capability.GetSshSecrets() {
 			decrypted, err := crypt.Decrypt(secret)
 			if err != nil {

--- a/manifests/crds/cpet.belastingdienst.nl_paas.yaml
+++ b/manifests/crds/cpet.belastingdienst.nl_paas.yaml
@@ -43,7 +43,7 @@ spec:
                 additionalProperties:
                   properties:
                     enabled:
-                      description: Do we want an ArgoCD namespace, default false
+                      description: Do we want to use this capability, default false
                       type: boolean
                     extra_permissions:
                       description: |-
@@ -53,15 +53,15 @@ spec:
                       type: boolean
                     gitPath:
                       description: the path in the git repo that contains the Applications
-                        / Application Sets to be used by this ArgoCD
+                        / Application Sets to be used by this capability
                       type: string
                     gitRevision:
                       description: The revision of the git repo that contains the
-                        Applications / Application Sets to be used by this ArgoCD
+                        Applications / Application Sets to be used by this capability
                       type: string
                     gitUrl:
                       description: The URL that contains the Applications / Application
-                        Sets to be used by this ArgoCD
+                        Sets to be used by this capability
                       type: string
                     quota:
                       additionalProperties:
@@ -77,7 +77,7 @@ spec:
                       additionalProperties:
                         type: string
                       description: |-
-                        You can add ssh keys (which is a type of secret) for ArgoCD to use for access to bitBucket
+                        You can add ssh keys (which is a type of secret) for capability to use for access to bitBucket
                         They must be encrypted with the public key corresponding to the private key deployed together with the PaaS operator
                       type: object
                   type: object


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There is some leftovers of direct links to ArgoCD, which should now point to capabilities generically.
And I added a TODO for deprecation of a field when increasing API version.

## What is the new behavior?

- dead code is removed
- all ArgoCD specific stuff points to generic capability stuff
- a TODO item is added for deprecation of API fields

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

