### PR TITLE
refactor(e2e): generalize wait-for-status utility

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -385,6 +385,10 @@ func (p Paas) WithoutMe(references []metav1.OwnerReference) (withoutMe []metav1.
 	return withoutMe
 }
 
+func (p Paas) GetConditions() []metav1.Condition {
+	return p.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // PaasList contains a list of Paas

--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -42,6 +42,10 @@ type PaasConfig struct {
 	Status PaasConfigStatus `json:"status,omitempty"`
 }
 
+func (p PaasConfig) GetConditions() []metav1.Condition {
+	return p.Status.Conditions
+}
+
 type PaasConfigSpec struct {
 	// Deprecated: Will be replaced by a secretRef to overcome caching
 	// Paths where the manager can find the decryptKeys to decrypt Paas'es

--- a/api/v1alpha1/paasns_types.go
+++ b/api/v1alpha1/paasns_types.go
@@ -80,6 +80,10 @@ func (p PaasNS) AmIOwner(references []metav1.OwnerReference) bool {
 	return false
 }
 
+func (p PaasNS) GetConditions() []metav1.Condition {
+	return p.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // PaasNSList contains a list of PaasNS

--- a/test/e2e/paas.go
+++ b/test/e2e/paas.go
@@ -4,16 +4,12 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/api/meta"
 
 	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/e2e-framework/klient/k8s"
-	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
@@ -24,21 +20,16 @@ func getPaas(ctx context.Context, name string, t *testing.T, cfg *envconf.Config
 
 // createPaasSync requests Paas creation and returns once it has reconciled.
 func createPaasSync(ctx context.Context, cfg *envconf.Config, paas *api.Paas) error {
-	if err := cfg.Client().Resources().Create(ctx, paas); err != nil {
-		return fmt.Errorf("failed to create Paas %s: %w", paas.GetName(), err)
-	}
-
-	return waitForPaasReconciliation(ctx, cfg, paas, 0)
+	return createSyncStatus(ctx, cfg, paas, func(conds []metav1.Condition) bool {
+		return meta.IsStatusConditionTrue(conds, api.TypeReadyPaas)
+	})
 }
 
 // updatePaasSync requests an update to a Paas and returns once the Paas reports successful reconciliation.
 func updatePaasSync(ctx context.Context, cfg *envconf.Config, paas *api.Paas) error {
-	oldGeneration := paas.Generation
-	if err := cfg.Client().Resources().Update(ctx, paas); err != nil {
-		return fmt.Errorf("failed to update Paas %s: %w", paas.GetName(), err)
-	}
-
-	return waitForPaasReconciliation(ctx, cfg, paas, oldGeneration)
+	return updateSyncStatus(ctx, cfg, paas, func(conds []metav1.Condition) bool {
+		return meta.IsStatusConditionTrue(conds, api.TypeReadyPaas)
+	})
 }
 
 // deletePaasSync deletes the Paas with the associated name.
@@ -48,28 +39,4 @@ func deletePaasSync(ctx context.Context, name string, t *testing.T, cfg *envconf
 	if err := deleteResourceSync(ctx, cfg, paas); err != nil {
 		t.Fatal(err)
 	}
-}
-
-// waitForPaasReconciliation polls a Paas resource, blocking until the Paas status reports successful reconciliation.
-func waitForPaasReconciliation(ctx context.Context, cfg *envconf.Config, paas *api.Paas, oldGeneration int64) error {
-	waitCond := conditions.New(cfg.Client().Resources()).
-		ResourceMatch(paas, func(object k8s.Object) bool {
-			conditionsMet := meta.IsStatusConditionPresentAndEqual(object.(*api.Paas).Status.Conditions, api.TypeReadyPaas, metav1.ConditionTrue)
-			if conditionsMet {
-				foundCondition := meta.FindStatusCondition(object.(*api.Paas).Status.Conditions, api.TypeReadyPaas)
-				versionMet := object.(*api.Paas).Generation != oldGeneration && object.(*api.Paas).Generation == foundCondition.ObservedGeneration
-				return conditionsMet && versionMet
-			}
-			return false
-		})
-
-	if err := waitForDefaultOpts(ctx, waitCond); err != nil {
-		err = cfg.Client().Resources().Get(ctx, paas.GetName(), paas.Namespace, paas)
-		if err != nil {
-			return fmt.Errorf("could not get paas resource which was waited for: %w", err)
-		}
-		return fmt.Errorf("failed waiting for Paas %s to be reconciled: %w and has status block: %v", paas.GetName(), err, paas.Status)
-	}
-
-	return nil
 }

--- a/test/e2e/paasns.go
+++ b/test/e2e/paasns.go
@@ -2,36 +2,17 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 
 	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/e2e-framework/klient/k8s"
-	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
 // waitForPaasNSReconciliation polls a PaasNs resource, blocking until the Conditions report successful reconciliation.
 func waitForPaasNSReconciliation(ctx context.Context, cfg *envconf.Config, paasns *api.PaasNS, oldGeneration int64) error {
-	waitCond := conditions.New(cfg.Client().Resources()).
-		ResourceMatch(paasns, func(object k8s.Object) bool {
-			conditionsMet := meta.IsStatusConditionPresentAndEqual(object.(*api.PaasNS).Status.Conditions, api.TypeReadyPaasNs, metav1.ConditionTrue)
-			if conditionsMet {
-				foundCondition := meta.FindStatusCondition(object.(*api.PaasNS).Status.Conditions, api.TypeReadyPaasNs)
-				versionMet := object.(*api.PaasNS).Generation != oldGeneration && object.(*api.PaasNS).Generation == foundCondition.ObservedGeneration
-				return conditionsMet && versionMet
-			}
-			return false
-		})
-
-	if err := waitForDefaultOpts(ctx, waitCond); err != nil {
-		err = cfg.Client().Resources().Get(ctx, paasns.GetName(), paasns.Namespace, paasns)
-		if err != nil {
-			return fmt.Errorf("could not get paasns resource which is waited for: %w", err)
-		}
-		return fmt.Errorf("failed waiting for PaasNS %s to be reconciled: %w and has status block: %v", paasns.GetName(), err, paasns.Status)
-	}
-
-	return nil
+	return waitForStatus(ctx, cfg, paasns, oldGeneration, func(conds []metav1.Condition) bool {
+		return meta.IsStatusConditionTrue(conds, api.TypeReadyPaasNs)
+	})
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -9,6 +9,7 @@ import (
 
 	argo "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachinerywait "k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -81,4 +82,62 @@ func getApplicationSetListEntries(applicationSet *argo.ApplicationSet) ([]map[st
 	}
 
 	return entries, nil
+}
+
+// This is a workaround to match our custom resource types; all our types have the same `.Status.Conditions` fields, but
+// Go generics do not currently allow accessing shared struct fields via generic types. This is apparently a feature
+// slated for Go 2. (https://github.com/golang/go/issues/48522#issuecomment-924380147)
+type withStatus interface {
+	GetConditions() []metav1.Condition
+}
+
+// waitForStatus accepts a k8s object with a `.status.conditions` block, and waits until the resource has been updated and status
+// conditions have been matched as per the passed function. Only conditions matching the current generation of the resource are
+// passed to the match function. `oldGeneration` must contain the generation of the resource prior to its requested update. The
+// `generation` of a resource only updates on changes to its spec. For new resources, use 0.
+func waitForStatus(ctx context.Context, cfg *envconf.Config, obj k8s.Object, oldGeneration int64, match func(conds []metav1.Condition) bool) error {
+	var fetched k8s.Object
+	waitCond := conditions.New(cfg.Client().Resources()).
+		ResourceMatch(obj, func(object k8s.Object) bool {
+			fetched = object
+
+			currentGen := object.GetGeneration()
+			if currentGen <= oldGeneration {
+				return false
+			}
+
+			// Filter out all non-current status conditions
+			conds := make([]metav1.Condition, 0)
+			for _, c := range object.(withStatus).GetConditions() {
+				if currentGen == c.ObservedGeneration {
+					conds = append(conds, c)
+				}
+			}
+
+			return match(conds)
+		})
+
+	if err := waitForDefaultOpts(ctx, waitCond); err != nil {
+		return fmt.Errorf("failed waiting for %s to be reconciled: %w and has status block: %v", fetched.GetName(), err, fetched.(withStatus).GetConditions())
+	}
+
+	return nil
+}
+
+func updateSyncStatus(ctx context.Context, cfg *envconf.Config, obj k8s.Object, match func(conds []metav1.Condition) bool) error {
+	gen := obj.GetGeneration()
+
+	if err := cfg.Client().Resources().Update(ctx, obj); err != nil {
+		return fmt.Errorf("failed to update %s: %w", obj.GetName(), err)
+	}
+
+	return waitForStatus(ctx, cfg, obj, gen, match)
+}
+
+func createSyncStatus(ctx context.Context, cfg *envconf.Config, obj k8s.Object, match func(conds []metav1.Condition) bool) error {
+	if err := cfg.Client().Resources().Create(ctx, obj); err != nil {
+		return fmt.Errorf("failed to create %s: %w", obj.GetName(), err)
+	}
+
+	return waitForStatus(ctx, cfg, obj, 0, match)
 }


### PR DESCRIPTION
With #192 coming down the pipe and new tests needed for PaasConfig I saw some opportunity to generalize our update-and-wait-for-resource-status logic. Let me know if this looks like a good idea.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

