### PR TITLE
test(e2e): paas cannot be reconciled without config

### DIFF
--- a/test/e2e/paasconfig_test.go
+++ b/test/e2e/paasconfig_test.go
@@ -6,14 +6,13 @@ import (
 
 	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
 	v1alpha1 "github.com/belastingdienst/opr-paas/api/v1alpha1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/belastingdienst/opr-paas/internal/quota"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/e2e-framework/klient/k8s"
-	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
@@ -37,23 +36,9 @@ func TestPaasConfig(t *testing.T) {
 				return ctx
 			}).
 			Assess("Operator reports error when no PaasConfig is loaded", assertOperatorErrorWithoutPaasConfig).
+			Assess("Paas reconciliation resumes once PaasConfig is loaded", assertPaasReconciliationResumed).
 			Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				// Recreate the PaasConfig resource for other tests
-				paasconfig := &v1alpha1.PaasConfig{}
-				*paasconfig = examplePaasConfig
-
-				err := cfg.Client().Resources().Create(ctx, paasconfig)
-				if err != nil && !apierrors.IsAlreadyExists(err) {
-					t.Fatalf("Failed to recreate PaasConfig: %v", err)
-				}
-
-				waitUntilPaasConfigExists := conditions.New(cfg.Client().Resources()).ResourceMatch(paasconfig, func(obj k8s.Object) bool {
-					return obj.(*api.PaasConfig).Name == paasconfig.Name
-				})
-
-				if err := waitForDefaultOpts(ctx, waitUntilPaasConfigExists); err != nil {
-					t.Fatalf("Failed to recreate PaasConfig: %v", err)
-				}
+				deletePaasSync(ctx, "foo", t, cfg)
 
 				return ctx
 			}).
@@ -139,7 +124,37 @@ func assertOperatorErrorWithoutPaasConfig(ctx context.Context, t *testing.T, cfg
 
 	require.True(t, apierrors.IsNotFound(err))
 
-	// Verify operator behavior when no PaasConfig exists?
+	paas := &api.Paas{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+		Spec: api.PaasSpec{
+			Requestor: "paas-user",
+			Quota:     make(quota.Quota),
+		},
+	}
+
+	require.NoError(t, cfg.Client().Resources().Create(ctx, paas))
+	require.NoError(
+		t,
+		waitForStatus(ctx, cfg, paas, 0, func(conds []metav1.Condition) bool {
+			cond := meta.FindStatusCondition(conds, api.TypeHasErrorsPaas)
+			return cond != nil &&
+				cond.Status == metav1.ConditionTrue &&
+				cond.Message == "please reach out to your system administrator as there is no Paasconfig available to reconcile against."
+		}),
+	)
+
+	return ctx
+}
+
+func assertPaasReconciliationResumed(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	paasConfig := examplePaasConfig.DeepCopy()
+	require.NoError(t, createSync(ctx, cfg, paasConfig, api.TypeActivePaasConfig))
+
+	paas := getPaas(ctx, "foo", t, cfg)
+	// Because the spec is not being changed between the failed and resumed reconciliation, the generation of the Paas resource is
+	// not incremented. Thus we pass the initial generation (i.e. 0), as `waitForCondition` waits to observe a generation change
+	// before matching the condition.
+	require.NoError(t, waitForCondition(ctx, cfg, paas, 0, api.TypeReadyPaas))
 
 	return ctx
 }

--- a/test/e2e/paasconfig_test.go
+++ b/test/e2e/paasconfig_test.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
+const paasConfigDuplicateName = "paas-config-2"
+
 func TestPaasConfig(t *testing.T) {
 	testenv.Test(
 		t,
@@ -47,6 +49,15 @@ func TestPaasConfig(t *testing.T) {
 			Assess("PaasConfig is Active", assertPaasConfigIsActive).
 			Assess("PaasConfig is Updated", assertPaasConfigIsUpdated).
 			Assess("PaasConfig Invalid Spec", assertPaasConfigInvalidSpec).
+			Assess("Operator reports error when a second PaasConfig is loaded", assertDoublePaasConfigError).
+			Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				secondPaasConfig := &v1alpha1.PaasConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: paasConfigDuplicateName},
+				}
+				require.NoError(t, deleteResourceSync(ctx, cfg, secondPaasConfig))
+
+				return ctx
+			}).
 			Feature(),
 	)
 }
@@ -113,6 +124,24 @@ func assertPaasConfigInvalidSpec(ctx context.Context, t *testing.T, cfg *envconf
 	err = cfg.Client().Resources().Get(ctx, "invalid-paas-config", "", &paasConfig)
 	require.Error(t, err, "Expected error when getting invalid PaasConfig")
 	require.True(t, apierrors.IsNotFound(err), "Expected NotFound error, got: %v", err)
+
+	return ctx
+}
+
+func assertDoublePaasConfigError(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	paasConfig := examplePaasConfig.DeepCopy()
+	paasConfig.Name = paasConfigDuplicateName
+
+	require.NoError(t, cfg.Client().Resources().Create(ctx, paasConfig))
+	require.NoError(
+		t,
+		waitForStatus(ctx, cfg, paasConfig, 0, func(conds []metav1.Condition) bool {
+			cond := meta.FindStatusCondition(conds, api.TypeHasErrorsPaasConfig)
+			return cond != nil &&
+				cond.Status == metav1.ConditionTrue &&
+				cond.Message == "paasConfig singleton violation"
+		}),
+	)
 
 	return ctx
 }


### PR DESCRIPTION
Adds a scenario to the PaasConfig e2e test to ensure that reconciliation for a new Paas fails when no PaasConfig is loaded, but is resumed and successfully reconciled when/if a PaasConfig is loaded at a later time. Also tests the singleton pattern for PaasConfig; creation of a second PaasConfig resource results in error.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): New test scenario


Relates to: #200 

This PR covers the first 3 test scenarios as outlined in #200.