### PR TITLE
chore: Simplify paasconfig predicate

### DIFF
--- a/internal/controller/paasconfig_controller.go
+++ b/internal/controller/paasconfig_controller.go
@@ -53,10 +53,8 @@ func (r *PaasConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.PaasConfig{}).
 		WithEventFilter(
-			predicate.Or(
-				predicate.GenerationChangedPredicate{}, // Spec changed
-				// TODO add custom predicate funcs for more finegrained reconciliation?
-			)).
+			predicate.GenerationChangedPredicate{}, // Spec changed .
+		).
 		Complete(r)
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The PaasConfig setupWithManager code uses the: `or` predicate, but there is only one predicate used.

## What is the new behavior?

The `or` is being removed, simply using the predicate.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->