### PR TITLE
chore: Kubebuilder as the de facto way of writing api's

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -27,32 +27,34 @@ const (
 	TypeDegradedPaas = "Degraded"
 )
 
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // PaasSpec defines the desired state of Paas
 type PaasSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	// Capabilities is a subset of capabilities that will be available in this Paas Project
-	Capabilities PaasCapabilities `json:"capabilities,omitempty"`
+	// +kubebuilder:validation:Optional
+	Capabilities PaasCapabilities `json:"capabilities"`
 
-	// Requestor is an informational field which decides on the requestor (also application responable)
+	// Requestor is an informational field which decides on the requestor (also application responsible)
+	// +kubebuilder:validation:Required
 	Requestor string `json:"requestor"`
 
-	Groups PaasGroups `json:"groups,omitempty"`
+	// +kubebuilder:validation:Optional
+	Groups PaasGroups `json:"groups"`
 
 	// Quota defines the quotas which should be set on the cluster resource quota as used by this Paas project
+	// +kubebuilder:validation:Required
 	Quota paas_quota.Quota `json:"quota"`
 
 	// Namespaces can be used to define extra namespaces to be created as part of this Paas project
-	Namespaces []string `json:"namespaces,omitempty"`
+	// +kubebuilder:validation:Optional
+	Namespaces []string `json:"namespaces"`
 	// You can add ssh keys (which is a type of secret) for ArgoCD to use for access to bitBucket
 	// They must be encrypted with the public key corresponding to the private key deployed together with the Paas operator
-	SshSecrets map[string]string `json:"sshSecrets,omitempty"`
+	// +kubebuilder:validation:Optional
+	SshSecrets map[string]string `json:"sshSecrets"`
 
 	// Indicated by which 3rd party Paas's ArgoCD this Paas is managed
-	ManagedByPaas string `json:"managedByPaas,omitempty"`
+	// +kubebuilder:validation:Optional
+	ManagedByPaas string `json:"managedByPaas"`
 }
 
 func (p Paas) ManagedByPaas() string {
@@ -130,9 +132,12 @@ func (p Paas) extraNamespaces() (ns map[string]bool) {
 }
 
 type PaasGroup struct {
-	Query string   `json:"query,omitempty"`
-	Users []string `json:"users,omitempty"`
-	Roles []string `json:"roles,omitempty"`
+	// +kubebuilder:validation:Optional
+	Query string `json:"query"`
+	// +kubebuilder:validation:Optional
+	Users []string `json:"users"`
+	// +kubebuilder:validation:Optional
+	Roles []string `json:"roles"`
 }
 
 func (pg PaasGroup) Name(defName string) string {
@@ -262,24 +267,31 @@ func (pcs PaasCapabilities) ResetCapSshSecret(capability string) (err error) {
 
 type PaasCapability struct {
 	// Do we want to use this capability, default false
-	Enabled bool `json:"enabled,omitempty"`
+	// +kubebuilder:validation:Optional
+	Enabled bool `json:"enabled"`
 	// The URL that contains the Applications / Application Sets to be used by this capability
-	GitUrl string `json:"gitUrl,omitempty"`
+	// +kubebuilder:validation:Optional
+	GitUrl string `json:"gitUrl"`
 	// The revision of the git repo that contains the Applications / Application Sets to be used by this capability
-	GitRevision string `json:"gitRevision,omitempty"`
+	// +kubebuilder:validation:Optional
+	GitRevision string `json:"gitRevision"`
 	// the path in the git repo that contains the Applications / Application Sets to be used by this capability
-	GitPath string `json:"gitPath,omitempty"`
+	// +kubebuilder:validation:Optional
+	GitPath string `json:"gitPath"`
 	// Custom fields to configure this specific Capability
-	CustomFields map[string]string `json:"custom_fields,omitempty"`
+	// +kubebuilder:validation:Optional
+	CustomFields map[string]string `json:"custom_fields"`
 	// This project has it's own ClusterResourceQuota settings
-	Quota paas_quota.Quota `json:"quota,omitempty"`
+	// +kubebuilder:validation:Optional
+	Quota paas_quota.Quota `json:"quota"`
 	// You can add ssh keys (which is a type of secret) for capability to use for access to bitBucket
 	// They must be encrypted with the public key corresponding to the private key deployed together with the Paas operator
-	SshSecrets map[string]string `json:"sshSecrets,omitempty"`
+	// +kubebuilder:validation:Optional
+	SshSecrets map[string]string `json:"sshSecrets"`
 	// You can enable extra permissions for the service accounts belonging to this capability
 	// Exact definitions is configured in Paas Configmap
-	// Note that we want to remove (some of) these permissions in future releases (like self-provisioner)
-	ExtraPermissions bool `json:"extra_permissions,omitempty"`
+	// +kubebuilder:validation:Optional
+	ExtraPermissions bool `json:"extra_permissions"`
 }
 
 func (pc *PaasCapability) CapExtraFields(fieldConfig map[string]ConfigCustomField) (fields map[string]string, err error) {
@@ -348,10 +360,13 @@ func (pc *PaasCapability) SetSshSecret(key string, value string) {
 // PaasStatus defines the observed state of Paas
 type PaasStatus struct {
 	// Deprecated: use paasns.status.conditions instead
-	Messages []string `json:"messages,omitempty"`
+	// +kubebuilder:validation:Optional
+	Messages []string `json:"messages"`
 	// Deprecated: will not be set and removed in a future release
-	Quota      map[string]paas_quota.Quota `json:"quotas,omitempty"`
-	Conditions []metav1.Condition          `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	// +kubebuilder:validation:Optional
+	Quota map[string]paas_quota.Quota `json:"quotas"`
+	// +kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
 // Deprecated: use paas.status.conditions instead

--- a/api/v1alpha1/paasns_types.go
+++ b/api/v1alpha1/paasns_types.go
@@ -24,16 +24,22 @@ const (
 
 // PaasNSSpec defines the desired state of PaasNS
 type PaasNSSpec struct {
-	Paas       string            `json:"paas"`
-	Groups     []string          `json:"groups,omitempty"`
-	SshSecrets map[string]string `json:"sshSecrets,omitempty"`
+	// The metadata.name of the Paas which created the namespace in which this PaasNS is applied
+	// +kubebuilder:validation:Required
+	Paas string `json:"paas"`
+	// Groupnames of the groups, created externally, which should have access to the namespace created through this PaasNS
+	// +kubebuilder:validation:Optional
+	Groups []string `json:"groups"`
+	// SshSecrets which should exist in the namespace created through this PaasNS, the values are the encrypted secrets through Crypt
+	// +kubebuilder:validation:Optional
+	SshSecrets map[string]string `json:"sshSecrets"`
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:path=paasns,scope=Namespaced
 
-// PaasNS is the Schema for the paasns API
+// PaasNS is the Schema for the PaasNS API
 type PaasNS struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -100,8 +106,10 @@ func init() {
 // PaasStatus defines the observed state of Paas
 type PaasNsStatus struct {
 	// Deprecated: use paasns.status.conditions instead
-	Messages   []string           `json:"messages,omitempty"`
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	// +kubebuilder:validation:Optional
+	Messages []string `json:"messages"`
+	// +kubebuilder:validation:Optional
+	Conditions []metav1.Condition `json:"conditions" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
 // Deprecated: use paasns.status.conditions instead

--- a/docs/administrators-guide/capabilities.md
+++ b/docs/administrators-guide/capabilities.md
@@ -27,7 +27,7 @@ Adding capabilities does not require code changes / building new images. It only
 Cluster administrators can configure the ApplicationSet to be used for this specific capability.
 Imagine a cluster-wide ArgoCD to manage capabilities for Paas'es.
 It is deployed in the namespace `paas-capabilities-argocd`.
-To enable any capability, `spec.ApplicationSet_namespace` needs to be set to `paas-capabilities-argocd`, so that the Paas operator will locate ApplicationSets for capabilities in this namespace.
+To enable any capability, `spec.clusterwide_argocd_namespace` needs to be set to `paas-capabilities-argocd`, so that the Paas operator will locate ApplicationSets for capabilities in this namespace.
 And for a new capability (e.a. `new-capability`), there should be an ApplicationSet to manage resources for this new capability.
 This ApplicationSet should be created in `paas-capabilities-argocd`, and it's name (e.a. `new-capability`) should be configured in PaasConfig (`spec.capabilities["new-capability"].ApplicationSet`).
 After setting this configuration, for every Paas with the capability `new-capability` enabled, the Paas operator will
@@ -179,7 +179,7 @@ For more information on Custom Fields please revert to:
 On every cluster running the Paas operator, a PaasConfig resource is defined.
 This PaasConfig resource holds the specific configuration for the operator.
 For each capability a chapter needs to be set in `spec.capabilities`. An example can be found below.
-Furthermore, the Paas operator needs to know the namespace where to search for ApplicationSets managing the capability (`spec.ApplicationSet_namespace`).
+Furthermore, the Paas operator needs to know the namespace where to search for ApplicationSets managing the capability (`spec.clusterwide_argocd_namespace`).
 
 ### Example PaasConfig with a capability
 
@@ -193,7 +193,7 @@ Below example shows all configuration required to configure a capability.
     metadata:
       name: opr-paas-config
     spec:
-      ApplicationSet_namespace: paas-capabilities-argocd
+      clusterwide_argocd_namespace: paas-capabilities-argocd
       capabilities:
         mycap:
           ApplicationSet: mycap-as

--- a/docs/administrators-guide/configuration.md
+++ b/docs/administrators-guide/configuration.md
@@ -58,7 +58,7 @@ Example PaasConfig
       requestor_label: level-one-support
       decryptKeyPaths:
         - /secrets/paas
-      applicationset_namespace: prod-argocd
+      clusterwide_argocd_namespace: prod-argocd
       exclude_appset_name: something-to-be-excluded
       quota_label: clusterquotagroup
       rolemappings:

--- a/examples/resources/_v1alpha1_paasconfig.yaml
+++ b/examples/resources/_v1alpha1_paasconfig.yaml
@@ -3,7 +3,7 @@ kind: PaasConfig
 metadata:
   name: paas-config
 spec:
-  applicationset_namespace: asns
+  clusterwide_argocd_namespace: asns
   argopermissions:
     resource_name: argocd
     default_policy: "role:tester"

--- a/internal/controller/argo_projects.go
+++ b/internal/controller/argo_projects.go
@@ -73,7 +73,7 @@ func (r *PaasReconciler) BackendAppProject(
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: GetConfig().AppSetNamespace,
+			Namespace: GetConfig().ClusterWideArgoCDNamespace,
 			Labels:    paas.ClonedLabels(),
 			// Only removes appProject when apps no longer reference appProject
 			Finalizers: []string{

--- a/manifests/crds/cpet.belastingdienst.nl_paas.yaml
+++ b/manifests/crds/cpet.belastingdienst.nl_paas.yaml
@@ -54,7 +54,6 @@ spec:
                       description: |-
                         You can enable extra permissions for the service accounts belonging to this capability
                         Exact definitions is configured in Paas Configmap
-                        Note that we want to remove (some of) these permissions in future releases (like self-provisioner)
                       type: boolean
                     gitPath:
                       description: the path in the git repo that contains the Applications
@@ -126,7 +125,7 @@ spec:
                 type: object
               requestor:
                 description: Requestor is an informational field which decides on
-                  the requestor (also application responable)
+                  the requestor (also application responsible)
                 type: string
               sshSecrets:
                 additionalProperties:

--- a/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
@@ -37,11 +37,6 @@ spec:
             type: object
           spec:
             properties:
-              applicationset_namespace:
-                default: argocd
-                description: Namespace in which ArgoCD applicationSets will be found
-                  for managing capabilities
-                type: string
               argopermissions:
                 description: |-
                   Deprecated: ArgoCD specific code will be removed from the operator
@@ -119,6 +114,7 @@ spec:
                       description: Quota settings for this capability
                       properties:
                         clusterwide:
+                          default: false
                           description: Is this a clusterwide quota or not
                           type: boolean
                         defaults:
@@ -164,6 +160,10 @@ spec:
                   type: object
                 description: A map with zero or more ConfigCapability
                 type: object
+              clusterwide_argocd_namespace:
+                description: Namespace in which a clusterwide ArgoCD can be found
+                  for managing capabilities and appProjects
+                type: string
               debug:
                 default: false
                 description: Enable debug information generation or not
@@ -231,6 +231,7 @@ spec:
                 - namespace
                 type: object
             required:
+            - clusterwide_argocd_namespace
             - decryptKeyPaths
             - exclude_appset_name
             - whitelist

--- a/manifests/crds/cpet.belastingdienst.nl_paasns.yaml
+++ b/manifests/crds/cpet.belastingdienst.nl_paasns.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PaasNS is the Schema for the paasns API
+        description: PaasNS is the Schema for the PaasNS API
         properties:
           apiVersion:
             description: |-
@@ -40,14 +40,21 @@ spec:
             description: PaasNSSpec defines the desired state of PaasNS
             properties:
               groups:
+                description: Groupnames of the groups, created externally, which should
+                  have access to the namespace created through this PaasNS
                 items:
                   type: string
                 type: array
               paas:
+                description: The metadata.name of the Paas which created the namespace
+                  in which this PaasNS is applied
                 type: string
               sshSecrets:
                 additionalProperties:
                   type: string
+                description: SshSecrets which should exist in the namespace created
+                  through this PaasNS, the values are the encrypted secrets through
+                  Crypt
                 type: object
             required:
             - paas

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -40,7 +40,7 @@ var examplePaasConfig = v1alpha1.PaasConfig{
 		Name: "paas-config",
 	},
 	Spec: v1alpha1.PaasConfigSpec{
-		AppSetNamespace: "asns",
+		ClusterWideArgoCDNamespace: "asns",
 		ArgoPermissions: v1alpha1.ConfigArgoPermissions{
 			ResourceName:  "argocd",
 			DefaultPolicy: "role:tester",

--- a/test/manifests/config/paas_config.yml
+++ b/test/manifests/config/paas_config.yml
@@ -1,5 +1,5 @@
 ---
-applicationset_namespace: asns
+clusterwide_argocd_namespace: asns
 argopermissions:
   resource_name: argocd
   role: admin


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Kubebuilder markers and json markers are used intertwined throughout the api types. There is not a coding standard in place. There is also too much required config.

Fixes #223

## What is the new behavior?

* Uses kubebuilder markers as the de facto in api spec and status.
* Renames config item `applicationset_namespace` to `clusterwide_argocd_namespace` as it is also used for deploying argo appProjects in that namespace. It is required as the appProjects are always created. There is no default namespace name as the namespace is not created through the operator but must be created externally. Once we get rid of the ArgoCD specific code, we should be able to make it optional.
* Sets config values to optional where applicable
* Adds descriptions to PaasNs spec fields
* Updates crds

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->