### PR TITLE
fix: Reconcile updates of capability values successfull

### DIFF
--- a/internal/controller/argo_app.go
+++ b/internal/controller/argo_app.go
@@ -8,6 +8,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	argo "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
@@ -25,25 +26,21 @@ const (
 )
 
 // ensureArgoApp ensures ArgoApp presence in given argo application.
-func (r *PaasNSReconciler) EnsureArgoApp(
+func (r *PaasReconciler) EnsureArgoApp(
 	ctx context.Context,
-	paasns *v1alpha1.PaasNS,
 	paas *v1alpha1.Paas,
 ) error {
-	if paasns.Name != "argocd" {
-		return nil
-	}
-
 	ctx = setLogComponent(ctx, "argoapp")
 	logger := log.Ctx(ctx)
+	namespace := fmt.Sprintf("%s-%s", paas.Name, "argocd")
 	namespacedName := types.NamespacedName{
-		Namespace: paasns.NamespaceName(),
+		Namespace: namespace,
 		Name:      appName,
 	}
 
 	// See if argo application exists and create if it doesn't
 	found := &argo.Application{}
-	if argoApp, err := r.backendArgoApp(ctx, paasns, paas); err != nil {
+	if argoApp, err := r.backendArgoApp(ctx, paas); err != nil {
 		return err
 	} else if err := r.Get(ctx, namespacedName, found); err == nil {
 		logger.Info().Msg("argo Application already exists, updating")
@@ -60,15 +57,14 @@ func (r *PaasNSReconciler) EnsureArgoApp(
 }
 
 // backendArgoApp is code for creating a ArgoApp
-func (r *PaasNSReconciler) backendArgoApp(
+func (r *PaasReconciler) backendArgoApp(
 	ctx context.Context,
-	paasns *v1alpha1.PaasNS,
 	paas *v1alpha1.Paas,
 ) (*argo.Application, error) {
 	logger := log.Ctx(ctx)
 	logger.Info().Msgf("defining %s Argo Application", appName)
 
-	namespace := paasns.NamespaceName()
+	namespace := fmt.Sprintf("%s-%s", paas.Name, "argocd")
 	argoConfig := paas.Spec.Capabilities["argocd"]
 	argoConfig.SetDefaults()
 	fields, err := argoConfig.CapExtraFields(GetConfig().Capabilities["argocd"].CustomFields)
@@ -83,7 +79,7 @@ func (r *PaasNSReconciler) backendArgoApp(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: namespace,
-			Labels:    paasns.ClonedLabels(),
+			Labels:    paas.ClonedLabels(),
 		},
 
 		Spec: argo.ApplicationSpec{

--- a/internal/controller/capabilities.go
+++ b/internal/controller/capabilities.go
@@ -122,29 +122,37 @@ func splitToService(paasName string) (string, string) {
 	return parts[0], parts[1]
 }
 
-// ensureAppSetCap ensures a list entry in the AppSet for the capability
-func (r *PaasNSReconciler) EnsureAppSetCap(
+// ensureAppSetCap ensures a list entry in the AppSet for each capability
+func (r *PaasReconciler) ensureAppSetCaps(
 	ctx context.Context,
-	paasns *v1alpha1.PaasNS,
 	paas *v1alpha1.Paas,
+) error {
+	config := GetConfig()
+	for capName := range paas.Spec.Capabilities {
+		if _, exists := config.Capabilities[capName]; !exists {
+			return fmt.Errorf("Capability not configured")
+		}
+		// Only do this when enabled
+		capability := paas.Spec.Capabilities[capName]
+		if enabled := capability.IsEnabled(); enabled {
+			if err := r.ensureAppSetCap(ctx, paas, capName); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ensureAppSetCap ensures a list entry in the AppSet for the capability
+func (r *PaasReconciler) ensureAppSetCap(
+	ctx context.Context,
+	paas *v1alpha1.Paas,
+	capName string,
 ) error {
 	var err error
 	var fields Elements
-	if cap, exists := paas.Spec.Capabilities[paasns.Name]; !exists {
-		// This function is called from on other function within this exact if exists check
-		return fmt.Errorf("We should never end here")
-	} else if capConfig, exists := GetConfig().Capabilities[paasns.Name]; !exists {
-		return fmt.Errorf("Capability not configured")
-	} else if fields, err = cap.CapExtraFields(capConfig.CustomFields); err != nil {
-		return err
-	}
-	service, subService := splitToService(paas.Name)
-	fields["requestor"] = paas.Spec.Requestor
-	fields["paas"] = paas.Name
-	fields["service"] = service
-	fields["subservice"] = subService
 	// See if AppSet exists raise error if it doesn't
-	namespacedName := GetConfig().CapabilityK8sName(paasns.Name)
+	namespacedName := GetConfig().CapabilityK8sName(capName)
 	appSet := &appv1.ApplicationSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Applicationset",
@@ -156,15 +164,24 @@ func (r *PaasNSReconciler) EnsureAppSetCap(
 		},
 	}
 	ctx = setLogComponent(ctx, "appset")
-	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset %s", paasns.Name, namespacedName.String())
+	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset", capName)
 	err = r.Get(ctx, namespacedName, appSet)
-	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
 	var entries Entries
 	var listGen *appv1.ApplicationSetGenerator
 	if err != nil {
 		// Applicationset does not exist
 		return err
 	}
+
+	capability := paas.Spec.Capabilities[capName]
+	if fields, err = capability.CapExtraFields(GetConfig().Capabilities[capName].CustomFields); err != nil {
+		return err
+	}
+	service, subService := splitToService(paas.Name)
+	fields["requestor"] = paas.Spec.Requestor
+	fields["paas"] = paas.Name
+	fields["service"] = service
+	fields["subservice"] = subService
 	patch := client.MergeFrom(appSet.DeepCopy())
 	if listGen = getListGen(appSet.Spec.Generators); listGen == nil {
 		// create the list
@@ -173,7 +190,7 @@ func (r *PaasNSReconciler) EnsureAppSetCap(
 		}
 		appSet.Spec.Generators = append(appSet.Spec.Generators, *listGen)
 		entries = Entries{
-			paasns.Spec.Paas: fields,
+			paas.Name: fields,
 		}
 	} else if entries, err = EntriesFromJSON(listGen.List.Elements); err != nil {
 		return err
@@ -192,41 +209,20 @@ func (r *PaasNSReconciler) EnsureAppSetCap(
 	return r.Patch(ctx, appSet, patch)
 }
 
-func (r *PaasNSReconciler) finalizeAppSetCap(
+// finalizeAppSetCaps ensures the list entries in the AppSets are removed for each capability in the Paas
+func (r *PaasReconciler) finalizeAppSetCaps(
 	ctx context.Context,
-	paasns *v1alpha1.PaasNS,
+	paas *v1alpha1.Paas,
 ) error {
-	// See if AppSet exists raise error if it doesn't
-	as := &appv1.ApplicationSet{}
-	asNamespacedName := GetConfig().CapabilityK8sName(paasns.Name)
-	ctx = setLogComponent(ctx, "appset")
-	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset", paasns.Name)
-	err := r.Get(ctx, asNamespacedName, as)
-	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
-	var entries Entries
-	var listGen *appv1.ApplicationSetGenerator
-	if err != nil {
-		// Applicationset does not exixt
-		return nil
+	for capName := range paas.Spec.Capabilities {
+		if err := r.finalizeAppSetCap(ctx, paas, capName); err != nil {
+			return err
+		}
 	}
-	patch := client.MergeFrom(as.DeepCopy())
-	if listGen = getListGen(as.Spec.Generators); listGen == nil {
-		// no need to create the list
-		return nil
-	} else if entries, err = EntriesFromJSON(listGen.List.Elements); err != nil {
-		return err
-	} else {
-		delete(entries, paasns.Spec.Paas)
-	}
-	if json, err := entries.AsJSON(); err != nil {
-		return err
-	} else {
-		listGen.List.Elements = json
-	}
-
-	return r.Patch(ctx, as, patch)
+	return nil
 }
 
+// finalizeAppSetCap ensures the list entry for the capability is removed
 func (r *PaasReconciler) finalizeAppSetCap(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
@@ -238,7 +234,6 @@ func (r *PaasReconciler) finalizeAppSetCap(
 	ctx = setLogComponent(ctx, "appset")
 	log.Ctx(ctx).Info().Msgf("reconciling %s Applicationset", capability)
 	err := r.Get(ctx, asNamespacedName, as)
-	// groups := NewGroups().AddFromStrings(paas.Spec.LdapGroups)
 	var entries Entries
 	var listGen *appv1.ApplicationSetGenerator
 	if err != nil {
@@ -261,17 +256,4 @@ func (r *PaasReconciler) finalizeAppSetCap(
 	}
 
 	return r.Patch(ctx, as, patch)
-}
-
-// ensureAppSetCap ensures a list entry in the AppSet voor the capability
-func (r *PaasReconciler) FinalizeAppSetCaps(
-	ctx context.Context,
-	paas *v1alpha1.Paas,
-) error {
-	for capName := range paas.Spec.Capabilities {
-		if err := r.finalizeAppSetCap(ctx, paas, capName); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -207,6 +207,21 @@ func (r *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		return ctrl.Result{}, errors.Join(err, r.setErrorCondition(ctx, paas, err))
 	} else if err = r.ReconcileRolebindings(ctx, paas); err != nil {
 		return ctrl.Result{}, errors.Join(err, r.setErrorCondition(ctx, paas, err))
+	} else if err = r.ensureAppSetCaps(ctx, paas); err != nil {
+		return ctrl.Result{}, errors.Join(err, r.setErrorCondition(ctx, paas, err))
+	} else if argoCap, exists := paas.Spec.Capabilities["argocd"]; exists {
+		if argoCap.IsEnabled() {
+			logger.Info().Msg("creating Argo App for client bootstrapping")
+
+			// Create bootstrap Argo App
+			if err := r.EnsureArgoApp(ctx, paas); err != nil {
+				return ctrl.Result{}, errors.Join(err, r.setErrorCondition(ctx, paas, err))
+			}
+
+			if err := r.EnsureArgoCD(ctx, paas); err != nil {
+				return ctrl.Result{}, errors.Join(err, r.setErrorCondition(ctx, paas, err))
+			}
+		}
 	}
 
 	// Reconciling succeeded, set appropriate Condition
@@ -283,7 +298,7 @@ func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *PaasReconciler) finalizePaas(ctx context.Context, paas *v1alpha1.Paas) error {
 	logger := log.Ctx(ctx)
 	logger.Debug().Msg("inside Paas finalizer")
-	if err := r.FinalizeAppSetCaps(ctx, paas); err != nil {
+	if err := r.finalizeAppSetCaps(ctx, paas); err != nil {
 		logger.Err(err).Msg("appSet finalizer error")
 		return err
 	} else if err = r.FinalizeClusterQuotas(ctx, paas); err != nil {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -19,7 +19,6 @@ import (
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
-	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
 
 	quotav1 "github.com/openshift/api/quota/v1"
 	userv1 "github.com/openshift/api/user/v1"
@@ -239,7 +238,7 @@ func TestMain(m *testing.M) {
 			}
 
 			waitUntilPaasConfigExists := conditions.New(cfg.Client().Resources()).ResourceMatch(paasconfig, func(obj k8s.Object) bool {
-				return obj.(*api.PaasConfig).Name == paasconfig.Name
+				return obj.(*v1alpha1.PaasConfig).Name == paasconfig.Name
 			})
 
 			if err := waitForDefaultOpts(ctx, waitUntilPaasConfigExists); err != nil {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?

paas_controller
It is this controllers responsibility to reconcile a Paas, on which spec the CustomFields and ArgoCD capability values are present. It will reconcile PaasNs'es for each capability.

paasns_controller
It is this controllers responsibility to reconcile a PaasNs. It is also it's responsibility to reconcile AppSets containing the values of CustomFields and in case of the ArgoCD capability, to reconcile the Argo related resources.

In case of updating a CustomField / ArgoCD related value, the paas_controller is triggered to reconcile the updated paas. That goes as far as checking whether the PaasNs is in the desired state. As the PaasNs itself, holds no CustomFields / ArgoCD capability values, the desired state has not changed. Thus updating these values, causes no reconciliation of the PaasNs related to that capability, thus not updating the ArgoCD related resources / CustomField values in any appSet.

Fixes: #185 

## What is the new behaviour?

By moving the appSetCaps and ArgoApp reconcilers functions from the PaasNs to the Paas controller, the responsibility is allocated to the correct controller for applying updates to those fields. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->