### PR TITLE
ci(docs): set version to vn.n.x (adding .x)

### DIFF
--- a/.github/workflows/build-and-publish-docs.yaml
+++ b/.github/workflows/build-and-publish-docs.yaml
@@ -66,10 +66,11 @@ jobs:
         id: extract_short_tag
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          SHORT_TAG="$(echo "$TAG" | sed 's/\([0-9]*\.[0-9]*\).*/\1/')"
+          SHORT_TAG="$(echo "$TAG" | sed 's/\([0-9]*\.[0-9]*\).*/\1\.x/')"
           echo "SHORT_TAG=$SHORT_TAG" >> $GITHUB_OUTPUT
 
       - name: Deploy with mike 🚀
+        # note that "mike set-default latest" was run manually in initial docs setup
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |


### PR DESCRIPTION
Small change to update the docs version numbering to vN.N.x (example: v1.0.x)

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

vN.N (ex. v1.0)

## What is the new behavior?

vN.N.x (ex. v1.0.x)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
