### PR TITLE
chore: Adds missing ClusterRoles for PaasConfig

### DIFF
--- a/manifests/rbac/kustomization.yaml
+++ b/manifests/rbac/kustomization.yaml
@@ -8,8 +8,10 @@ resources:
   - role.yaml
   - role_binding.yaml
   - service_account.yaml
-# Uncomment the following four lines if you want to add roles for end-users
+# Uncomment the following lines if you want to add roles for end-users
 # - paas_editor_role.yaml
 # - paas_viewer_role.yaml
 # - paasns_editor_role.yaml
 # - paasns_viewer_role.yaml
+# - paasconfig_editor_role.yaml
+# - paasconfig_viewer_role.yaml

--- a/manifests/rbac/paasconfig_editor_role.yaml
+++ b/manifests/rbac/paasconfig_editor_role.yaml
@@ -1,0 +1,31 @@
+# permissions for end users to edit paasconfig.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: paasconfig-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: opr-paas
+    app.kubernetes.io/part-of: opr-paas
+    app.kubernetes.io/managed-by: kustomize
+  name: paasconfig-editor-role
+rules:
+- apiGroups:
+  - cpet.belastingdienst.nl
+  resources:
+  - paasconfig
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cpet.belastingdienst.nl
+  resources:
+  - paasconfig/status
+  verbs:
+  - get

--- a/manifests/rbac/paasconfig_viewer_role.yaml
+++ b/manifests/rbac/paasconfig_viewer_role.yaml
@@ -1,0 +1,27 @@
+# permissions for end users to view paasconfig.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: paasconfig-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: opr-paas
+    app.kubernetes.io/part-of: opr-paas
+    app.kubernetes.io/managed-by: kustomize
+  name: paasconfig-viewer-role
+rules:
+- apiGroups:
+  - cpet.belastingdienst.nl
+  resources:
+  - paasconfig
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cpet.belastingdienst.nl
+  resources:
+  - paasconfig/status
+  verbs:
+  - get


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the new behavior?

For completeness, adds ClusterRoles for PaasConfig which where normally generated by operator-sdk but we forgot to add.
Those aren't deployed by default.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->