### PR TITLE
fix: Ci not triggered after #247

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-22.04
     outputs:
-      backend: ${{ steps.filter.outputs.backend_any_changed }}
+      backend: ${{ steps.filter.outputs.backend_any_changed && steps.filter.outputs.ci_any_changed }}
     steps:
       - uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # v4.0.0
       - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275 # v45.0.1
@@ -37,6 +37,7 @@ jobs:
               - '!docs/**'
               - '!examples/**'
               - '!.github/**'
+            ci:
               - '.github/workflows/ci-run-on-pr.yaml'
   
   check-go:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

CI will now only run when the `.github/workflows/ci-run-on-pr.yaml` has changed.

## What is the new behavior?

Create two selectors in `changed-files` 
Run CI when one of both has been changed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->