### PR TITLE
test: Cleanup main_test.go

### DIFF
--- a/internal/controller/main_test.go
+++ b/internal/controller/main_test.go
@@ -6,23 +6,11 @@ See LICENSE.md for details.
 
 package controller
 
-// broken with adding ArgoPermissions capability
-// Seems we need to downgrade to v.0.26.4
-// (see https://github.com/operator-framework/operator-sdk/issues/6396)
-// but that adds other incompatibilities.
-// Maybe fix later.
-
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestMain_getConfig(t *testing.T) {
-	os.Setenv("PAAS_CONFIG", "../../test/manifests/config/paas_config.yml")
-	assert.NotNil(t, GetConfig(), "some-ns")
-}
 
 func TestMain_intersection(t *testing.T) {
 	l1 := []string{"v1", "v2", "v2", "v3", "v4"}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

main_test.go in internal, contains a test to check whether the GetConfig returns something, when an envvar is set to steer where the config can be found. However, GetConfig does always return non-nil and the envvar is not used anymore to state where configfile can be found. The test is therefore useless.

## What is the new behavior?

* Cleanup main_test.go in internal, as no configfile is set via an env-var. 
* Cleanup main_test.go by removing an unrelated comment

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->