### PR TITLE
fix: Remove old groups on Paas group spec update

### DIFF
--- a/internal/controller/groups.go
+++ b/internal/controller/groups.go
@@ -165,9 +165,11 @@ func (r *PaasReconciler) FinalizeGroups(
 	if err != nil {
 		return err
 	}
-	err = r.FinalizeLdapGroups(ctx, removedLdapGroups)
-	if err != nil {
-		return err
+	if len(removedLdapGroups) != 0 {
+		err = r.FinalizeLdapGroups(ctx, removedLdapGroups)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -188,9 +190,11 @@ func (r *PaasReconciler) ReconcileGroups(
 	if err != nil {
 		return err
 	}
-	err = r.FinalizeLdapGroups(ctx, removedLdapGroups)
-	if err != nil {
-		return err
+	if len(removedLdapGroups) != 0 {
+		err = r.FinalizeLdapGroups(ctx, removedLdapGroups)
+		if err != nil {
+			return err
+		}
 	}
 	for _, group := range desiredGroups {
 		if err := r.EnsureGroup(ctx, paas, group); err != nil {
@@ -219,6 +223,7 @@ func (r *PaasReconciler) deleteObsoleteGroups(ctx context.Context, paas *v1alpha
 				if existingGroup.Annotations["openshift.io/ldap.uid"] != "" {
 					removedLdapGroups = append(removedLdapGroups, existingGroup.Annotations["openshift.io/ldap.uid"])
 				}
+				continue
 			}
 			logger.Info().Msgf("not last owner of group %s", existingGroup.Name)
 			// FIXME no updates to users is executed

--- a/internal/controller/ldap_groups.go
+++ b/internal/controller/ldap_groups.go
@@ -100,7 +100,6 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 ) error {
 	ctx = setLogComponent(ctx, "ldapgroup")
 	logger := log.Ctx(ctx)
-	// See if group already exists and create if it doesn't
 	cm := &corev1.ConfigMap{}
 	wlConfigMap := GetConfig().GroupSyncList
 	err := r.Get(ctx, types.NamespacedName{Name: wlConfigMap.Name, Namespace: wlConfigMap.Namespace}, cm)

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -304,17 +304,8 @@ func (r *PaasReconciler) finalizePaas(ctx context.Context, paas *v1alpha1.Paas) 
 	} else if err = r.FinalizeClusterQuotas(ctx, paas); err != nil {
 		logger.Err(err).Msg("quota finalizer error")
 		return err
-	} else if cleanedLdapQueries, err := r.FinalizeGroups(ctx, paas); err != nil {
-		// The whole idea is that groups (which are resources)
-		// can also be ldapGroups (lines in a field in a configmap)
-		// ldapGroups are only cleaned if the corresponding group is also cleaned
+	} else if err = r.FinalizeGroups(ctx, paas); err != nil {
 		logger.Err(err).Msg("group finalizer error")
-		if ldapErr := r.FinalizeLdapGroups(ctx, cleanedLdapQueries); ldapErr != nil {
-			logger.Err(ldapErr).Msg("and ldapGroup finalizer error")
-		}
-		return err
-	} else if err = r.FinalizeLdapGroups(ctx, cleanedLdapQueries); err != nil {
-		logger.Err(err).Msg("ldapGroup finalizer error")
 		return err
 	} else if err = r.FinalizeExtraClusterRoleBindings(ctx, paas); err != nil {
 		logger.Err(err).Msg("extra ClusterRoleBindings finalizer error")

--- a/test/e2e/groupquery_test.go
+++ b/test/e2e/groupquery_test.go
@@ -22,6 +22,7 @@ const (
 	groupWithQueryName       = "aug-cet-groupquery" //nolint:gosec
 	groupQuery               = "CN=aug-cet-groupquery,OU=paas,DC=test,DC=acme,DC=org"
 	group2Query              = "CN=aug-cet-queryviewrole,OU=paas,DC=test,DC=acme,DC=org"
+	updatedGroup2Query       = "CN=aug-cet-second-queryviewrole,OU=paas,DC=test,DC=acme,DC=org"
 )
 
 func TestGroupQuery(t *testing.T) {
@@ -50,6 +51,7 @@ func TestGroupQuery(t *testing.T) {
 
 				return ctx
 			}).
+			Assess("old group is removed from groupsynclist when groupkey is renamed", assertLdapGroupRemovedAfterUpdatingKey).
 			Assess("first group remains unchanged after Paas update", assertGroupQueryCreated).
 			Assess("groups are deleted when Paas is deleted", assertGroupQueryDeleted).
 			Teardown(teardownPaasFn(paasWithGroupQuery)).
@@ -98,8 +100,11 @@ func assertGroupQueryCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *
 
 	assert.Equal(t, group2Name, group2.Name, "The group name should match the one defined in the Paas")
 	assert.Empty(t, group2.Users, "No users should be defined in the group")
-	assert.Len(t, group2.Labels, 1)
-	assert.Equal(t, "my-ldap-host", group2.Labels["openshift.io/ldap.host"], "The correct label should be defined")
+	assert.Len(t, group2.Labels, 1, "Group should contain one label")
+	assert.Equal(t, "my-ldap-host", group2.Labels["openshift.io/ldap.host"], "The ldap.host label should contain PaasConfig value")
+	assert.Len(t, group2.Annotations, 2, "Group should have 2 annotations")
+	assert.Equal(t, group2Query, group2.Annotations["openshift.io/ldap.uid"], "The ldap.uid annotation should contain group.query value")
+	assert.Equal(t, "my-ldap-host:13", group2.Annotations["openshift.io/ldap.url"], "The ldap.url annotation should contain PaasConfig value")
 	assert.Equal(t, paas.UID, group2.OwnerReferences[0].UID, "The owner of the group should be the Paas defining it")
 	assert.Len(t, rolebinding.Subjects, 1)
 	assert.Equal(t, group2Name, rolebinding.Subjects[0].Name, "A RoleBinding for the passed 'viewer' role should be set for the group")
@@ -109,6 +114,26 @@ func assertGroupQueryCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *
 			assert.NotEqual(t, group2Name, sub.Name, "No RoleBindings should be set on the parent Paas")
 		}
 	}
+
+	return ctx
+}
+
+func assertLdapGroupRemovedAfterUpdatingKey(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	paas := getPaas(ctx, paasWithGroupQuery, t, cfg)
+	paas.Spec.Groups = api.PaasGroups{groupWithQueryName: api.PaasGroup{Query: groupQuery}, "updatedSecondLdapGroup": api.PaasGroup{
+		Query: updatedGroup2Query,
+		Roles: []string{"viewer"},
+	}}
+
+	if err := updateSync(ctx, cfg, paas, api.TypeReadyPaas); err != nil {
+		t.Fatal(err)
+	}
+
+	// Regression for #269 old group should be removed from groupsynclist
+	groupsynclist := getOrFail(ctx, "wlname", "gsns", &corev1.ConfigMap{}, t, cfg)
+	t.Log("Groupsynclist", groupsynclist)
+	assert.NotContains(t, groupsynclist.Data["groupsynclist.txt"], group2Query,
+		"The groupsynclist does not include obsolete group query")
 
 	return ctx
 }

--- a/test/e2e/groupusers_test.go
+++ b/test/e2e/groupusers_test.go
@@ -16,10 +16,12 @@ import (
 )
 
 const (
-	paasWithGroups = "paas-with-groups"
-	paasNamespace  = "my-ns"
-	paasAbsoluteNs = paasWithGroups + "-" + paasNamespace
-	groupName      = "aug-cet-test"
+	paasWithGroups         = "paas-with-groups"
+	paasNamespace          = "my-ns"
+	paasAbsoluteNs         = paasWithGroups + "-" + paasNamespace
+	groupName              = "aug-cet-test"
+	secondGroupName        = "aug-cet-viewrole"
+	updatedSecondGroupName = "aug-cet-viewrole-updated"
 )
 
 func TestGroupUsers(t *testing.T) {
@@ -37,6 +39,7 @@ func TestGroupUsers(t *testing.T) {
 			Setup(createPaasFn(paasWithGroups, paasSpec)).
 			Assess("group is created with user", assertGroupCreated).
 			Assess("second group with role is created after Paas update", assertGroupCreatedAfterUpdate).
+			Assess("old group is removed when group in Paas is renamed", assertGroupNotRemovedAfterUpdatingKey).
 			Assess("first group remains unchanged after Paas update", assertGroupCreated).
 			Assess("is deleted when Paas is deleted", assertGroupsDeleted).
 			Teardown(teardownPaasFn(paasWithGroups)).
@@ -58,6 +61,9 @@ func assertGroupCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) 
 	// Correct labels are defined
 	assert.Len(t, group.Labels, 1)
 	assert.Equal(t, "my-ldap-host", group.Labels["openshift.io/ldap.host"])
+	assert.Len(t, group.Annotations, 2, "Group should have 2 annotations")
+	assert.Equal(t, "", group.Annotations["openshift.io/ldap.uid"], "The ldap.uid annotation should contain group.query value")
+	assert.Equal(t, "my-ldap-host:13", group.Annotations["openshift.io/ldap.url"], "The ldap.url annotation should contain PaasConfig value")
 	// The owner of the group is the Paas that created it
 	assert.Equal(t, paas.UID, group.OwnerReferences[0].UID)
 	// The groupsynclist is unchanged (empty)
@@ -78,8 +84,7 @@ func assertGroupCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) 
 
 func assertGroupCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	paas := getPaas(ctx, paasWithGroups, t, cfg)
-	group2Name := "aug-cet-viewrole"
-	paas.Spec.Groups[group2Name] = api.PaasGroup{
+	paas.Spec.Groups[secondGroupName] = api.PaasGroup{
 		Roles: []string{"viewer"},
 		Users: []string{"bar"},
 	}
@@ -88,13 +93,13 @@ func assertGroupCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *envco
 		t.Fatal(err)
 	}
 
-	group2 := getOrFail(ctx, group2Name, cfg.Namespace(), &userv1.Group{}, t, cfg)
+	group2 := getOrFail(ctx, secondGroupName, cfg.Namespace(), &userv1.Group{}, t, cfg)
 	groupsynclist := getOrFail(ctx, "wlname", "gsns", &corev1.ConfigMap{}, t, cfg)
 	rolebinding := getOrFail(ctx, "paas-view", paasAbsoluteNs, &rbacv1.RoleBinding{}, t, cfg)
 	rolebindingsPaas := listOrFail(ctx, paasWithGroups, &rbacv1.RoleBindingList{}, t, cfg)
 
 	// Group name matches the one defined in the Paas
-	assert.Equal(t, group2Name, group2.Name)
+	assert.Equal(t, secondGroupName, group2.Name)
 	// Defined user is in group
 	assert.Equal(t, "[bar]", group2.Users.String())
 	// Correct labels are defined
@@ -106,12 +111,55 @@ func assertGroupCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *envco
 	assert.Empty(t, groupsynclist.Data["groupsynclist.txt"])
 	// Default RoleBinding (as per Paas config) is set for group
 	assert.Len(t, rolebinding.Subjects, 1)
-	assert.Equal(t, group2Name, rolebinding.Subjects[0].Name)
+	assert.Equal(t, secondGroupName, rolebinding.Subjects[0].Name)
 	assert.Equal(t, "view", rolebinding.RoleRef.Name)
 	// No RoleBindings set on parent Paas
 	for _, rb := range rolebindingsPaas.Items {
 		for _, sub := range rb.Subjects {
-			assert.NotEqual(t, group2Name, sub.Name)
+			assert.NotEqual(t, secondGroupName, sub.Name)
+		}
+	}
+
+	return ctx
+}
+
+func assertGroupNotRemovedAfterUpdatingKey(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	paas := getPaas(ctx, paasWithGroups, t, cfg)
+	paas.Spec.Groups = api.PaasGroups{groupName: api.PaasGroup{Users: []string{"foo"}}, updatedSecondGroupName: api.PaasGroup{
+		Roles: []string{"viewer"},
+		Users: []string{"bar"},
+	}}
+
+	if err := updateSync(ctx, cfg, paas, api.TypeReadyPaas); err != nil {
+		t.Fatal(err)
+	}
+
+	failWhenExists(ctx, secondGroupName, cfg.Namespace(), &userv1.Group{}, t, cfg)
+	// Updated groupname created
+	updatedGroup2 := getOrFail(ctx, updatedSecondGroupName, cfg.Namespace(), &userv1.Group{}, t, cfg)
+	groupsynclist := getOrFail(ctx, "wlname", "gsns", &corev1.ConfigMap{}, t, cfg)
+	rolebinding := getOrFail(ctx, "paas-view", paasAbsoluteNs, &rbacv1.RoleBinding{}, t, cfg)
+	rolebindingsPaas := listOrFail(ctx, paasWithGroups, &rbacv1.RoleBindingList{}, t, cfg)
+
+	// Group name matches the one defined in the Paas
+	assert.Equal(t, updatedSecondGroupName, updatedGroup2.Name)
+	// Defined user is in group
+	assert.Equal(t, "[bar]", updatedGroup2.Users.String())
+	// Correct labels are defined
+	assert.Len(t, updatedGroup2.Labels, 1)
+	assert.Equal(t, "my-ldap-host", updatedGroup2.Labels["openshift.io/ldap.host"])
+	// The owner of the group is the Paas that created it
+	assert.Equal(t, paas.UID, updatedGroup2.OwnerReferences[0].UID)
+	// The groupsynclist is unchanged (empty)
+	assert.Empty(t, groupsynclist.Data["groupsynclist.txt"])
+	// Default RoleBinding (as per Paas config) is set for group
+	assert.Len(t, rolebinding.Subjects, 1)
+	assert.Equal(t, updatedSecondGroupName, rolebinding.Subjects[0].Name)
+	assert.Equal(t, "view", rolebinding.RoleRef.Name)
+	// No RoleBindings set on parent Paas
+	for _, rb := range rolebindingsPaas.Items {
+		for _, sub := range rb.Subjects {
+			assert.NotEqual(t, updatedSecondGroupName, sub.Name)
 		}
 	}
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When groups are renamed in a Paas, the old group isn't removed.

Fixes: #269 

## What is the new behavior?

Obsolete groups are removed when a Paas groupname is updated in a Paas.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->