### PR TITLE
feat: Configurable GroupSyncList key

### DIFF
--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -67,6 +67,12 @@ type PaasConfigSpec struct {
 	// +kubebuilder:validation:Required
 	GroupSyncList NamespacedName `json:"groupsynclist"`
 
+	// Deprecated: GroupSyncListKey code will be removed from the operator to make it more generic
+	// A key in the configures GroupSyncList which will contain the LDAP groups to be synced using LDAP sync
+	// +kubebuilder:default:=groupsynclist.txt
+	// +kubebuilder:validation:Optional
+	GroupSyncListKey string `json:"groupsynclist_key"`
+
 	// LDAP configuration for the operator to add to Groups
 	// +kubebuilder:validation:Optional
 	LDAP ConfigLdap `json:"ldap"`

--- a/docs/overview/core_concepts/groupsynclist.md
+++ b/docs/overview/core_concepts/groupsynclist.md
@@ -5,6 +5,9 @@ running `oc adm groups sync` commands periodically.
 
 The information for this job comes from a ConfigMap called `groupsynclist`.
 
+The Paas operator will manipulate the data in a key of a configured ConfigMap. The targeted configmap is 
+configured through the `paasconfig.spec.groupsynclist`. The keyname can be configured with `paasconfig.spec.groupsynclistkey`.
+
 We are in the process of changing this solution to a more K8S generic solution for
 management of Users and Groups.
 

--- a/internal/controller/ldap_groups.go
+++ b/internal/controller/ldap_groups.go
@@ -20,10 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	groupSyncListKeyName = "groupsynclist.txt"
-)
-
 func (r *PaasReconciler) ensureLdapGroupsConfigMap(
 	ctx context.Context,
 	groups string,
@@ -40,7 +36,7 @@ func (r *PaasReconciler) ensureLdapGroupsConfigMap(
 			Namespace: wlConfigMap.Namespace,
 		},
 		Data: map[string]string{
-			groupSyncListKeyName: groups,
+			GetConfig().GroupSyncListKey: groups,
 		},
 	})
 }
@@ -74,9 +70,9 @@ func (r *PaasReconciler) EnsureLdapGroups(
 	} else if err != nil {
 		logger.Err(err).Msg("could not retrieve groupsynclist configmap")
 		return err
-	} else if groupsynclist, exists := cm.Data[groupSyncListKeyName]; !exists {
+	} else if groupsynclist, exists := cm.Data[GetConfig().GroupSyncListKey]; !exists {
 		logger.Info().Msg("adding groupsynclist.txt to groupsynclist configmap")
-		cm.Data[groupSyncListKeyName] = gs.AsString()
+		cm.Data[GetConfig().GroupSyncListKey] = gs.AsString()
 	} else {
 		logger.Info().Msgf("reading group queries from groupsynclist %v", cm)
 		groupsynclistGroups := groups.NewGroups()
@@ -87,7 +83,7 @@ func (r *PaasReconciler) EnsureLdapGroups(
 			return nil
 		}
 		logger.Info().Msg("adding to groupsynclist configmap")
-		cm.Data[groupSyncListKeyName] = groupsynclistGroups.AsString()
+		cm.Data[GetConfig().GroupSyncListKey] = groupsynclistGroups.AsString()
 	}
 	logger.Info().Msgf("updating groupsynclist configmap: %v", cm)
 	return r.Update(ctx, cm)
@@ -112,9 +108,9 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 		logger.Err(err).Msg("error retrieving groupsynclist configmap")
 		// Error that isn't due to the group not existing
 		return err
-	} else if groupsynclist, exists := cm.Data[groupSyncListKeyName]; !exists {
+	} else if groupsynclist, exists := cm.Data[GetConfig().GroupSyncListKey]; !exists {
 		// No groupsynclist.txt exists in the configmap, so nothing to clean
-		logger.Info().Msgf("%s does not exists in groupsynclist configmap", groupSyncListKeyName)
+		logger.Info().Msgf("%s does not exists in groupsynclist configmap", GetConfig().GroupSyncListKey)
 		return nil
 	} else {
 		var isChanged bool
@@ -132,7 +128,7 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 		if !isChanged {
 			return nil
 		}
-		cm.Data[groupSyncListKeyName] = gs.AsString()
+		cm.Data[GetConfig().GroupSyncListKey] = gs.AsString()
 	}
 	return r.Update(ctx, cm)
 }

--- a/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
@@ -194,6 +194,12 @@ spec:
                 - name
                 - namespace
                 type: object
+              groupsynclist_key:
+                default: groupsynclist.txt
+                description: |-
+                  Deprecated: GroupSyncListKey code will be removed from the operator to make it more generic
+                  A key in the configures GroupSyncList which will contain the LDAP groups to be synced using LDAP sync
+                type: string
               ldap:
                 description: LDAP configuration for the operator to add to Groups
                 properties:

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -170,6 +170,7 @@ var examplePaasConfig = v1alpha1.PaasConfig{
 			Namespace: "gsns",
 			Name:      "wlname",
 		},
+		GroupSyncListKey:  "groupsynclist.txt",
 		ExcludeAppSetName: "whatever",
 	},
 }


### PR DESCRIPTION
Allow configuration of the key in the groupsynclist which is managed by the operator.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The key in the groupsynclist is fixed: `groupsynclist.txt`

Fixes #273

## What is the new behavior?

The key in the groupsynclist can be configured in the PaasConfig crd. It has a default value.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->