### PR TITLE
fix: correct conversion int64 float64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=paas-manager-role crd paths="./..." output:crd:artifacts:config=manifests/crds output:crd:artifacts:config=manifests/crds output:rbac:artifacts:config=manifests/rbac
+	$(CONTROLLER_GEN) rbac:roleName=paas-manager-role crd:allowDangerousTypes=true paths="./..." output:crd:artifacts:config=manifests/crds output:crd:artifacts:config=manifests/crds output:rbac:artifacts:config=manifests/rbac
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -228,7 +228,7 @@ type ConfigQuotaSettings struct {
 
 	// The ratio of the requested quota which will be applied to the total quota
 	// +kubebuilder:validation:Optional
-	Ratio int64 `json:"ratio"`
+	Ratio float64 `json:"ratio"`
 
 	// The default quota which the enabled capability gets
 	// +kubebuilder:validation:Required

--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -228,6 +228,9 @@ type ConfigQuotaSettings struct {
 
 	// The ratio of the requested quota which will be applied to the total quota
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Format:=float
+	// +kubebuilder:validation:Minimum:=0.0
+	// +kubebuilder:validation:Maximum:=1.0
 	Ratio float64 `json:"ratio"`
 
 	// The default quota which the enabled capability gets

--- a/docs/administrators-guide/capabilities.md
+++ b/docs/administrators-guide/capabilities.md
@@ -230,5 +230,5 @@ Below example shows all configuration required to configure a capability.
               requests.memory: 16Gi
               requests.storage: "10Gi"
               thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
-            ratio: 10
+            ratio: 0.1
     ```

--- a/docs/administrators-guide/configuration.md
+++ b/docs/administrators-guide/configuration.md
@@ -133,7 +133,7 @@ Example PaasConfig
               thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
             min: {}
             max: {}
-            ratio: 10
+            ratio: 0.1
         sso:
           applicationset: prod-paas-sso
           default_permissions: {}

--- a/examples/resources/_v1alpha1_paasconfig.yaml
+++ b/examples/resources/_v1alpha1_paasconfig.yaml
@@ -56,7 +56,7 @@ spec:
         max:
           requests.cpu: '1'
           requests.memory: 1Gi
-        ratio: 10
+        ratio: 0.1
     sso:
       applicationset: ssoas
       default_permissions: {}

--- a/internal/quota/quotalists.go
+++ b/internal/quota/quotalists.go
@@ -95,7 +95,7 @@ func (pcr QuotaLists) Min() Quota {
 	return quotaResources
 }
 
-func (pcr QuotaLists) OptimalValues(ratio int64, minQuotas Quota, maxQuotas Quota) Quota {
+func (pcr QuotaLists) OptimalValues(ratio float64, minQuotas Quota, maxQuotas Quota) Quota {
 	// Calculate resources with 3 different approaches and select largest value
 	approaches := NewQuotaLists()
 	approaches.Append(pcr.Sum().Resized(ratio))

--- a/internal/quota/quotalists_test.go
+++ b/internal/quota/quotalists_test.go
@@ -35,17 +35,17 @@ var (
 			"block":  resource.MustParse("100Gi"),
 		},
 	}
-	sum_cpu            int64 = 12000
-	sum_memory         int64 = 30 * GiB
-	min_cpu            int64 = 3000
-	min_memory         int64 = 6 * GiB
-	max_cpu            int64 = 6000
-	max_memory         int64 = 12 * GiB
-	largest_two_cpu    int64 = 9000
-	largest_two_memory int64 = 24 * GiB
-	ratio              int64 = 70 // 70%
-	optimal_shared     int64 = 100 * GiB
-	optimal_block      int64 = 210 * GiB
+	sum_cpu            int64   = 12000
+	sum_memory         int64   = 30 * GiB
+	min_cpu            int64   = 3000
+	min_memory         int64   = 6 * GiB
+	max_cpu            int64   = 6000
+	max_memory         int64   = 12 * GiB
+	largest_two_cpu    int64   = 9000
+	largest_two_memory int64   = 24 * GiB
+	ratio              float64 = 0.7 // 70%
+	optimal_shared     int64   = 100 * GiB
+	optimal_block      int64   = 210 * GiB
 
 	minQuota = map[corev1.ResourceName]resource.Quantity{
 		"cpu": resource.MustParse("10"),

--- a/internal/quota/quotas.go
+++ b/internal/quota/quotas.go
@@ -18,10 +18,10 @@ func (pq Quota) MergeWith(targetQuota map[corev1.ResourceName]resourcev1.Quantit
 	return q
 }
 
-func (pq Quota) Resized(scale int64) (q Quota) {
+func (pq Quota) Resized(scale float64) (q Quota) {
 	q = make(Quota)
 	for key, value := range pq {
-		resized := value.AsApproximateFloat64() * (float64(scale) / 100)
+		resized := value.AsApproximateFloat64() * scale
 		q[key] = *(resourcev1.NewQuantity(int64(resized), value.Format))
 	}
 	return q

--- a/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
@@ -149,6 +149,9 @@ spec:
                         ratio:
                           description: The ratio of the requested quota which will
                             be applied to the total quota
+                          format: float
+                          maximum: 1
+                          minimum: 0
                           type: number
                       required:
                       - defaults

--- a/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
@@ -149,6 +149,7 @@ spec:
                         ratio:
                           description: The ratio of the requested quota which will
                             be applied to the total quota
+                          type: number
                       required:
                       - defaults
                       type: object

--- a/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crds/cpet.belastingdienst.nl_paasconfig.yaml
@@ -149,8 +149,6 @@ spec:
                         ratio:
                           description: The ratio of the requested quota which will
                             be applied to the total quota
-                          format: int64
-                          type: integer
                       required:
                       - defaults
                       type: object

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -121,7 +121,7 @@ var examplePaasConfig = v1alpha1.PaasConfig{
 						corev1.ResourceLimitsCPU:    resourcev1.MustParse("1"),
 						corev1.ResourceLimitsMemory: resourcev1.MustParse("1Gi"),
 					},
-					Ratio: 10,
+					Ratio: 0.1,
 				},
 			},
 			"sso": {


### PR DESCRIPTION
Fixes an incorrect conversion from float64 to int64 by reverting to using float64.

## Pull Request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In the earlier change to using PaasConfig, we replaced the use of float64 for a resource ratio by an int64. This resulted in an incorrect conversion and as such opted to keep using float64 since extreme precision is not required here.

## What is the new behavior?

Use a float64 for ratio in PaasConfig.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
