### PR TITLE
ci: Make make run-operator idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,9 @@ setup-e2e: kustomize ## Setup test environment in the K8s cluster specified in ~
 run-operator:
 	# Clean start
 	killall goreman || true
-	kubectl create namespace paas-system
+	@kubectl get namespace paas-system >/dev/null 2>&1 || kubectl create namespace paas-system
 	kubectl apply -f manifests/config/example-keys.yaml
 	goreman -f $(PAAS_PROCFILE) start
-	kubectl delete namespace paas-system
 
 ##@ Build
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

Running `make run-operator` twice results in an error as the `paas-system` namespace isn't removed and creating an already existing namespace results in an error as well

## What is the new behavior?

Running `make run-operator` is idempotent

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->