### PR TITLE
fix: User groups per Paas

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -202,6 +202,16 @@ func (pgs PaasGroups) Names() (groups []string) {
 	return groups
 }
 
+func (p Paas) GroupKey2GroupName(groupKey string) string {
+	if group, exists := p.Spec.Groups[groupKey]; !exists {
+		return ""
+	} else if len(group.Query) > 0 {
+		return group.Name(groupKey)
+	} else {
+		return fmt.Sprintf("%s-%s", p.Name, p.Spec.Groups.Key2Name(groupKey))
+	}
+}
+
 func (pgs PaasGroups) LdapQueries() []string {
 	var queries []string
 	for _, group := range pgs {

--- a/api/v1alpha1/paas_types_test.go
+++ b/api/v1alpha1/paas_types_test.go
@@ -25,6 +25,9 @@ var testGroups = PaasGroups{
 		Query: "CN=test4",
 		Users: []string{"usr3", "usr2"},
 	},
+	"test": PaasGroup{
+		Users: []string{"usr3", "usr2"},
+	},
 }
 
 // Paas
@@ -89,7 +92,9 @@ func TestPaas_GetNsSshSecrets(t *testing.T) {
 
 func TestPaasGroups_Filtered(t *testing.T) {
 	pgs := PaasGroups{
-		"grp1": {},
+		"grp1": {
+			Query: "cn=test1,ou=org_unit,dc=example,dc=org",
+		},
 		"grp2": {},
 		"grp3": {},
 	}
@@ -163,16 +168,33 @@ func TestPaasGroups_Key2Name(t *testing.T) {
 }
 
 func TestPaasGroups_Keys(t *testing.T) {
-	assert.NotNil(t, "", testGroups.Keys())
+	assert.NotNil(t, testGroups.Keys(), "Keys not nill")
 	assert.Contains(t, testGroups.Keys(), "cn=test1")
 	assert.Contains(t, testGroups.Keys(), "cn=test3")
 	assert.NotContains(t, testGroups.Keys(), "cn=test4")
 }
 
+func TestPaas_GroupKey2GroupName(t *testing.T) {
+	paas := Paas{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "paas",
+		},
+		Spec: PaasSpec{
+			Groups: testGroups,
+		},
+	}
+	assert.Equal(t, "", paas.GroupKey2GroupName("testers"), "Key not present in Paas")
+	assert.NotNil(t, paas.GroupKey2GroupName("cn=test1"), "")
+	assert.Equal(t, "test2", paas.GroupKey2GroupName("cn=test1"), "cn=test1 is a query group thus returning Key2Name value.")
+	assert.NotNil(t, paas.GroupKey2GroupName("test"), "Test is a present")
+	assert.Equal(t, "paas-test", paas.GroupKey2GroupName("test"), "Test is a group of users thus prefixed by Paas name")
+}
+
 func TestPaasGroups_Names(t *testing.T) {
 	output := testGroups.Names()
 	assert.NotNil(t, output)
-	assert.Len(t, output, 2)
+	assert.Len(t, output, 3)
+	assert.Contains(t, output, "test")
 	assert.Contains(t, output, "test2")
 	assert.Contains(t, output, "test4")
 }
@@ -517,7 +539,6 @@ func Test_Paas_WithoutMe(t *testing.T) {
 }
 
 // compound tests
-
 func TestPaas_Namespaces(t *testing.T) {
 	paas := Paas{
 		ObjectMeta: metav1.ObjectMeta{

--- a/docs/user-guide/02_groups-and-users.md
+++ b/docs/user-guide/02_groups-and-users.md
@@ -4,7 +4,7 @@ summary: A short overview of defining authorization for users and groups
 authors:
   - hikarukin
   - devotional-phoenix-97
-date: 2025-01-20
+date: 2025-01-21
 ---
 
 ## Groups and Users
@@ -18,9 +18,9 @@ For more information on authorization, please see [Core Concepts - Authorization
 
 !!! Note
 
-    When both an LDAP query and a list of users is defined, the users from the list
-    are added in addition to the users from the LDAP group. If the user from the list
-    was already added through the LDAP group, the user is simply ignored.
+    When both an LDAP query and a list of users is defined, the LDAP query takes precedence
+    above the users. This because `oc adm group sync` overwrites / errors when there are already
+    users in the group which it believes it should create.
 
 !!! example
 
@@ -34,8 +34,6 @@ For more information on authorization, please see [Core Concepts - Authorization
         example_group:
           query: >-
             CN=example_group,OU=example,OU=UID,DC=example,DC=nl
-          users:
-            - jdsmith
         second_example_group:
           users:
             - jdsmith

--- a/internal/controller/clusterrolebindings.go
+++ b/internal/controller/clusterrolebindings.go
@@ -24,18 +24,17 @@ import (
 
 const crbNameFormat string = "paas-%s"
 
-// ensureClusterRoleBinding ensures ClusterRoleBindings to enable extra permissions for certain capabilities.
+// getClusterRoleBinding returns a ClusterRoleBinding to enable extra permissions for certain capabilities.
 func getClusterRoleBinding(
 	r client.Client,
 	ctx context.Context,
 	role string,
 ) (crb *rbac.ClusterRoleBinding, err error) {
-	// See if rolebinding exists and create if it doesn't
 	crbName := fmt.Sprintf(crbNameFormat, role)
 	found := &rbac.ClusterRoleBinding{}
 	err = r.Get(ctx, types.NamespacedName{Name: crbName}, found)
 	if err != nil && errors.IsNotFound(err) {
-		return newClusterRoleBinding(role), nil
+		return backendClusterRoleBinding(role), nil
 	} else if err != nil {
 		return nil, err
 	} else {
@@ -62,8 +61,8 @@ func updateClusterRoleBinding(
 	return nil
 }
 
-// backendRoleBinding is a code for Creating RoleBinding
-func newClusterRoleBinding(
+// backendClusterRoleBinding is a code for Creating RoleBinding
+func backendClusterRoleBinding(
 	role string,
 ) *rbac.ClusterRoleBinding {
 	crbName := fmt.Sprintf(crbNameFormat, role)
@@ -74,6 +73,7 @@ func newClusterRoleBinding(
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crbName,
+			// TODO are these labels still correct?
 			Labels: map[string]string{
 				"app.kubernetes.io/created-by": "opr-paas",
 				"app.kubernetes.io/part-of":    "opr-paas",

--- a/test/e2e/groupquery_test.go
+++ b/test/e2e/groupquery_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	GroupNameFormat          = "%s-%s"
 	paasWithGroupQuery       = "paas-group-query"
 	paasGroupQueryNamespace  = "group-query-ns"
 	paasGroupQueryAbsoluteNs = paasWithGroupQuery + "-" + paasGroupQueryNamespace
@@ -62,21 +63,22 @@ func TestGroupQuery(t *testing.T) {
 
 func assertGroupQueryCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	paas := getPaas(ctx, paasWithGroupQuery, t, cfg)
-	group := getOrFail(ctx, groupWithQueryName, cfg.Namespace(), &userv1.Group{}, t, cfg)
+	group := getOrFail(ctx, paas.GroupKey2GroupName(groupWithQueryName), cfg.Namespace(), &userv1.Group{}, t, cfg)
 	rolebinding := getOrFail(ctx, "paas-admin", paasGroupQueryAbsoluteNs, &rbacv1.RoleBinding{}, t, cfg)
 	rolebindingsPaas := listOrFail(ctx, paasWithGroupQuery, &rbacv1.RoleBindingList{}, t, cfg)
 
-	assert.Equal(t, groupWithQueryName, group.Name, "The group name should match the one defined in the Paas")
+	assert.Equal(t, paas.GroupKey2GroupName(groupWithQueryName), group.Name, "The group name should match the one defined in the query")
 	assert.Empty(t, group.Users, "No users should be defined in the group")
-	assert.Len(t, group.Labels, 1)
+	assert.Len(t, group.Labels, 2)
 	assert.Equal(t, "my-ldap-host", group.Labels["openshift.io/ldap.host"], "The correct label should be defined")
+	assert.Equal(t, "paas", group.Labels["app.kubernetes.io/managed-by"], "Labeled as managed by Paas")
 	assert.Equal(t, paas.UID, group.OwnerReferences[0].UID, "The owner of the group should be the Paas defining it")
 	assert.Len(t, rolebinding.Subjects, 1)
-	assert.Equal(t, groupWithQueryName, rolebinding.Subjects[0].Name, "The configured default RoleBinding should be set for the group")
+	assert.Equal(t, paas.GroupKey2GroupName(groupWithQueryName), rolebinding.Subjects[0].Name, "The configured default RoleBinding should be set for the group")
 	assert.Equal(t, "admin", rolebinding.RoleRef.Name, "The role in the Paas `rolemappings` configuration for the default role should be applied in the RoleBinding")
 	for _, rb := range rolebindingsPaas.Items {
 		for _, sub := range rb.Subjects {
-			assert.NotEqual(t, groupWithQueryName, sub.Name, "No RoleBindings should be set on the parent Paas")
+			assert.NotEqual(t, paas.GroupKey2GroupName(groupWithQueryName), sub.Name, "No RoleBindings should be set on the parent Paas")
 		}
 	}
 
@@ -85,9 +87,10 @@ func assertGroupQueryCreated(ctx context.Context, t *testing.T, cfg *envconf.Con
 
 func assertGroupQueryCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	paas := getPaas(ctx, paasWithGroupQuery, t, cfg)
-	group2Name := "aug-cet-queryviewrole"
-	paas.Spec.Groups[group2Name] = api.PaasGroup{
+	group2Key := "aug-cet-queryviewrole"
+	paas.Spec.Groups[group2Key] = api.PaasGroup{
 		Query: group2Query,
+		Users: []string{"foo", "bar"},
 		Roles: []string{"viewer"},
 	}
 
@@ -95,24 +98,26 @@ func assertGroupQueryCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *
 		t.Fatal(err)
 	}
 
-	group2 := getOrFail(ctx, group2Name, cfg.Namespace(), &userv1.Group{}, t, cfg)
+	group2 := getOrFail(ctx, paas.GroupKey2GroupName(group2Key), cfg.Namespace(), &userv1.Group{}, t, cfg)
 	rolebinding := getOrFail(ctx, "paas-view", paasGroupQueryAbsoluteNs, &rbacv1.RoleBinding{}, t, cfg)
 	rolebindingsPaas := listOrFail(ctx, paasWithGroupQuery, &rbacv1.RoleBindingList{}, t, cfg)
 
-	assert.Equal(t, group2Name, group2.Name, "The group name should match the one defined in the Paas")
+	// 123
+	assert.Equal(t, paas.GroupKey2GroupName(group2Key), group2.Name, "The group name should match the one defined in the Paas")
 	assert.Empty(t, group2.Users, "No users should be defined in the group")
-	assert.Len(t, group2.Labels, 1, "Group should contain one label")
+	assert.Len(t, group2.Labels, 2, "Group should contain two labels")
 	assert.Equal(t, "my-ldap-host", group2.Labels["openshift.io/ldap.host"], "The ldap.host label should contain PaasConfig value")
+	assert.Equal(t, "paas", group2.Labels["app.kubernetes.io/managed-by"], "Labeled as managed by Paas")
 	assert.Len(t, group2.Annotations, 2, "Group should have 2 annotations")
 	assert.Equal(t, group2Query, group2.Annotations["openshift.io/ldap.uid"], "The ldap.uid annotation should contain group.query value")
 	assert.Equal(t, "my-ldap-host:13", group2.Annotations["openshift.io/ldap.url"], "The ldap.url annotation should contain PaasConfig value")
 	assert.Equal(t, paas.UID, group2.OwnerReferences[0].UID, "The owner of the group should be the Paas defining it")
 	assert.Len(t, rolebinding.Subjects, 1)
-	assert.Equal(t, group2Name, rolebinding.Subjects[0].Name, "A RoleBinding for the passed 'viewer' role should be set for the group")
+	assert.Equal(t, paas.GroupKey2GroupName(group2Key), rolebinding.Subjects[0].Name, "A RoleBinding for the passed 'viewer' role should be set for the group")
 	assert.Equal(t, "view", rolebinding.RoleRef.Name, "The role in the Paas `rolemappings` configuration for the passed 'viewer' role should be applied in the RoleBinding")
 	for _, rb := range rolebindingsPaas.Items {
 		for _, sub := range rb.Subjects {
-			assert.NotEqual(t, group2Name, sub.Name, "No RoleBindings should be set on the parent Paas")
+			assert.NotEqual(t, paas.GroupKey2GroupName(group2Key), sub.Name, "No RoleBindings should be set on the parent Paas")
 		}
 	}
 
@@ -122,7 +127,6 @@ func assertGroupQueryCreatedAfterUpdate(ctx context.Context, t *testing.T, cfg *
 func assertGroupKeyAndNameDifferenceIsOk(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	paas := getPaas(ctx, paasWithGroupQuery, t, cfg)
 	group3Key := "aug-cet-group3key"
-	group3Name := "different"
 	paas.Spec.Groups[group3Key] = api.PaasGroup{
 		Query: "CN=different",
 		Roles: []string{"viewer"},
@@ -133,19 +137,19 @@ func assertGroupKeyAndNameDifferenceIsOk(ctx context.Context, t *testing.T, cfg 
 	}
 
 	failWhenExists(ctx, group3Key, cfg.Namespace(), &userv1.Group{}, t, cfg)
-	_ = getOrFail(ctx, group3Name, cfg.Namespace(), &userv1.Group{}, t, cfg)
+	_ = getOrFail(ctx, paas.GroupKey2GroupName(group3Key), cfg.Namespace(), &userv1.Group{}, t, cfg)
 	rolebinding := getOrFail(ctx, "paas-view", paasGroupQueryAbsoluteNs, &rbacv1.RoleBinding{}, t, cfg)
 	rolebindingsPaas := listOrFail(ctx, paasWithGroupQuery, &rbacv1.RoleBindingList{}, t, cfg)
 
 	expectedSubject := rbacv1.Subject{
 		Kind:     "Group",
-		APIGroup: "rbac.authorization.k8s.io", Name: group3Name,
+		APIGroup: "rbac.authorization.k8s.io", Name: paas.GroupKey2GroupName(group3Key),
 	}
 	assert.Contains(t, rolebinding.Subjects, expectedSubject, "A RoleBinding for the passed 'viewer' role should be set for the group")
 	assert.Equal(t, "view", rolebinding.RoleRef.Name, "The role in the Paas `rolemappings` configuration for the passed 'viewer' role should be applied in the RoleBinding")
 	for _, rb := range rolebindingsPaas.Items {
 		for _, sub := range rb.Subjects {
-			assert.NotEqual(t, group3Name, sub.Name, "No RoleBindings should be set on the parent Paas")
+			assert.NotEqual(t, paas.GroupKey2GroupName(group3Key), sub.Name, "No RoleBindings should be set on the parent Paas")
 		}
 	}
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

1. Groups, both with users and LDAP groups, are clusterwide. Possible referenced by multiple Paas'es. When users groups have the same key across Paas'es on one cluster, users of one Paas can possibly access the namespaces of other Paas'es.
2. When one of the multiple Paas'es from 1. has been removed, the users aren't updated so there is still the possibility to access the other Paas.
3. Technically it is possible to specify a group with users and a query. This results in unexpected behaviour as the OpenShift groupsync will remove the users added by Paas.

* Fixes #289
* Fixes #285

## What is the new behavior?

1. Group spec containing only users, results into an OpenShift group, prefixed by the Paas name, as is done with namespaces. In this way, groups are made unique.
2. If a group spec contains both users and a query, only the query will be added, to prevent unexpected OpenShift GroupSync behaviour.
 
* Stops potential err swallowed in ReconcileRoleBindings
* Stops potential err swallowed in Groups
* Uses a labelselector to list groups, relates to discussion in #176
* Updates docs accordingly

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->