### PR TITLE
fix: Set correct groupNames in ArgoCD after redesigning the groupNames

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -212,6 +212,13 @@ func (p Paas) GroupKey2GroupName(groupKey string) string {
 	}
 }
 
+func (p Paas) GroupNames() (groupNames []string) {
+	for groupKey := range p.Spec.Groups {
+		groupNames = append(groupNames, p.GroupKey2GroupName(groupKey))
+	}
+	return groupNames
+}
+
 func (pgs PaasGroups) LdapQueries() []string {
 	var queries []string
 	for _, group := range pgs {

--- a/api/v1alpha1/paas_types_test.go
+++ b/api/v1alpha1/paas_types_test.go
@@ -190,6 +190,22 @@ func TestPaas_GroupKey2GroupName(t *testing.T) {
 	assert.Equal(t, "paas-test", paas.GroupKey2GroupName("test"), "Test is a group of users thus prefixed by Paas name")
 }
 
+func TestPaas_GroupNames(t *testing.T) {
+	paas := Paas{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "paas",
+		},
+		Spec: PaasSpec{
+			Groups: testGroups,
+		},
+	}
+	groupNames := paas.GroupNames()
+	assert.Len(t, groupNames, 3, "Three group names found")
+	assert.Contains(t, groupNames, "test2", "cn=test1 is a query group thus returning Key2Name value.")
+	assert.Contains(t, groupNames, "paas-test", "Test is a group of users thus prefixed by Paas name")
+	assert.Contains(t, groupNames, "test4", "cn=test3 is a query group thus returning Key2Name value.")
+}
+
 func TestPaasGroups_Names(t *testing.T) {
 	output := testGroups.Names()
 	assert.NotNil(t, output)

--- a/internal/controller/argocd.go
+++ b/internal/controller/argocd.go
@@ -32,7 +32,7 @@ func (r *PaasReconciler) EnsureArgoCD(
 	namespace := fmt.Sprintf("%s-%s", paas.Name, "argocd")
 
 	defaultPolicy := GetConfig().ArgoPermissions.DefaultPolicy
-	policy := GetConfig().ArgoPermissions.FromGroups(paas.Spec.Groups.Names())
+	policy := GetConfig().ArgoPermissions.FromGroups(paas.GroupNames())
 	scopes := "[groups]"
 
 	argo := &argocd.ArgoCD{


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

After merging #301 the groups added to ArgoCD permissions aren't the groupNames as created by the groupcontroller. So none existent groups where added to ArgoCD. When teams upgrade their Paas operator, possible loose their permission to ArgoCD.

## What is the new behavior?

Implement a new func to retrieve all groupNames from a Paas perspective.
Use that func to set groupNames in the Argopermissions block.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->