### PR TITLE
feat: add configurable CORS settings, CSP and nosniff

### DIFF
--- a/cmd/webservice/check_paas_test.go
+++ b/cmd/webservice/check_paas_test.go
@@ -1,17 +1,27 @@
+/*
+Copyright 2025, Tax Administration of The Netherlands.
+Licensed under the EUPL 1.2.
+See LICENSE.md for details.
+*/
+
 package main
 
 import (
 	"os"
 	"testing"
 
-	v1alpha1 "github.com/belastingdienst/opr-paas/api/v1alpha1"
-	"github.com/belastingdienst/opr-paas/internal/crypt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	v1alpha1 "github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/crypt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCheckPaas(t *testing.T) {
+	// Allow all origins for testing
+	t.Setenv(allowedAllOriginsEnv, "true")
+
 	// generate private/public keys
 	priv, err := os.CreateTemp("", "private")
 	require.NoError(t, err, "Creating tempfile for private key")

--- a/cmd/webservice/check_paas_test.go
+++ b/cmd/webservice/check_paas_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestCheckPaas(t *testing.T) {
 	// Allow all origins for testing
-	t.Setenv(allowedAllOriginsEnv, "true")
+	t.Setenv(allowedOriginsEnv, "*")
 
 	// generate private/public keys
 	priv, err := os.CreateTemp("", "private")

--- a/cmd/webservice/config.go
+++ b/cmd/webservice/config.go
@@ -15,19 +15,23 @@ import (
 )
 
 const (
-	publicEnv           = "PAAS_PUBLIC_KEY_PATH"
-	privateKeyEnv       = "PAAS_PRIVATE_KEYS_PATH"
-	defaultPublicPath   = "/secrets/paas/publicKey"
-	defaultPrivatePath  = "/secrets/paas/privateKeys"
-	endpointEnv         = "PAAS_ENDPOINT"
-	defaultEndpointPort = 8080
+	publicEnv            = "PAAS_PUBLIC_KEY_PATH"
+	privateKeyEnv        = "PAAS_PRIVATE_KEYS_PATH"
+	defaultPublicPath    = "/secrets/paas/publicKey"
+	defaultPrivatePath   = "/secrets/paas/privateKeys"
+	endpointEnv          = "PAAS_ENDPOINT"
+	defaultEndpointPort  = 8080
+	allowedOriginEnv     = "PAAS_WS_ALLOWED_ORIGIN"
+	allowedAllOriginsEnv = "PAAS_WS_ALLOW_ALL_ORIGINS"
 )
 
 type WSConfig struct {
 	PublicKeyPath string
 	// comma separated list of privateKeyPaths
-	PrivateKeyPath string
-	Endpoint       string
+	PrivateKeyPath  string
+	Endpoint        string
+	AllowedOrigin   string
+	AllowAllOrigins string
 }
 
 func formatEndpoint(endpoint string) string {
@@ -68,17 +72,36 @@ func formatEndpoint(endpoint string) string {
 	return fmt.Sprintf("%s:%d", endpoint, defaultEndpointPort)
 }
 
-func NewWSConfig() WSConfig {
-	var config WSConfig
+func NewWSConfig() (config WSConfig) {
+
 	config.PublicKeyPath = os.Getenv(publicEnv)
 	if config.PublicKeyPath == "" {
 		config.PublicKeyPath = defaultPublicPath
 	}
+
 	config.PrivateKeyPath = os.Getenv(privateKeyEnv)
 	if config.PrivateKeyPath == "" {
 		config.PrivateKeyPath = defaultPrivatePath
 	}
+
 	config.Endpoint = formatEndpoint(os.Getenv(endpointEnv))
+	config.AllowedOrigin = os.Getenv(allowedOriginEnv)
+	config.AllowAllOrigins = os.Getenv(allowedAllOriginsEnv)
 
 	return config
+}
+
+func (config WSConfig) Validate() (valid bool, msg string) {
+
+	if !strings.EqualFold(config.AllowAllOrigins, "true") {
+		if config.AllowedOrigin == "" {
+			return false, "must specify an origin if allowAllOrigins is not set to true"
+		}
+
+		if !strings.Contains(config.AllowedOrigin, "http://") && !strings.Contains(config.AllowedOrigin, "https://") {
+			return false, "must contain either http:// or https:// for AllowedOrigin"
+		}
+	}
+
+	return true, "no issues detected"
 }

--- a/cmd/webservice/config.go
+++ b/cmd/webservice/config.go
@@ -73,7 +73,6 @@ func formatEndpoint(endpoint string) string {
 }
 
 func NewWSConfig() (config WSConfig) {
-
 	config.PublicKeyPath = os.Getenv(publicEnv)
 	if config.PublicKeyPath == "" {
 		config.PublicKeyPath = defaultPublicPath
@@ -92,7 +91,6 @@ func NewWSConfig() (config WSConfig) {
 }
 
 func (config WSConfig) Validate() (valid bool, msg string) {
-
 	if !strings.EqualFold(config.AllowAllOrigins, "true") {
 		if config.AllowedOrigin == "" {
 			return false, "must specify an origin if allowAllOrigins is not set to true"

--- a/cmd/webservice/config_test.go
+++ b/cmd/webservice/config_test.go
@@ -30,41 +30,41 @@ func (s *ConfigTestSuite) TestCorsConfiguration() {
 	s.Run("must not validate with empty AllowAllOrigins and empty AllowedOrigin", func() {
 		config := NewWSConfig()
 
-		assert.Empty(s.T(), config.AllowAllOrigins)
-		assert.Empty(s.T(), config.AllowedOrigin)
+		s.Empty(config.AllowAllOrigins)
+		s.Empty(config.AllowedOrigin)
 
 		valid, msg := config.Validate()
-		assert.False(s.T(), valid)
-		assert.Equal(s.T(), "must specify an origin if allowAllOrigins is not set to true", msg)
+		s.False(valid)
+		s.Equal("must specify an origin if allowAllOrigins is not set to true", msg)
 	})
 
 	s.Run("must validate with AllowAllOrigins is true", func() {
 		config := NewWSConfig()
 
 		config.AllowAllOrigins = "true"
-		assert.Empty(s.T(), config.AllowedOrigin)
+		s.Empty(config.AllowedOrigin)
 
 		valid, msg := config.Validate()
-		assert.True(s.T(), valid)
-		assert.Equal(s.T(), "no issues detected", msg)
+		s.True(valid)
+		s.Equal("no issues detected", msg)
 
 		config.AllowedOrigin = "http://www.example.com"
-		assert.NotEmpty(s.T(), config.AllowedOrigin)
+		s.NotEmpty(config.AllowedOrigin)
 
 		_, msg = config.Validate()
-		assert.Equal(s.T(), "no issues detected", msg)
+		s.Equal("no issues detected", msg)
 	})
 
 	s.Run("must validate with AllowAllOrigins not true and AllowedOrigin set", func() {
 		config := NewWSConfig()
 		config.AllowedOrigin = "http://www.example.com"
 
-		assert.Empty(s.T(), config.AllowAllOrigins)
-		assert.NotEmpty(s.T(), config.AllowedOrigin)
+		s.Empty(config.AllowAllOrigins)
+		s.NotEmpty(config.AllowedOrigin)
 
 		valid, msg := config.Validate()
-		assert.True(s.T(), valid)
-		assert.Equal(s.T(), "no issues detected", msg)
+		s.True(valid)
+		s.Equal("no issues detected", msg)
 	})
 }
 

--- a/cmd/webservice/config_test.go
+++ b/cmd/webservice/config_test.go
@@ -11,7 +11,65 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
+
+type ConfigTestSuite struct {
+	suite.Suite
+	// add fields if needed
+}
+
+func (s *ConfigTestSuite) SetupTest() {
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}
+
+func (s *ConfigTestSuite) TestCorsConfiguration() {
+
+	s.T().Run("must not validate with empty AllowAllOrigins and empty AllowedOrigin", func(t *testing.T) {
+		config := NewWSConfig()
+
+		assert.Empty(t, config.AllowAllOrigins)
+		assert.Empty(t, config.AllowedOrigin)
+
+		valid, msg := config.Validate()
+		assert.False(t, valid)
+		assert.Equal(t, "must specify an origin if allowAllOrigins is not set to true", msg)
+
+	})
+
+	s.T().Run("must validate with AllowAllOrigins is true", func(t *testing.T) {
+		config := NewWSConfig()
+
+		config.AllowAllOrigins = "true"
+		assert.Empty(t, config.AllowedOrigin)
+
+		valid, msg := config.Validate()
+		assert.True(t, valid)
+		assert.Equal(t, "no issues detected", msg)
+
+		config.AllowedOrigin = "http://www.example.com"
+		assert.NotEmpty(t, config.AllowedOrigin)
+
+		valid, msg = config.Validate()
+		assert.Equal(t, "no issues detected", msg)
+
+	})
+
+	s.T().Run("must validate with AllowAllOrigins not true and AllowedOrigin set", func(t *testing.T) {
+		config := NewWSConfig()
+		config.AllowedOrigin = "http://www.example.com"
+
+		assert.Empty(t, config.AllowAllOrigins)
+		assert.NotEmpty(t, config.AllowedOrigin)
+
+		valid, msg := config.Validate()
+		assert.True(t, valid)
+		assert.Equal(t, "no issues detected", msg)
+	})
+}
 
 func Test_formatEndpoint(t *testing.T) {
 	// test: empty endpoint

--- a/cmd/webservice/config_test.go
+++ b/cmd/webservice/config_test.go
@@ -27,47 +27,44 @@ func TestConfigTestSuite(t *testing.T) {
 }
 
 func (s *ConfigTestSuite) TestCorsConfiguration() {
-
-	s.T().Run("must not validate with empty AllowAllOrigins and empty AllowedOrigin", func(t *testing.T) {
+	s.Run("must not validate with empty AllowAllOrigins and empty AllowedOrigin", func() {
 		config := NewWSConfig()
 
-		assert.Empty(t, config.AllowAllOrigins)
-		assert.Empty(t, config.AllowedOrigin)
+		assert.Empty(s.T(), config.AllowAllOrigins)
+		assert.Empty(s.T(), config.AllowedOrigin)
 
 		valid, msg := config.Validate()
-		assert.False(t, valid)
-		assert.Equal(t, "must specify an origin if allowAllOrigins is not set to true", msg)
-
+		assert.False(s.T(), valid)
+		assert.Equal(s.T(), "must specify an origin if allowAllOrigins is not set to true", msg)
 	})
 
-	s.T().Run("must validate with AllowAllOrigins is true", func(t *testing.T) {
+	s.Run("must validate with AllowAllOrigins is true", func() {
 		config := NewWSConfig()
 
 		config.AllowAllOrigins = "true"
-		assert.Empty(t, config.AllowedOrigin)
+		assert.Empty(s.T(), config.AllowedOrigin)
 
 		valid, msg := config.Validate()
-		assert.True(t, valid)
-		assert.Equal(t, "no issues detected", msg)
+		assert.True(s.T(), valid)
+		assert.Equal(s.T(), "no issues detected", msg)
 
 		config.AllowedOrigin = "http://www.example.com"
-		assert.NotEmpty(t, config.AllowedOrigin)
+		assert.NotEmpty(s.T(), config.AllowedOrigin)
 
-		valid, msg = config.Validate()
-		assert.Equal(t, "no issues detected", msg)
-
+		_, msg = config.Validate()
+		assert.Equal(s.T(), "no issues detected", msg)
 	})
 
-	s.T().Run("must validate with AllowAllOrigins not true and AllowedOrigin set", func(t *testing.T) {
+	s.Run("must validate with AllowAllOrigins not true and AllowedOrigin set", func() {
 		config := NewWSConfig()
 		config.AllowedOrigin = "http://www.example.com"
 
-		assert.Empty(t, config.AllowAllOrigins)
-		assert.NotEmpty(t, config.AllowedOrigin)
+		assert.Empty(s.T(), config.AllowAllOrigins)
+		assert.NotEmpty(s.T(), config.AllowedOrigin)
 
 		valid, msg := config.Validate()
-		assert.True(t, valid)
-		assert.Equal(t, "no issues detected", msg)
+		assert.True(s.T(), valid)
+		assert.Equal(s.T(), "no issues detected", msg)
 	})
 }
 

--- a/cmd/webservice/main.go
+++ b/cmd/webservice/main.go
@@ -201,10 +201,10 @@ func SetupRouter() *gin.Engine {
 	}
 
 	// Insert a middleware to set the X-Content-Type-Options header.
-	// router.Use(func(c *gin.Context) {
-	// 	c.Header("X-Content-Type-Options", "nosniff")
-	// 	c.Next()
-	// })
+	router.Use(func(c *gin.Context) {
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Next()
+	})
 
 	router.GET("/version", version)
 	router.POST("/v1/encrypt", v1Encrypt)

--- a/cmd/webservice/main_test.go
+++ b/cmd/webservice/main_test.go
@@ -131,6 +131,17 @@ func Test_getRSA(t *testing.T) {
 	assert.Len(t, encrypted, 684)
 }
 
+func TestNoSniffIsSet(t *testing.T) {
+	// Allow all origins for test
+	t.Setenv(allowedOriginsEnv, "*")
+
+	router := SetupRouter()
+	w := performRequest(router, "GET", "/version")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, w.Header().Get("X-Content-Type-Options"), "nosniff")
+
+}
+
 func Test_version(t *testing.T) {
 	// Allow all origins for test
 	t.Setenv(allowedOriginsEnv, "*")

--- a/cmd/webservice/main_test.go
+++ b/cmd/webservice/main_test.go
@@ -33,6 +33,9 @@ func performRequest(r http.Handler, method, path string) *httptest.ResponseRecor
 }
 
 func Test_getConfig(t *testing.T) {
+	// Allow all origins for test
+	t.Setenv(allowedAllOriginsEnv, "true")
+
 	// Reset config if any test before set config
 	_config = nil
 	_crypt = nil
@@ -46,8 +49,10 @@ func Test_getConfig(t *testing.T) {
 	assert.Equal(t, "/secrets/paas/publicKey", config.PublicKeyPath)
 
 	_config = &WSConfig{
-		PublicKeyPath: "/some/weird/path",
-		Endpoint:      ":3000",
+		PublicKeyPath:   "/some/weird/path",
+		Endpoint:        ":3000",
+		AllowAllOrigins: "false",
+		AllowedOrigin:   "http://example.com",
 	}
 
 	config = getConfig()
@@ -61,6 +66,9 @@ func Test_getConfig(t *testing.T) {
 }
 
 func Test_getRSA(t *testing.T) {
+	// Allow all origins for test
+	t.Setenv(allowedAllOriginsEnv, "true")
+
 	// Reset config if any test before set config
 	_config = nil
 	_crypt = nil
@@ -125,6 +133,9 @@ func Test_getRSA(t *testing.T) {
 }
 
 func Test_version(t *testing.T) {
+	// Allow all origins for test
+	t.Setenv(allowedAllOriginsEnv, "true")
+
 	expected := gin.H{
 		"version": v.PaasVersion,
 	}
@@ -143,6 +154,9 @@ func Test_version(t *testing.T) {
 }
 
 func Test_healthz(t *testing.T) {
+	// Allow all origins for test
+	t.Setenv(allowedAllOriginsEnv, "true")
+
 	expected := gin.H{
 		"message": "healthy",
 	}
@@ -161,6 +175,9 @@ func Test_healthz(t *testing.T) {
 }
 
 func Test_readyz(t *testing.T) {
+	// Allow all origins for test
+	t.Setenv(allowedAllOriginsEnv, "true")
+
 	expected := gin.H{
 		"message": "ready",
 	}
@@ -179,6 +196,9 @@ func Test_readyz(t *testing.T) {
 }
 
 func Test_v1CheckPaas(t *testing.T) {
+	// Allow all origins for test
+	t.Setenv(allowedAllOriginsEnv, "true")
+
 	// Reset config if any test before set config
 	_config = nil
 	_crypt = nil
@@ -268,6 +288,9 @@ func Test_v1CheckPaas(t *testing.T) {
 }
 
 func Test_v1CheckPaasInternalServerError(t *testing.T) {
+	// Allow all origins for test
+	t.Setenv(allowedAllOriginsEnv, "true")
+
 	// Reset config if any test before get config
 	_config = nil
 	_crypt = nil

--- a/cmd/webservice/main_test.go
+++ b/cmd/webservice/main_test.go
@@ -138,8 +138,7 @@ func TestNoSniffIsSet(t *testing.T) {
 	router := SetupRouter()
 	w := performRequest(router, "GET", "/version")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, w.Header().Get("X-Content-Type-Options"), "nosniff")
-
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 }
 
 func Test_version(t *testing.T) {

--- a/cmd/webservice/main_test.go
+++ b/cmd/webservice/main_test.go
@@ -34,7 +34,7 @@ func performRequest(r http.Handler, method, path string) *httptest.ResponseRecor
 
 func Test_getConfig(t *testing.T) {
 	// Allow all origins for test
-	t.Setenv(allowedAllOriginsEnv, "true")
+	t.Setenv(allowedOriginsEnv, "*")
 
 	// Reset config if any test before set config
 	_config = nil
@@ -49,10 +49,9 @@ func Test_getConfig(t *testing.T) {
 	assert.Equal(t, "/secrets/paas/publicKey", config.PublicKeyPath)
 
 	_config = &WSConfig{
-		PublicKeyPath:   "/some/weird/path",
-		Endpoint:        ":3000",
-		AllowAllOrigins: "false",
-		AllowedOrigin:   "http://example.com",
+		PublicKeyPath:  "/some/weird/path",
+		Endpoint:       ":3000",
+		AllowedOrigins: []string{"http://example.com"},
 	}
 
 	config = getConfig()
@@ -67,7 +66,7 @@ func Test_getConfig(t *testing.T) {
 
 func Test_getRSA(t *testing.T) {
 	// Allow all origins for test
-	t.Setenv(allowedAllOriginsEnv, "true")
+	t.Setenv(allowedOriginsEnv, "*")
 
 	// Reset config if any test before set config
 	_config = nil
@@ -134,7 +133,7 @@ func Test_getRSA(t *testing.T) {
 
 func Test_version(t *testing.T) {
 	// Allow all origins for test
-	t.Setenv(allowedAllOriginsEnv, "true")
+	t.Setenv(allowedOriginsEnv, "*")
 
 	expected := gin.H{
 		"version": v.PaasVersion,
@@ -155,7 +154,7 @@ func Test_version(t *testing.T) {
 
 func Test_healthz(t *testing.T) {
 	// Allow all origins for test
-	t.Setenv(allowedAllOriginsEnv, "true")
+	t.Setenv(allowedOriginsEnv, "*")
 
 	expected := gin.H{
 		"message": "healthy",
@@ -176,7 +175,7 @@ func Test_healthz(t *testing.T) {
 
 func Test_readyz(t *testing.T) {
 	// Allow all origins for test
-	t.Setenv(allowedAllOriginsEnv, "true")
+	t.Setenv(allowedOriginsEnv, "*")
 
 	expected := gin.H{
 		"message": "ready",
@@ -197,7 +196,7 @@ func Test_readyz(t *testing.T) {
 
 func Test_v1CheckPaas(t *testing.T) {
 	// Allow all origins for test
-	t.Setenv(allowedAllOriginsEnv, "true")
+	t.Setenv(allowedOriginsEnv, "*")
 
 	// Reset config if any test before set config
 	_config = nil
@@ -289,7 +288,7 @@ func Test_v1CheckPaas(t *testing.T) {
 
 func Test_v1CheckPaasInternalServerError(t *testing.T) {
 	// Allow all origins for test
-	t.Setenv(allowedAllOriginsEnv, "true")
+	t.Setenv(allowedOriginsEnv, "*")
 
 	// Reset config if any test before get config
 	_config = nil
@@ -317,4 +316,14 @@ func Test_v1CheckPaasInternalServerError(t *testing.T) {
 
 	assert.Equal(t, 500, w.Code)
 	assert.Equal(t, "", w.Body.String())
+}
+
+func TestBuildCSP(t *testing.T) {
+	externalHosts := ""
+	expected := "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'; font-src 'self'; object-src 'none'"
+	assert.Equal(t, expected, buildCSP(externalHosts))
+
+	externalHosts = "http://example.com"
+	expected = "default-src 'none'; script-src 'self' http://example.com; style-src 'self' http://example.com; img-src 'self' http://example.com; connect-src 'self' http://example.com; font-src 'self' http://example.com; object-src 'none'"
+	assert.Equal(t, expected, buildCSP(externalHosts))
 }


### PR DESCRIPTION
This PR adds configurable settings (through ENV vars) for CORS. It will allow you to either allow all origins, or list or origins. Also sets CSP. This also adds related tests.

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

All origins are allowed, hardcoded.

## What is the new behavior?

Adds:

- configurable allowed list of origins, -OR-;
- allowed all origins;
- improved allowance of methods;
- improved allowance of headers;
- add `X-Content-Type-Options: nosniff` header;
- add CSP based on allowed origins;

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

After upgrade, setting `PAAS_WS_ALLOWED_ORIGINS` is required. Failure to do so will result in an error.