### PR TITLE
fix: Updates to a Paas reconciles appSetCaps

### DIFF
--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -298,10 +298,7 @@ func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *PaasReconciler) finalizePaas(ctx context.Context, paas *v1alpha1.Paas) error {
 	logger := log.Ctx(ctx)
 	logger.Debug().Msg("inside Paas finalizer")
-	if err := r.finalizeAppSetCaps(ctx, paas); err != nil {
-		logger.Err(err).Msg("appSet finalizer error")
-		return err
-	} else if err = r.FinalizeClusterQuotas(ctx, paas); err != nil {
+	if err := r.FinalizeClusterQuotas(ctx, paas); err != nil {
 		logger.Err(err).Msg("quota finalizer error")
 		return err
 	} else if err = r.FinalizeGroups(ctx, paas); err != nil {

--- a/internal/controller/paasns_controller.go
+++ b/internal/controller/paasns_controller.go
@@ -382,6 +382,15 @@ func (r *PaasNSReconciler) finalizePaasNs(ctx context.Context, paasns *v1alpha1.
 	ctx = setLogComponent(ctx, "paasns")
 	logger := log.Ctx(ctx)
 
+	config := GetConfig()
+	// If PaasNs is related to a capability, remove it from appSet
+	if _, exists := config.Capabilities[paasns.Name]; exists {
+		if err := r.finalizeAppSetCap(ctx, paasns); err != nil {
+			err = fmt.Errorf("cannot remove paas from capability ApplicationSet belonging to Paas %s: %s", paasns.Spec.Paas, err.Error())
+			return err
+		}
+	}
+
 	paas, nss, err := r.paasFromPaasNs(ctx, paasns)
 	if err != nil {
 		err = fmt.Errorf("cannot find Paas %s: %s", paasns.Spec.Paas, err.Error())


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

After merging #231 , removing a capability from a Paas'es doesn't update the appSetCap

## What is the new behavior?

Removes appsetcap on updating a Paas, by moving finalizing of appSetcaps back to the PaasNs controller. As removing a capability, also removes the PaasNs, thus triggering finalizing of the PaasNs, thus removing the appSetCap

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->