### PR TITLE
chore: add example CORS origin to deployment manifest

### DIFF
--- a/docs/administrators-guide/sshSecrets.md
+++ b/docs/administrators-guide/sshSecrets.md
@@ -74,14 +74,14 @@ Another option is to run the webservice. To enable the webservice enable the web
 After that you can replace the publicKey data in the paas-sshsecrets-publickey ConfigMap,
 k8s changes the mount and the webservice automatically picks up the file changes and uses the new key.
 
-!!! warning
+!!! warning "Warning: starting v1.4.0"
 
-    When deploying the webservice application, you will be required to add an environment
-    variable called `PAAS_WS_ALLOWED_ORIGINS` in which you either give `*` or one or more
-    CORS related origins, comman separated.
+    When deploying the webservice, you will be required to add an environment variable
+    called `PAAS_WS_ALLOWED_ORIGINS` in which you either give `*` or one or more
+    CORS related origins, comma separated.
 
-    By default, the webservice will be deployed using `http://www.example.com` as a value
-    and will not work for you.
+    By default, the webservice will be deployed using `http://www.example.com` as
+    a value. This will not work for you.
 
 ### Reencryption
 

--- a/docs/administrators-guide/sshSecrets.md
+++ b/docs/administrators-guide/sshSecrets.md
@@ -74,6 +74,15 @@ Another option is to run the webservice. To enable the webservice enable the web
 After that you can replace the publicKey data in the paas-sshsecrets-publickey ConfigMap,
 k8s changes the mount and the webservice automatically picks up the file changes and uses the new key.
 
+!!! warning
+
+    When deploying the webservice application, you will be required to add an environment
+    variable called `PAAS_WS_ALLOWED_ORIGINS` in which you either give `*` or one or more
+    CORS related origins, comman separated.
+
+    By default, the webservice will be deployed using `http://www.example.com` as a value
+    and will not work for you.
+
 ### Reencryption
 
 A proper encryption product also has options to cycle the encrypted data.

--- a/manifests/webservice/deployment.yaml
+++ b/manifests/webservice/deployment.yaml
@@ -27,6 +27,8 @@ spec:
           environment:
             - name: PAAS_PUBLIC_KEY_PATH
               value: /secrets/paas/publicKey
+            - name: PAAS_WS_ALLOWED_ORIGINS
+              value: http://www.example.com
           image: webservice:latest
           imagePullPolicy: Always
           name: webservice


### PR DESCRIPTION
Add example origin to deployment manifest.

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [X] Documentation content changes
- [X] Other (please describe): added example CORS origin to deployment manifest

## What is the current behavior?

No env entry in deployment so webservice panics.

## What is the new behavior?

Example entry prevents panic, but would require customization by admin.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
