### PR TITLE
feat(paas_webhook): add secrets validation

### DIFF
--- a/internal/webhook/v1alpha1/paas_webhook.go
+++ b/internal/webhook/v1alpha1/paas_webhook.go
@@ -90,6 +90,10 @@ func (v *PaasCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Ob
 func (v *PaasCustomValidator) validate(ctx context.Context, paas *v1alpha1.Paas) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 	conf := config.GetConfig()
+	// Check for uninitialized config
+	if conf.DecryptKeysSecret.Name == "" {
+		return nil, apierrors.NewInternalError(fmt.Errorf("uninitialized PaasConfig"))
+	}
 	if errs := v.validateCaps(conf, paas.Spec.Capabilities); errs != nil {
 		allErrs = append(allErrs, errs...)
 	}

--- a/internal/webhook/v1alpha1/paas_webhook_test.go
+++ b/internal/webhook/v1alpha1/paas_webhook_test.go
@@ -7,10 +7,18 @@ See LICENSE.md for details.
 package v1alpha1
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha512"
+	"encoding/base64"
+	"errors"
+
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/internal/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Paas Webhook", func() {
@@ -26,6 +34,10 @@ var _ = Describe("Paas Webhook", func() {
 		validator = PaasCustomValidator{k8sClient}
 		conf := v1alpha1.PaasConfig{
 			Spec: v1alpha1.PaasConfigSpec{
+				DecryptKeysSecret: v1alpha1.NamespacedName{
+					Name:      "keys",
+					Namespace: "paas-system",
+				},
 				Capabilities: v1alpha1.ConfigCapabilities{},
 			},
 		}
@@ -65,6 +77,43 @@ var _ = Describe("Paas Webhook", func() {
 			Expect(err).Error().To(MatchError(ContainSubstring("Invalid value: \"foo\"")))
 			Expect(err).Error().To(MatchError(ContainSubstring("Invalid value: \"bar\"")))
 		})
+
+		It("Should deny creation when a secret is set that cannot be decrypted", func() {
+			const paasName = "my-paas"
+			encrypted, err := rsa.EncryptOAEP(sha512.New(), rand.Reader, pubkey, []byte("some encrypted string"), []byte(paasName))
+			Expect(err).NotTo(HaveOccurred())
+
+			obj = &v1alpha1.Paas{
+				ObjectMeta: metav1.ObjectMeta{Name: paasName},
+				Spec: v1alpha1.PaasSpec{
+					SshSecrets: map[string]string{
+						"valid secret":   base64.StdEncoding.EncodeToString(encrypted),
+						"invalid secret": base64.StdEncoding.EncodeToString([]byte("foo bar baz")),
+						"invalid base64": "foo bar baz",
+					},
+				},
+			}
+
+			_, err = validator.ValidateCreate(ctx, obj)
+			var serr *apierrors.StatusError
+			Expect(errors.As(err, &serr)).To(BeTrue())
+
+			causes := serr.Status().Details.Causes
+			Expect(causes).To(ContainElements(
+				metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: "Invalid value: \"invalid base64\": cannot be decrypted: illegal base64 data at input byte 8",
+					Field:   "spec.sshSecrets",
+				},
+				metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: "Invalid value: \"invalid secret\": cannot be decrypted: unable to decrypt data with any of the private keys",
+					Field:   "spec.sshSecrets",
+				},
+			))
+			Expect(causes).To(HaveLen(2))
+		})
+
 		//It("Should admit creation if all required fields are present", func() {
 		//	By("simulating an invalid creation scenario")
 		//	Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -8,7 +8,11 @@ package v1alpha1
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -23,8 +27,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	admissionv1 "k8s.io/api/admission/v1"
-	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,12 +48,36 @@ var (
 	ctx       context.Context
 	k8sClient client.Client
 	testEnv   *envtest.Environment
+	pubkey    *rsa.PublicKey
 )
 
-func TestAPIs(t *testing.T) {
+func TestWebhooks(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Webhook Suite")
+}
+
+func setupPaasSys() {
+	// Create system namespace
+	err := k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "paas-system"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Set up private key
+	privkey, err := rsa.GenerateKey(rand.Reader, 4096)
+	Expect(err).NotTo(HaveOccurred())
+	err = k8sClient.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keys",
+			Namespace: "paas-system",
+		},
+		Data: map[string][]byte{"privatekey0": pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privkey)})},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Save public key so we can encrypt things within tests
+	pubkey = &privkey.PublicKey
 }
 
 var _ = BeforeSuite(func() {
@@ -84,23 +113,19 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	scheme := apimachineryruntime.NewScheme()
-	err = apiv1alpha1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = admissionv1.AddToScheme(scheme)
+	err = apiv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
+		Scheme: scheme.Scheme,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Host:    webhookInstallOptions.LocalServingHost,
 			Port:    webhookInstallOptions.LocalServingPort,
@@ -133,6 +158,8 @@ var _ = BeforeSuite(func() {
 
 		return conn.Close()
 	}).Should(Succeed())
+
+	setupPaasSys()
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Adds `sshSecrets` validation to the Paas admission webhook.

Checks one of the items off #235.

I had to remove one of the test scenarios from the `PaasConfig` end-to-end test, because the behaviour has changed: since the webhook rejects Paas creation/update when a `PaasConfig` has not been initialized, reconciliation "resume" for unreconciled `Paas` objects after `PaasConfig` creation is no longer possible.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
