### PR TITLE
chore: error messages should be without caps

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -266,7 +266,7 @@ func (pcs PaasCapabilities) IsCap(name string) bool {
 
 func (pcs PaasCapabilities) GetCapability(capability string) (cap PaasCapability, err error) {
 	if cap, exists := pcs[capability]; !exists {
-		return cap, fmt.Errorf("Capability %s does not exist", capability)
+		return cap, fmt.Errorf("capability %s does not exist", capability)
 	} else {
 		return cap, nil
 	}
@@ -337,7 +337,7 @@ func (pc *PaasCapability) CapExtraFields(fieldConfig map[string]ConfigCustomFiel
 	var issues []error
 	for key, value := range pc.CustomFields {
 		if _, exists := fieldConfig[key]; !exists {
-			issues = append(issues, fmt.Errorf("Custom field %s is not configured in capability config", key))
+			issues = append(issues, fmt.Errorf("custom field %s is not configured in capability config", key))
 		} else {
 			fields[key] = value
 		}
@@ -345,12 +345,12 @@ func (pc *PaasCapability) CapExtraFields(fieldConfig map[string]ConfigCustomFiel
 	for key, fieldConf := range fieldConfig {
 		if value, exists := fields[key]; exists {
 			if matched, err := regexp.Match(fieldConf.Validation, []byte(value)); err != nil {
-				issues = append(issues, fmt.Errorf("Could not validate value %s: %w", value, err))
+				issues = append(issues, fmt.Errorf("could not validate value %s: %w", value, err))
 			} else if !matched {
-				issues = append(issues, fmt.Errorf("Invalid value %s (does not match %s)", value, fieldConf.Validation))
+				issues = append(issues, fmt.Errorf("invalid value %s (does not match %s)", value, fieldConf.Validation))
 			}
 		} else if fieldConf.Required {
-			issues = append(issues, fmt.Errorf("Value %s is required", key))
+			issues = append(issues, fmt.Errorf("value %s is required", key))
 		} else {
 			fields[key] = fieldConf.Default
 		}

--- a/api/v1alpha1/paas_types_test.go
+++ b/api/v1alpha1/paas_types_test.go
@@ -290,7 +290,7 @@ func TestPaasCapabilities_CapExtraFields(t *testing.T) {
 		},
 	}
 	fields, err = pc.CapExtraFields(map[string]ConfigCustomField{})
-	assert.Equal(t, "Custom field not_in_config is not configured in capability config", err.Error())
+	assert.Equal(t, "custom field not_in_config is not configured in capability config", err.Error())
 	assert.Nil(t, fields, "not_in_config should return nilmap for fields")
 
 	// required_field key not being set throws error
@@ -300,7 +300,7 @@ func TestPaasCapabilities_CapExtraFields(t *testing.T) {
 	fields, err = pc.CapExtraFields(map[string]ConfigCustomField{
 		"required_key": {Required: true},
 	})
-	assert.Equal(t, "Value required_key is required", err.Error())
+	assert.Equal(t, "value required_key is required", err.Error())
 	assert.Nil(t, fields, "required_field should return nilmap for fields")
 
 	// validation errors throw issues
@@ -314,7 +314,7 @@ func TestPaasCapabilities_CapExtraFields(t *testing.T) {
 			Validation: "^valid_value$",
 		},
 	})
-	assert.Equal(t, "Invalid value invalid_value (does not match ^valid_value$)", err.Error())
+	assert.Equal(t, "invalid value invalid_value (does not match ^valid_value$)", err.Error())
 	assert.Nil(t, fields, "invalid_value should return nilmap for fields")
 }
 


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There where error messages with caps in api/v1alpha1/paas_types.go

## What is the new behavior?

Caps are gone

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

