### PR TITLE
chore: Refining crypt so that it has a nicer interface for unittests

### DIFF
--- a/cmd/webservice/check_paas_test.go
+++ b/cmd/webservice/check_paas_test.go
@@ -31,7 +31,7 @@ func TestCheckPaas(t *testing.T) {
 	require.NoError(t, err, "Creating tempfile for public key")
 	defer os.Remove(pub.Name()) // clean up
 
-	crypt.NewGeneratedCrypt(priv.Name(), pub.Name()) //nolint:errcheck // this is fine in test
+	crypt.GenerateKeyPair(priv.Name(), pub.Name()) //nolint:errcheck // this is fine in test
 	getConfig()
 	_config.PublicKeyPath = pub.Name()
 	_config.PrivateKeyPath = priv.Name()

--- a/cmd/webservice/main_test.go
+++ b/cmd/webservice/main_test.go
@@ -85,7 +85,7 @@ func Test_getRSA(t *testing.T) {
 	defer os.Remove(pub.Name()) // clean up
 
 	t.Log("generating new keys and creating crypt")
-	crypt.NewGeneratedCrypt(priv.Name(), pub.Name()) //nolint:errcheck // this is fine in test
+	crypt.GenerateKeyPair(priv.Name(), pub.Name()) //nolint:errcheck // this is fine in test
 
 	// test: non-existing public key should panic
 	getConfig()
@@ -225,7 +225,7 @@ func Test_v1CheckPaas(t *testing.T) {
 	t.Setenv("PAAS_PRIVATE_KEYS_PATH", priv.Name()) //nolint:errcheck // this is fine in test
 
 	// Generate keyPair to be used during test
-	crypt.NewGeneratedCrypt(priv.Name(), pub.Name()) //nolint:errcheck // this is fine in test
+	crypt.GenerateKeyPair(priv.Name(), pub.Name()) //nolint:errcheck // this is fine in test
 
 	// Encrypt secret for test
 	rsa := getRsa("testPaas")

--- a/internal/crypt/crypt.go
+++ b/internal/crypt/crypt.go
@@ -52,8 +52,10 @@ func NewCryptFromKeys(privateKeys CryptPrivateKeys, publicKeyPath string, encryp
 	}, nil
 }
 
-func NewGeneratedCrypt(privateKeyPath string, publicKeyPath string) (*Crypt, error) {
-	var c Crypt
+func NewGeneratedCrypt(privateKeyPath string, publicKeyPath string, context string) (*Crypt, error) {
+	c := Crypt{
+		encryptionContext: []byte(context),
+	}
 	if privateKey, err := rsa.GenerateKey(rand.Reader, 4096); err != nil {
 		return nil, fmt.Errorf("unable to generate private key: %w", err)
 	} else {

--- a/internal/crypt/main.go
+++ b/internal/crypt/main.go
@@ -73,7 +73,7 @@ func GenerateKeyPair(privateKey string, publicKey string) error {
 		publicKey = f.Name()
 	}
 
-	if _, err := NewGeneratedCrypt(privateKey, publicKey); err != nil {
+	if _, err := NewGeneratedCrypt(privateKey, publicKey, ""); err != nil {
 		return fmt.Errorf("failed to generate new key pair: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Crurrently crypt has a Function to create a crypt with generated keys, but the functiona has no option to swet a crypt context
and the crypt has no way to change the context. So we end up generating, destroying and then recreating a crypt from teh generated keys.
We could add an option to set the context, but making it threadsafe might be overkill 
and not making it threadsafe is a risk especcially since we use it in multithreaded parts of our codebvase.

## What is the new behavior?

By adding thge context to the genrate function, we get a crypt that actually makes sense and the overhead is neglegible.
Furthermore we better distingt between 2 similar functions (one to return a crypt with generated keys and one to just generate keys).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This PR is split from #327 and #327 relies on it.
