### PR TITLE
hotfix: managing users in groups should not happen to ldap managed groups

### DIFF
--- a/internal/controller/groups.go
+++ b/internal/controller/groups.go
@@ -24,13 +24,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const (
+	ldapUidAnnotationKey = "openshift.io/ldap.uid"
+	ldapUrlAnnotationKey = "openshift.io/ldap.url"
+	ldapHostLabelKey     = "openshift.io/ldap.host"
+	managedByLabelKey    = "app.kubernetes.io/managed-by"
+	managedByLabelValue  = "paas"
+)
+
 // EnsureGroup ensures Group presence
 func (r *PaasReconciler) EnsureGroup(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 	group *userv1.Group,
 ) error {
-	var changed bool
+	var (
+		changed   bool
+		groupName = group.GetName()
+	)
 	logger := log.Ctx(ctx)
 	// See if group already exists and create if it doesn't
 	found := &userv1.Group{}
@@ -38,7 +49,7 @@ func (r *PaasReconciler) EnsureGroup(
 		Name: group.Name,
 	}, found)
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info().Msg("creating the group")
+		logger.Info().Msg("creating group " + groupName)
 		// Create the group
 		if err = r.Create(ctx, group); err != nil {
 			// creating the group failed
@@ -47,18 +58,23 @@ func (r *PaasReconciler) EnsureGroup(
 		return nil
 	} else if err != nil {
 		// Error that isn't due to the group not existing
-		logger.Err(err).Msg("could not retrieve the group")
+		logger.Err(err).Msg("could not retrieve group " + groupName)
 		return err
 	}
 	if !paas.AmIOwner(found.OwnerReferences) {
-		logger.Info().Msg("setting owner reference")
+		logger.Info().Msg("setting owner reference on group " + groupName)
 		if err := controllerutil.SetOwnerReference(paas, found, r.Scheme); err != nil {
-			logger.Err(err).Msg("error while setting owner reference")
+			logger.Err(err).Msg("error while setting owner reference on group " + groupName)
 			return err
 		}
 		changed = true
 	}
-	if !reflect.DeepEqual(group.Users, found.Users) {
+
+	if _, exists := group.Labels[ldapHostLabelKey]; exists {
+		logger.Debug().Msg("group " + groupName + " is ldap group, not changing users")
+	} else if reflect.DeepEqual(group.Users, found.Users) {
+		logger.Debug().Msg("users for group " + groupName + " are as expected")
+	} else {
 		found.Users = group.Users
 		changed = true
 	}
@@ -87,23 +103,22 @@ func (r *PaasReconciler) backendGroup(
 			Name:   groupName,
 			Labels: paas.ClonedLabels(),
 			Annotations: map[string]string{
-				"openshift.io/ldap.uid": group.Query,
-				"openshift.io/ldap.url": fmt.Sprintf("%s:%d",
+				ldapUidAnnotationKey: group.Query,
+				ldapUrlAnnotationKey: fmt.Sprintf("%s:%d",
 					config.GetConfig().LDAP.Host,
 					config.GetConfig().LDAP.Port,
 				),
 			},
 		}
-		g.ObjectMeta.Labels["openshift.io/ldap.host"] = config.GetConfig().LDAP.Host
-		g.ObjectMeta.Labels["app.kubernetes.io/managed-by"] = "paas"
+		g.ObjectMeta.Labels[ldapHostLabelKey] = config.GetConfig().LDAP.Host
 	} else {
 		g.ObjectMeta = metav1.ObjectMeta{
 			Name:   groupName,
 			Labels: paas.ClonedLabels(),
 		}
-		g.ObjectMeta.Labels["app.kubernetes.io/managed-by"] = "paas"
 		g.Users = group.Users
 	}
+	g.ObjectMeta.Labels[managedByLabelKey] = managedByLabelValue
 
 	if err := controllerutil.SetOwnerReference(paas, g, r.Scheme); err != nil {
 		return nil, err
@@ -187,14 +202,14 @@ func (r *PaasReconciler) deleteObsoleteGroups(ctx context.Context, paas *v1alpha
 	logger.Info().Msg("deleting obsolete groups")
 	for _, existingGroup := range existingGroups {
 		if !isGroupInGroups(existingGroup, desiredGroups) {
-			if existingGroup.Annotations["openshift.io/ldap.uid"] != "" {
+			if existingGroup.Annotations[ldapUidAnnotationKey] != "" {
 				existingGroup.OwnerReferences = paas.WithoutMe(existingGroup.OwnerReferences)
 				if len(existingGroup.OwnerReferences) == 0 {
 					logger.Info().Msgf("deleting %s", existingGroup.Name)
 					if err = r.Delete(ctx, existingGroup); err != nil {
 						return removedLdapGroups, err
 					}
-					removedLdapGroups = append(removedLdapGroups, existingGroup.Annotations["openshift.io/ldap.uid"])
+					removedLdapGroups = append(removedLdapGroups, existingGroup.Annotations[ldapUidAnnotationKey])
 					continue
 				}
 				logger.Info().Msgf("not last owner of group %s", existingGroup.Name)


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

#360 has enabled changing users for groups, but when a group is ldap managed, the users should not be managed by the paas operator.

## What is the new behavior?

The controller creates a group definition from the paas.
This has a label when ldap sync is configured and no label when paas managed.
We check this label to enable (or disable) managing the user block when it has changed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

