### PR TITLE
feat: Validate namespaces in crd

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -48,8 +48,12 @@ type PaasSpec struct {
 	Quota paas_quota.Quota `json:"quota"`
 
 	// Namespaces can be used to define extra namespaces to be created as part of this Paas project
+	// As the names are used as the names of PaasNs resources, they must comply to the DNS subdomainname regex
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names for more info
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:items:Pattern=`^[a-z0-9]([a-z0-9-.]{0,251}[a-z0-9])?$`
 	Namespaces []string `json:"namespaces"`
+
 	// You can add ssh keys (which is a type of secret) for ArgoCD to use for access to bitBucket
 	// They must be encrypted with the public key corresponding to the private key deployed together with the Paas operator
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/paas_types_ginkgo_test.go
+++ b/api/v1alpha1/paas_types_ginkgo_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2023, Tax Administration of The Netherlands.
+Licensed under the EUPL 1.2.
+See LICENSE.md for details.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/belastingdienst/opr-paas/internal/quota"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Namespace Validation", func() {
+	const resourceName = "test-paas"
+
+	Context("Valid Hostname", func() {
+		It("should accept a valid hostname", func() {
+			validNamespace := []string{"valid-hostname.example.com"}
+			paas := &Paas{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: resourceName,
+				},
+				Spec: PaasSpec{
+					Quota:      make(quota.Quota),
+					Requestor:  "valid-requestor",
+					Namespaces: validNamespace,
+				},
+			}
+
+			err := k8sClient.Create(context.TODO(), paas)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Delete(context.Background(), paas)).To(Succeed())
+		})
+	})
+
+	Context("Invalid Hostnames", func() {
+		DescribeTable("should reject invalid hostnames",
+			func(namespaces []string) {
+				paas := &Paas{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: resourceName,
+					},
+					Spec: PaasSpec{
+						Quota:      make(quota.Quota),
+						Requestor:  "valid-requestor",
+						Namespaces: namespaces,
+					},
+				}
+
+				err := k8sClient.Create(context.TODO(), paas)
+				Expect(err).To(HaveOccurred()) // Expect validation to fail
+			},
+			Entry("starts with a hyphen", []string{"-invalid.com"}),
+			Entry("starts with a dot", []string{"valid", ".invalid.com"}),
+			Entry("ends with a hyphen", []string{"invalid-.com-"}),
+			Entry("contains uppercase letters", []string{"Invalid.com"}),
+			Entry("contains special characters", []string{"invalid!name.com"}),
+			Entry("exceeds max length", []string{fmt.Sprintf("%s.com", string(make([]byte, 254)))}),
+		)
+	})
+})

--- a/api/v1alpha1/suite_test.go
+++ b/api/v1alpha1/suite_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024, Tax Administration of The Netherlands.
+Licensed under the EUPL 1.2.
+See LICENSE.md for details.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+
+	"github.com/go-logr/zerologr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	//+kubebuilder:scaffold:imports
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
+
+func TestApiV1Alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "v1alpha1 api Suite")
+}
+
+var _ = BeforeSuite(func() {
+	log.Logger = log.Level(zerolog.DebugLevel).
+		Output(zerolog.ConsoleWriter{Out: GinkgoWriter})
+	ctrl.SetLogger(zerologr.New(&log.Logger))
+
+	By("bootstrapping test environment")
+	binDirs, _ := filepath.Glob(filepath.Join("..", "..", "bin", "k8s",
+		fmt.Sprintf("*-%s-%s", runtime.GOOS, runtime.GOARCH)))
+	slices.Sort(binDirs)
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "manifests", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+
+		// The BinaryAssetsDirectory is only required if you want to run the tests directly
+		// without call the makefile target test. If not informed it will look for the
+		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
+		// Note that you must have the required binaries setup under the bin directory to perform
+		// the tests directly. When we run make test it will be setup and used automatically.
+		BinaryAssetsDirectory: binDirs[len(binDirs)-1],
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paas.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paas.yaml
@@ -122,9 +122,12 @@ spec:
                   is managed
                 type: string
               namespaces:
-                description: Namespaces can be used to define extra namespaces to
-                  be created as part of this Paas project
+                description: |-
+                  Namespaces can be used to define extra namespaces to be created as part of this Paas project
+                  As the names are used as the names of PaasNs resources, they must comply to the DNS subdomainname regex
+                  See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names for more info
                 items:
+                  pattern: ^[a-z0-9]([a-z0-9-.]{0,251}[a-z0-9])?$
                   type: string
                 type: array
               quota:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Namespaces in the paas.spec.namespaces can be named anything. However, these names are used to create PaasNs resources. Those names should comply to DNS hostnames. This can go wrong in the current setup, leading to not being able to create PaasNs'es.

Fixes: #303 

## What is the new behavior?

The paas crd contains a regex to validate namespace strings in the paas.spec.namespaces items.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->