### PR TITLE
chore: changing golangci-lint to use current defaults from operator-sdk (with extra disables)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,41 +1,64 @@
+run:
+  timeout: 5m
+  allow-parallel-runners: true
+
 issues:
-  exclude:
-    - SA1019
-    - SA5011
-  max-issues-per-linter: 0
-  max-same-issues: 0
+  # don't skip warning about doc comments
+  # don't exclude the default set of lint
+  exclude-use-default: false
+  # restore some of the defaults
+  # (fill in the rest as needed)
+  exclude-rules:
+    - path: 'api/*'
+      linters:
+        - lll
+    - path: 'internal/*'
+      linters:
+        - dupl
+        - lll
 linters:
+  disable-all: true
   enable:
-    - errcheck
-    - errorlint
+    #- dupl
+    #- errcheck
+    # WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
+    # ERRO [linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports.
+    #- exportloopref
     - ginkgolinter
-    - gocritic
-    - gofumpt
+    #- goconst
+    - gocyclo
+    - gofmt
     - goimports
-    - gosec
     - gosimple
     - govet
     - ineffassign
+    #- lll
     - misspell
-    - staticcheck
-    - testifylint
+    #- nakedret
+    #- prealloc
+    - revive
+    #- staticcheck
+    - typecheck
+    #- unconvert
+    #- unparam
     - unused
-    - whitespace
+
 linters-settings:
-  gocritic:
-    disabled-checks:
-      - appendAssign
-      - assignOp # Keep it disabled for readability
-      - badCond
-      - commentFormatting
-      - exitAfterDefer
-      - ifElseChain
-      - mapKey
-      - singleCaseSwitch
-      - typeSwitchVar
-  testifylint:
-    enable-all: true
-    disable:
-      - go-require
-run:
-  timeout: 50m
+  revive:
+    rules:
+      - name: comment-spacings
+      - name: add-constant
+        arguments:
+          - allowStrs: '""'
+            allowInts: '0,1,2,3'
+            ignoreFuncs: "assert\\.Len"
+            maxLitCount: '5'
+      - name: line-length-limit
+        severity: warning
+        disabled: true
+        exclude: ['']
+        arguments: [120]
+      - name: add-constant
+        disabled: true
+      - name: comment-spacings
+        disabled: true


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Fixes: #355

## What is the new behavior?

- revive is enabled (but many checks are still disabled)
- golangci-lint is in line with defaults from operator-sdk (but with checks disabled)
- from here we can enable checks and fix in a granular way

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

