### PR TITLE
feat: validate paas.spec.groups keys

### DIFF
--- a/internal/webhook/v1alpha1/paas_webhook.go
+++ b/internal/webhook/v1alpha1/paas_webhook.go
@@ -147,7 +147,7 @@ func validateCaps(ctx context.Context, client client.Client, conf v1alpha1.PaasC
 	return errs, nil
 }
 
-// validateCaps returns an error if any of the passed capabilities is not configured.
+// validateGroupNames returns an error if any of the passed capabilities is not configured.
 func validateGroupNames(ctx context.Context, client client.Client, conf v1alpha1.PaasConfigSpec, paas *v1alpha1.Paas) ([]*field.Error, error) {
 	var errs []*field.Error
 

--- a/internal/webhook/v1alpha1/paas_webhook.go
+++ b/internal/webhook/v1alpha1/paas_webhook.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -103,6 +104,7 @@ func (v *PaasCustomValidator) validate(ctx context.Context, paas *v1alpha1.Paas)
 		validateCaps,
 		validateSecrets,
 		validateCustomFields,
+		validateGroupNames,
 	} {
 		if errs, err := val(ctx, v.client, conf, paas); err != nil {
 			return nil, apierrors.NewInternalError(err)
@@ -138,6 +140,23 @@ func validateCaps(ctx context.Context, client client.Client, conf v1alpha1.PaasC
 				field.NewPath("spec").Child("capabilities"),
 				name,
 				"capability not configured",
+			))
+		}
+	}
+
+	return errs, nil
+}
+
+// validateCaps returns an error if any of the passed capabilities is not configured.
+func validateGroupNames(ctx context.Context, client client.Client, conf v1alpha1.PaasConfigSpec, paas *v1alpha1.Paas) ([]*field.Error, error) {
+	var errs []*field.Error
+
+	for name := range paas.Spec.Groups {
+		for _, errString := range validation.IsDNS1035Label(name) {
+			errs = append(errs, field.Invalid(
+				field.NewPath("spec").Child("groups"),
+				name,
+				errString,
 			))
 		}
 	}

--- a/test/e2e/groupquery_test.go
+++ b/test/e2e/groupquery_test.go
@@ -158,10 +158,12 @@ func assertGroupKeyAndNameDifferenceIsOk(ctx context.Context, t *testing.T, cfg 
 
 func assertLdapGroupRemovedAfterUpdatingKey(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	paas := getPaas(ctx, paasWithGroupQuery, t, cfg)
-	paas.Spec.Groups = api.PaasGroups{groupWithQueryName: api.PaasGroup{Query: groupQuery}, "updatedSecondLdapGroup": api.PaasGroup{
-		Query: updatedGroup2Query,
-		Roles: []string{"viewer"},
-	}}
+	paas.Spec.Groups = api.PaasGroups{
+		groupWithQueryName: api.PaasGroup{Query: groupQuery},
+		"updated-second-ldap-group": api.PaasGroup{
+			Query: updatedGroup2Query,
+			Roles: []string{"viewer"},
+		}}
 
 	if err := updateSync(ctx, cfg, paas, api.TypeReadyPaas); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Fixes: #304

## What is the new behavior?

- group names (key in map) are validated against RFC 1035

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

