### PR TITLE
feat: AppSet list generator fields as interface

### DIFF
--- a/internal/controller/argo_app.go
+++ b/internal/controller/argo_app.go
@@ -98,9 +98,9 @@ func (r *PaasReconciler) backendArgoApp(
 			},
 			Project: "default",
 			Source: &argo.ApplicationSource{
-				RepoURL:        fields["git_url"],
-				Path:           fields["git_path"],
-				TargetRevision: fields["git_revision"],
+				RepoURL:        fields.GetElementAsString("git_url"),
+				Path:           fields.GetElementAsString("git_path"),
+				TargetRevision: fields.GetElementAsString("git_revision"),
 			},
 			SyncPolicy: &argo.SyncPolicy{
 				Automated: &argo.SyncPolicyAutomated{

--- a/internal/fields/elements.go
+++ b/internal/fields/elements.go
@@ -1,0 +1,68 @@
+package fields
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Elements represents all key, value pars for one entry in the list of the listgenerator
+type Element any
+
+type Elements map[string]Element
+
+func ElementsFromJSON(raw []byte) (Elements, error) {
+	newElements := make(Elements)
+	if err := json.Unmarshal(raw, &newElements); err != nil {
+		return nil, err
+	} else {
+		return newElements, nil
+	}
+}
+
+// GetElementAsString gets a value and returns as string
+// This should be a method on Element, but a method cannot exist on interface datatypes
+func (es Elements) GetElementAsString(key string) string {
+	value, err := es.TryGetElementAsString(key)
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+// TryGetElementAsString gets a value and returns as string
+// This should be a method on Element, but a method cannot exist on interface datatypes
+func (es Elements) TryGetElementAsString(key string) (string, error) {
+	element, exists := es[key]
+	if !exists {
+		return "", errors.New("element does not exist")
+	}
+	value, ok := element.(string)
+	if ok {
+		return value, nil
+	}
+	return fmt.Sprintf("%v", value), nil
+}
+
+func (es Elements) AsString() string {
+	var l []string
+	for key, value := range es {
+		l = append(l, fmt.Sprintf("'%s': '%s'", key, strings.ReplaceAll(fmt.Sprintf("%e", value), "'", "\\'")))
+	}
+	return fmt.Sprintf("{ %s }", strings.Join(l, ", "))
+}
+
+func (es Elements) AsJSON() ([]byte, error) {
+	return json.Marshal(es)
+}
+
+func (es Elements) Key() string {
+	if key, exists := es["paas"]; exists {
+		paasKey, valid := key.(string)
+		if valid {
+			return paasKey
+		}
+	}
+	return ""
+}

--- a/internal/fields/entries.go
+++ b/internal/fields/entries.go
@@ -1,0 +1,50 @@
+package fields
+
+import (
+	"fmt"
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// Entries represents all entries in the list of the listgenerator
+// This is a map so that values are unique, the key is the paas entry
+type Entries map[string]Elements
+
+func (en Entries) AsString() string {
+	var l []string
+	for key, value := range en {
+		l = append(l, fmt.Sprintf("'%s': %s", key, value.AsString()))
+	}
+	return fmt.Sprintf("{ %s }", strings.Join(l, ", "))
+}
+
+func (en Entries) AsJSON() ([]apiextensionsv1.JSON, error) {
+	list := []apiextensionsv1.JSON{}
+	for _, entry := range en {
+		if data, err := entry.AsJSON(); err != nil {
+			return nil, err
+		} else {
+			list = append(list, apiextensionsv1.JSON{Raw: data})
+		}
+	}
+	return list, nil
+}
+
+func EntriesFromJSON(data []apiextensionsv1.JSON) (Entries, error) {
+	e := Entries{}
+	for _, raw := range data {
+		if entry, err := ElementsFromJSON(raw.Raw); err != nil {
+			return nil, err
+		} else {
+			key := entry.Key()
+			if key != "" {
+				e[key] = entry
+			} else {
+				// weird, this entry does not have a paas key, let's preserve, but put aside
+				e[string(raw.Raw)] = entry
+			}
+		}
+	}
+	return e, nil
+}


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

AppSet ListGenerator can have any datatype, but now has string datatype in opr-paas code

## What is the new behavior?

- AppSet listgenerator is defined by internal datatype, where map[string]string is changed to map[string]interface{}
- There is an option to get string value of interface. When not directly parsablle, fmt.Sprintf("%v", obj) is returned.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a prelude to feeding info from paas into capabilities.
