### PR TITLE
test: e2e tests with appset interface option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: test-e2e
 test-e2e:
-	go test -v ./test/e2e
+	go test -count=1 -v ./test/e2e
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint

--- a/internal/fields/elements.go
+++ b/internal/fields/elements.go
@@ -21,6 +21,16 @@ func ElementsFromJSON(raw []byte) (Elements, error) {
 	}
 }
 
+// GetElementsAsString gets a value and returns as string
+// This should be a method on Element, but a method cannot exist on interface datatypes
+func (es Elements) GetElementsAsStringMap() (values map[string]string) {
+	values = make(map[string]string)
+	for key := range es {
+		values[key] = es.GetElementAsString(key)
+	}
+	return values
+}
+
 // GetElementAsString gets a value and returns as string
 // This should be a method on Element, but a method cannot exist on interface datatypes
 func (es Elements) GetElementAsString(key string) string {
@@ -45,10 +55,16 @@ func (es Elements) TryGetElementAsString(key string) (string, error) {
 	return fmt.Sprintf("%v", value), nil
 }
 
-func (es Elements) AsString() string {
+func (es Elements) String() string {
 	var l []string
-	for key, value := range es {
-		l = append(l, fmt.Sprintf("'%s': '%s'", key, strings.ReplaceAll(fmt.Sprintf("%e", value), "'", "\\'")))
+	for key := range es {
+		value, err := es.TryGetElementAsString(key)
+		if err != nil {
+			panic("this is impossible, looping through keys in Elements object, and key cannot be fount, weird.")
+		}
+		key = strings.ReplaceAll(key, "'", "\\'")
+		value = strings.ReplaceAll(value, "'", "\\'")
+		l = append(l, fmt.Sprintf("'%s': '%s'", key, value))
 	}
 	return fmt.Sprintf("{ %s }", strings.Join(l, ", "))
 }

--- a/internal/fields/entries.go
+++ b/internal/fields/entries.go
@@ -11,10 +11,10 @@ import (
 // This is a map so that values are unique, the key is the paas entry
 type Entries map[string]Elements
 
-func (en Entries) AsString() string {
+func (en Entries) String() string {
 	var l []string
 	for key, value := range en {
-		l = append(l, fmt.Sprintf("'%s': %s", key, value.AsString()))
+		l = append(l, fmt.Sprintf("'%s': %s", key, value.String()))
 	}
 	return fmt.Sprintf("{ %s }", strings.Join(l, ", "))
 }

--- a/test/e2e/app-project_test.go
+++ b/test/e2e/app-project_test.go
@@ -77,8 +77,8 @@ func assertAppProjectCreated(ctx context.Context, t *testing.T, cfg *envconf.Con
 	require.NoError(t, appSetListEntriesError)
 	assert.Len(t, applicationSetListEntries, 1)
 
-	// At least one JSON object should have "paas": "paasnaam"
-	assert.Equal(t, simplePaas, applicationSetListEntries[0]["paas"])
+	// paas should be in the list of entries
+	assert.Contains(t, applicationSetListEntries, simplePaas)
 
 	return ctx
 }

--- a/test/e2e/capability-tekton_test.go
+++ b/test/e2e/capability-tekton_test.go
@@ -81,7 +81,7 @@ func assertCapTektonCreated(ctx context.Context, t *testing.T, cfg *envconf.Conf
 	assert.Len(t, applicationSetListEntries, 1)
 
 	// At least one JSON object should have "paas": "paasnaam"
-	assert.Equal(t, paasWithCapabilityTekton, applicationSetListEntries[0]["paas"])
+	assert.Contains(t, applicationSetListEntries, paasWithCapabilityTekton)
 
 	// Check whether the LabelSelector is specific to the paasnaam-Tekton namespace
 	labelSelector := tektonQuota.Spec.Selector.LabelSelector

--- a/test/e2e/capability_cap5_test.go
+++ b/test/e2e/capability_cap5_test.go
@@ -68,7 +68,7 @@ func assertCap5Created(ctx context.Context, t *testing.T, cfg *envconf.Config) c
 	assert.Len(t, applicationSetListEntries, 1)
 
 	// At least one JSON object should have "paas": "cap5paas"
-	assert.Equal(t, paasWithCapability5, applicationSetListEntries[0]["paas"])
+	assert.Contains(t, applicationSetListEntries, paasWithCapability5)
 
 	// Check whether the LabelSelector is specific to the cap5paas-cap5 namespace
 	labelSelector := cap5Quota.Spec.Selector.LabelSelector

--- a/test/e2e/capability_sso_test.go
+++ b/test/e2e/capability_sso_test.go
@@ -69,7 +69,7 @@ func assertCapSSOCreated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 	assert.Len(t, applicationSetListEntries, 1)
 
 	// At least one JSON object should have "paas": "paasnaam"
-	assert.Equal(t, paasWithCapabilitySSO, applicationSetListEntries[0]["paas"])
+	assert.Contains(t, applicationSetListEntries, paasWithCapabilitySSO)
 
 	// Check whether the LabelSelector is specific to the paasnaam-sso namespace
 	labelSelector := ssoQuota.Spec.Selector.LabelSelector


### PR DESCRIPTION

## Pull Request type


Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

currently e2e tests still expect a string as value in appset generator lists

## What is the new behavior?

with this check we change e2e tests use internal.fields.Elements and also work with interfaces

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

