### PR TITLE
chore(lint): increase max allowed public structs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -103,7 +103,7 @@ linters-settings:
       - name: max-control-nesting
         disabled: true
       - name: max-public-structs
-        disabled: true
+        arguments: [14]
       - name: redefines-builtin-id
         disabled: true
       - name: receiver-naming


### PR DESCRIPTION
Increase max allowed public structs in Revive linter rule

Signed-off-by: hikarukin <156204784+hikarukin@users.noreply.github.com>

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
