### PR TITLE
fix(docs): Updated example ApplicationSet in capability docs

### DIFF
--- a/docs/administrators-guide/configuration.md
+++ b/docs/administrators-guide/configuration.md
@@ -45,7 +45,7 @@ Example PaasConfig
           groupNames: "^[a-z0-9-]*$"
       debug: false
       groupsynclist:
-        namespace: chp-cronjobs
+        namespace: prod-cronjobs
         name: groupsynclist
       ldap:
         host: ${PROD_LDAP_HOST}

--- a/docs/overview/core_concepts/capabilities.md
+++ b/docs/overview/core_concepts/capabilities.md
@@ -98,8 +98,8 @@ The ArgoCD Applicationset could look like this:
 !!! example
 
     ```yaml
-    apiversion: argoproj.io/v1alpha1
-    kind: applicationset
+    apiVersion: argoproj.io/v1alpha1
+    kind: ApplicationSet
     metadata:
       # name of the applicationset, this can be used for Paas instances with the
       # argocd capability enabled
@@ -115,7 +115,7 @@ The ArgoCD Applicationset could look like this:
       generators: []
       template:
         metadata:
-          name: "{{paas}}-cpet-capability-argocd"
+          name: "{{paas}}-capability-argocd"
         spec:
           destination:
             namespace: "{{paas}}-argocd"
@@ -123,18 +123,18 @@ The ArgoCD Applicationset could look like this:
           project: "{{paas}}"
           source:
             kustomize:
-              commonlabels:
+              commonLabels:
                 capability: argocd
                 clusterquotagroup: "{{requestor}}"
                 paas: "{{paas}}"
                 service: "{{service}}"
                 subservice: "{{subservice}}"
             path: paas-capabilities/argocd
-            repourl: "ssh://git@github.com/belastingdienst/my-paas-capabilities.git"
-            targetrevision: master
-          syncpolicy:
+            repoURL: "ssh://git@github.com/belastingdienst/my-paas-capabilities.git"
+            targetRevision: master
+          syncPolicy:
             automated:
-              selfheal: true
+              selfHeal: true
     ```
 
 ### Example Paas


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Updated the syntax for the ArgoCD `ApplicationSet` resource in `capabilities.md`. The existing example appears to be incorrectly lowercased, which causes it to be rejected by a Kubernetes cluster.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

```bash
An error occurred:
No "apiVersion" field found in YAML.
```

## What is the new behavior?

- resource will be applied to the cluster

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->