### PR TITLE
chore: coverage of internal/fields

### DIFF
--- a/internal/controller/capabilities_test.go
+++ b/internal/controller/capabilities_test.go
@@ -157,11 +157,12 @@ var _ = Describe("Capabilities controller", Ordered, func() {
 						"git_path":      "",
 						"git_revision":  "",
 						"git_url":       "",
-						"groups":        "map[ldapgroup:map[query:CN=group1OU=example roles:[admin]] usergroup:map[query: roles:[edit view] users:[user1 user2]]]",
-						"paas":          paasName,
-						"requestor":     "my",
-						"service":       serviceName,
-						"subservice":    "paas",
+						// revive:disable-next-line
+						"groups":     "map[ldapgroup:map[query:CN=group1OU=example roles:[admin]] usergroup:map[query: roles:[edit view] users:[user1 user2]]]",
+						"paas":       paasName,
+						"requestor":  "my",
+						"service":    serviceName,
+						"subservice": "paas",
 					}))
 			})
 		})

--- a/internal/fields/elements.go
+++ b/internal/fields/elements.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -52,7 +53,7 @@ func (es Elements) TryGetElementAsString(key string) (string, error) {
 	if ok {
 		return value, nil
 	}
-	return fmt.Sprintf("%v", value), nil
+	return fmt.Sprintf("%v", element), nil
 }
 
 // Merge merges all key/value pairs from another Entries on top of this and returns the resulting total Entries set
@@ -65,11 +66,13 @@ func (es Elements) Merge(added Elements) Elements {
 
 func (es Elements) String() string {
 	var l []string
-	for key := range es {
-		value, err := es.TryGetElementAsString(key)
-		if err != nil {
-			panic("this is impossible, looping through keys in Elements object, and key cannot be fount, weird.")
-		}
+	keys := make([]string, 0, len(es))
+	for k := range es {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := es.GetElementAsString(key)
 		key = strings.ReplaceAll(key, "'", "\\'")
 		value = strings.ReplaceAll(value, "'", "\\'")
 		l = append(l, fmt.Sprintf("'%s': '%s'", key, value))

--- a/internal/fields/elements_test.go
+++ b/internal/fields/elements_test.go
@@ -47,7 +47,6 @@ func TestElementsFromImproperJSON(t *testing.T) {
 }
 
 func TestAsStringMap(t *testing.T) {
-	t.Logf("%v", 6.0)
 	assert.Equal(
 		t,
 		map[string]string{
@@ -78,6 +77,7 @@ func TestElementsAsString(t *testing.T) {
 	require.NotNil(t, elements)
 	assert.Equal(t, expected, elements.String())
 }
+
 func TestGetElementAsString(t *testing.T) {
 	require.NotNil(t, elements)
 	for _, key := range []string{key1, key2, key3, key4} {

--- a/internal/fields/elements_test.go
+++ b/internal/fields/elements_test.go
@@ -1,0 +1,101 @@
+package fields_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/belastingdienst/opr-paas/internal/fields"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	key1     = "a"
+	value1   = "b"
+	key2     = "c"
+	value2   = 6.0
+	key3     = "d"
+	key4     = ""
+	elements = fields.Elements{
+		key1: value1,
+		key2: value2,
+	}
+	properJSON    = []byte(fmt.Sprintf(`{"%s":"%s","%s":%f}`, key1, value1, key2, value2))
+	improperJSONs = [][]byte{
+		[]byte(fmt.Sprintf(`"%s":"%s",%f:%s}`, key1, value1, value2, key2)),
+		[]byte(fmt.Sprintf(`{"%s","%s"}`, key1, key2)),
+		[]byte(fmt.Sprintf(`["%s","%s"]`, key1, key2)),
+	}
+)
+
+func TestElementsFromProperJSON(t *testing.T) {
+	elements, err := fields.ElementsFromJSON(properJSON)
+	assert.NoError(t, err)
+	assert.NotNil(t, elements)
+	assert.Contains(t, elements, key1)
+	assert.Equal(t, elements[key1], value1)
+	assert.Contains(t, elements, key2)
+	assert.Equal(t, elements[key2], value2)
+}
+
+func TestElementsFromImproperJSON(t *testing.T) {
+	for _, JSON := range improperJSONs {
+		elements, err := fields.ElementsFromJSON(JSON)
+		assert.Error(t, err)
+		assert.Nil(t, elements)
+	}
+}
+
+func TestAsStringMap(t *testing.T) {
+	t.Logf("%v", 6.0)
+	assert.Equal(
+		t,
+		map[string]string{
+			"a": "b",
+			"c": "6",
+		},
+		elements.GetElementsAsStringMap(),
+	)
+}
+
+func TestTryGetElementAsString(t *testing.T) {
+	a, err := elements.TryGetElementAsString("a")
+	require.NoError(t, err)
+	assert.NotNil(t, a)
+	assert.Equal(t, a, "b")
+	b, err := elements.TryGetElementAsString("b")
+	require.Error(t, err)
+	assert.Empty(t, b)
+	c, err := elements.TryGetElementAsString("c")
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+	assert.IsType(t, "6", c)
+	assert.Equal(t, "6", c)
+}
+
+func TestElementsAsString(t *testing.T) {
+	expected := `{ 'a': 'b', 'c': '6' }`
+	require.NotNil(t, elements)
+	assert.Equal(t, expected, elements.String())
+}
+func TestGetElementAsString(t *testing.T) {
+	require.NotNil(t, elements)
+	for _, key := range []string{key1, key2, key3, key4} {
+		if _, exists := elements[key]; exists {
+			assert.NotEmpty(t, elements.GetElementAsString(key))
+		} else {
+			assert.Empty(t, elements.GetElementAsString(key))
+		}
+	}
+}
+
+func TestKey(t *testing.T) {
+	const paasName = "my-paas"
+	assert.Empty(t, elements.Key())
+	elements2 := fields.Elements{
+		key1:   value1,
+		key2:   value2,
+		"paas": paasName,
+	}
+	assert.Equal(t, paasName, elements2.Key())
+}

--- a/internal/fields/entries_test.go
+++ b/internal/fields/entries_test.go
@@ -1,32 +1,44 @@
 package fields_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/belastingdienst/opr-paas/internal/fields"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8sv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+const (
+	paas1Name   = "paas1"
+	paas1Value1 = "p1v1"
+	paas1Value2 = 2.0
+	paas1Value4 = "p1v4"
+	paas2Name   = "paas2"
+	paas2Value1 = "p2v1"
+	paas2Value2 = 3
+	paas2Value3 = "p2v3"
 )
 
 var (
 	entries1 = fields.Entries{
-		"paas1": fields.Elements{
-			"key1": "value1",
-			"key2": 2.0,
-			"paas": "paas1",
+		paas1Name: fields.Elements{
+			"key1": "othervalue1",
+			"key2": paas1Value2,
+			"paas": paas1Name,
 		},
 	}
 	entries2 = fields.Entries{
-		"paas1": fields.Elements{
-			"key1": "othervalue1",
-			"key4": "othervalue4",
-			"paas": "paas1",
+		paas1Name: fields.Elements{
+			"key1": paas1Value1,
+			"key4": paas1Value4,
+			"paas": paas1Name,
 		},
-		"paas2": fields.Elements{
-			"key1": "value1",
-			"key3": 3,
-			"paas": "paas2",
+		paas2Name: fields.Elements{
+			"key1": paas2Value1,
+			"key3": paas2Value3,
+			"paas": paas2Name,
 		},
 	}
 )
@@ -37,40 +49,54 @@ func TestHashData(t *testing.T) {
 	resultEntries := entries1.Merge(entries2)
 	assert.Len(t, resultEntries, 2)
 
-	require.Contains(t, resultEntries, "paas1")
-	elements1 := resultEntries["paas1"]
+	require.Contains(t, resultEntries, paas1Name)
+	elements1 := resultEntries[paas1Name]
 	assert.Len(t, elements1, 4)
 	require.Contains(t, elements1, "key1")
-	assert.Equal(t, elements1["key1"], "othervalue1")
+	assert.Equal(t, elements1["key1"], paas1Value1)
 	require.Contains(t, elements1, "key2")
-	assert.Equal(t, elements1["key2"], 2.0)
+	assert.Equal(t, elements1["key2"], paas1Value2)
 	require.Contains(t, elements1, "key4")
-	assert.Equal(t, elements1["key4"], "othervalue4")
+	assert.Equal(t, elements1["key4"], paas1Value4)
 	assert.Contains(t, elements1, "paas")
-	assert.Equal(t, elements1["paas"], "paas1")
+	assert.Equal(t, elements1["paas"], paas1Name)
 
-	require.Contains(t, resultEntries, "paas2")
-	elements2 := resultEntries["paas2"]
+	require.Contains(t, resultEntries, paas2Name)
+	elements2 := resultEntries[paas2Name]
 	assert.Len(t, elements2, 3)
 	require.Contains(t, elements1, "key1")
-	assert.Equal(t, "value1", elements2["key1"])
+	assert.Equal(t, paas2Value1, elements2["key1"])
 	require.Contains(t, elements2, "key3")
-	assert.Equal(t, 3, elements2["key3"])
+	assert.Equal(t, paas2Value3, elements2["key3"])
 	assert.Contains(t, elements2, "paas")
-	assert.Equal(t, "paas2", elements2["paas"])
+	assert.Equal(t, paas2Name, elements2["paas"])
 }
 
 func TestEntriesString(t *testing.T) {
 	assert.Equal(
 		t,
-		// revive:disable-next-line
-		"{ 'paas1': { 'key1': 'othervalue1', 'key2': '2', 'key4': 'othervalue4', 'paas': 'paas1' } }",
+		fmt.Sprintf("{ '%s': { 'key1': '%s', 'key2': '%.0f', 'key4': '%s', 'paas': '%s' } }",
+			paas1Name,
+			paas1Value1,
+			paas1Value2,
+			paas1Value4,
+			paas1Name,
+		),
 		entries1.String(),
 	)
 	assert.Equal(
 		t,
 		// revive:disable-next-line
-		"{ 'paas1': { 'key1': 'othervalue1', 'key4': 'othervalue4', 'paas': 'paas1' }, 'paas2': { 'key1': 'value1', 'key3': '3', 'paas': 'paas2' } }",
+		fmt.Sprintf("{ '%s': { 'key1': '%s', 'key4': '%s', 'paas': '%s' }, '%s': { 'key1': '%s', 'key3': '%s', 'paas': '%s' } }",
+			paas1Name,
+			paas1Value1,
+			paas1Value4,
+			paas1Name,
+			paas2Name,
+			paas2Value1,
+			paas2Value3,
+			paas2Name,
+		),
 		entries2.String(),
 	)
 }
@@ -79,17 +105,30 @@ func TestEntriesAsJSON(t *testing.T) {
 	json1, err := entries1.AsJSON()
 	assert.NoError(t, err)
 	assert.NotNil(t, json1)
-	var expected1 = []v1.JSON{
-		v1.JSON{Raw: []byte(`{"key1":"othervalue1","key2":2,"key4":"othervalue4","paas":"paas1"}`)},
+	expected1 := []k8sv1.JSON{
+		{Raw: []byte(
+			fmt.Sprintf(`{"key1":"%s","key2":%.0f,"key4":"%s","paas":"%s"}`,
+				paas1Value1,
+				paas1Value2,
+				paas1Value4,
+				paas1Name),
+		)},
 	}
 	assert.Equal(t, expected1, json1)
 
 	json2, err := entries2.AsJSON()
 	assert.NoError(t, err)
 	assert.NotNil(t, json2)
-	expected2 := []v1.JSON{
-		v1.JSON{Raw: []byte(`{"key1":"othervalue1","key4":"othervalue4","paas":"paas1"}`)},
-		v1.JSON{Raw: []byte(`{"key1":"value1","key3":3,"paas":"paas2"}`)},
+	expected2 := []k8sv1.JSON{
+		{Raw: []byte(
+			fmt.Sprintf(`{"key1":"%s","key4":"%s","paas":"%s"}`, paas1Value1, paas1Value4, paas1Name),
+		)},
+		{Raw: []byte(
+			fmt.Sprintf(`{"key1":"%s","key3":"%s","paas":"%s"}`,
+				paas2Value1,
+				paas2Value3,
+				paas2Name,
+			))},
 	}
 	assert.Equal(t, expected2, json2)
 	entries3 := fields.Entries{
@@ -104,6 +143,12 @@ func TestEntriesAsJSON(t *testing.T) {
 }
 
 func TestEntriesFromJSON(t *testing.T) {
+	const (
+		paas3Name   = "paas3"
+		paas3Value1 = "p3v1"
+		paas3Value2 = 2.0
+		paas3Value4 = "p3v4"
+	)
 	json1, err := entries1.AsJSON()
 	require.NoError(t, err)
 	require.NotNil(t, json1)
@@ -113,11 +158,11 @@ func TestEntriesFromJSON(t *testing.T) {
 	assert.Equal(t, entries1, entries)
 
 	for _, jData := range []string{
-		`{"key1":"othervalue1","key2":2,"key4":"othervalue4"}`,
-		`{"key1":"othervalue1","key2"`,
+		fmt.Sprintf(`{"key1":"%s","key2":%.0f,"key4":"%s"}`, paas3Value1, paas3Value2, paas3Value4),
+		fmt.Sprintf(`{"key1":"%s","key2"`, paas1Value1),
 	} {
 		t.Logf("testing with JSON data: %s", jData)
-		json2 := []v1.JSON{v1.JSON{Raw: []byte(jData)}}
+		json2 := []k8sv1.JSON{{Raw: []byte(jData)}}
 		entries, err = fields.EntriesFromJSON(json2)
 		assert.Error(t, err)
 		assert.Nil(t, entries)

--- a/internal/fields/entries_test.go
+++ b/internal/fields/entries_test.go
@@ -6,36 +6,120 @@ import (
 	"github.com/belastingdienst/opr-paas/internal/fields"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-func TestHashData(t *testing.T) {
-	entries1 := fields.Entries{
+var (
+	entries1 = fields.Entries{
 		"paas1": fields.Elements{
 			"key1": "value1",
-			"key2": 2,
+			"key2": 2.0,
+			"paas": "paas1",
 		},
 	}
-	entries2 := fields.Entries{
+	entries2 = fields.Entries{
 		"paas1": fields.Elements{
 			"key1": "othervalue1",
 			"key4": "othervalue4",
+			"paas": "paas1",
 		},
 		"paas2": fields.Elements{
 			"key1": "value1",
 			"key3": 3,
+			"paas": "paas2",
 		},
 	}
+)
+
+// internal/fields/entries.go						54-56 66-68 72-75
+
+func TestHashData(t *testing.T) {
 	resultEntries := entries1.Merge(entries2)
 	assert.Len(t, resultEntries, 2)
+
 	require.Contains(t, resultEntries, "paas1")
 	elements1 := resultEntries["paas1"]
-	assert.Len(t, elements1, 3)
+	assert.Len(t, elements1, 4)
 	require.Contains(t, elements1, "key1")
 	assert.Equal(t, elements1["key1"], "othervalue1")
 	require.Contains(t, elements1, "key2")
-	assert.Equal(t, elements1["key2"], 2)
-	assert.Contains(t, elements1, "key4")
+	assert.Equal(t, elements1["key2"], 2.0)
+	require.Contains(t, elements1, "key4")
+	assert.Equal(t, elements1["key4"], "othervalue4")
+	assert.Contains(t, elements1, "paas")
+	assert.Equal(t, elements1["paas"], "paas1")
+
 	require.Contains(t, resultEntries, "paas2")
 	elements2 := resultEntries["paas2"]
-	assert.Len(t, elements2, 2)
+	assert.Len(t, elements2, 3)
+	require.Contains(t, elements1, "key1")
+	assert.Equal(t, "value1", elements2["key1"])
+	require.Contains(t, elements2, "key3")
+	assert.Equal(t, 3, elements2["key3"])
+	assert.Contains(t, elements2, "paas")
+	assert.Equal(t, "paas2", elements2["paas"])
+}
+
+func TestEntriesString(t *testing.T) {
+	assert.Equal(
+		t,
+		// revive:disable-next-line
+		"{ 'paas1': { 'key1': 'othervalue1', 'key2': '2', 'key4': 'othervalue4', 'paas': 'paas1' } }",
+		entries1.String(),
+	)
+	assert.Equal(
+		t,
+		// revive:disable-next-line
+		"{ 'paas1': { 'key1': 'othervalue1', 'key4': 'othervalue4', 'paas': 'paas1' }, 'paas2': { 'key1': 'value1', 'key3': '3', 'paas': 'paas2' } }",
+		entries2.String(),
+	)
+}
+
+func TestEntriesAsJSON(t *testing.T) {
+	json1, err := entries1.AsJSON()
+	assert.NoError(t, err)
+	assert.NotNil(t, json1)
+	var expected1 = []v1.JSON{
+		v1.JSON{Raw: []byte(`{"key1":"othervalue1","key2":2,"key4":"othervalue4","paas":"paas1"}`)},
+	}
+	assert.Equal(t, expected1, json1)
+
+	json2, err := entries2.AsJSON()
+	assert.NoError(t, err)
+	assert.NotNil(t, json2)
+	expected2 := []v1.JSON{
+		v1.JSON{Raw: []byte(`{"key1":"othervalue1","key4":"othervalue4","paas":"paas1"}`)},
+		v1.JSON{Raw: []byte(`{"key1":"value1","key3":3,"paas":"paas2"}`)},
+	}
+	assert.Equal(t, expected2, json2)
+	entries3 := fields.Entries{
+		"paas3": fields.Elements{
+			"key1": "value1",
+		},
+	}
+	entries3["paas3"]["circular"] = &entries3
+	json3, err := entries3.AsJSON()
+	assert.Error(t, err)
+	assert.Nil(t, json3)
+}
+
+func TestEntriesFromJSON(t *testing.T) {
+	json1, err := entries1.AsJSON()
+	require.NoError(t, err)
+	require.NotNil(t, json1)
+
+	entries, err := fields.EntriesFromJSON(json1)
+	assert.NoError(t, err)
+	assert.Equal(t, entries1, entries)
+
+	for _, jData := range []string{
+		`{"key1":"othervalue1","key2":2,"key4":"othervalue4"}`,
+		`{"key1":"othervalue1","key2"`,
+	} {
+		t.Logf("testing with JSON data: %s", jData)
+		json2 := []v1.JSON{v1.JSON{Raw: []byte(jData)}}
+		entries, err = fields.EntriesFromJSON(json2)
+		assert.Error(t, err)
+		assert.Nil(t, entries)
+	}
 }

--- a/test/e2e/capability_argocd_test.go
+++ b/test/e2e/capability_argocd_test.go
@@ -183,7 +183,7 @@ func assertArgoCDUpdated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 		"git_path":     paasArgoGitPath,
 		"git_revision": updatedRevision,
 		"git_url":      paasArgoGitURL,
-		"groups":       "",
+		"groups":       "map[mygroup:map[query: roles:[view] users:[user1]]]",
 		"paas":         paasWithArgo,
 		"requestor":    paasRequestor,
 		"service":      "paas",


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- There is almost no coverage on internal/fields
- There is an implementation for group testing which uses reflect in internal/controller/capabilities_test

## What is the new behavior?

- There is 100% coverage on internal/fields
- group testing in internal/controller/capabilities_test can simply compafe the field against a string and no reflect is required

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

