### PR TITLE
chore(lint): remove redundant if statements

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -83,7 +83,6 @@ linters-settings:
       - name: function-length
         disabled: true
       - name: if-return
-        disabled: true
 
       # hikarukin: Fixing is seperate PR's:
       - name: import-alias-naming

--- a/internal/controller/paasconfig_controller.go
+++ b/internal/controller/paasconfig_controller.go
@@ -190,8 +190,5 @@ func (pcr *PaasConfigReconciler) setSuccessfulCondition(ctx context.Context, paa
 		Message: fmt.Sprintf("Reconciled (%s) successfully", paasConfig.Name),
 	})
 
-	if err := pcr.Status().Update(ctx, paasConfig); err != nil {
-		return err
-	}
-	return nil
+	return pcr.Status().Update(ctx, paasConfig)
 }

--- a/internal/controller/paasnamespaces.go
+++ b/internal/controller/paasnamespaces.go
@@ -63,10 +63,7 @@ func (r *PaasReconciler) ensurePaasNs(ctx context.Context, paas *v1alpha1.Paas, 
 		Namespace: pns.Namespace,
 	}, found)
 	if err != nil && errors.IsNotFound(err) {
-		if err = r.Create(ctx, pns); err != nil {
-			return err
-		}
-		return nil
+		return r.Create(ctx, pns)
 	} else if err != nil {
 		return err
 	} else if !paas.AmIOwner(found.OwnerReferences) {
@@ -139,9 +136,5 @@ func (r *PaasReconciler) ReconcilePaasNss(
 		}
 	}
 	logger.Info().Msg("cleaning obsolete namespaces ")
-	if err := r.FinalizePaasNss(ctx, paas); err != nil {
-		return err
-	}
-
-	return nil
+	return r.FinalizePaasNss(ctx, paas)
 }

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -40,19 +40,13 @@ func (r *PaasNSReconciler) EnsureSecret(
 	err := r.Get(ctx, namespacedName, found)
 	if err != nil && errors.IsNotFound(err) {
 		// Create the secret
-		if err = r.Create(ctx, secret); err != nil {
-			return err
-		}
-		return nil
+		return r.Create(ctx, secret)
 	} else if err != nil {
 		// Error that isn't due to the secret not existing
 		return err
-	} else {
-		if err = r.Update(ctx, secret); err != nil {
-			return err
-		}
-		return nil
 	}
+
+	return r.Update(ctx, secret)
 }
 
 func hashData(original string) string {


### PR DESCRIPTION
Enables the `[if-return]` Revive linting rule. Must wait for #431 to be merged as that PR similarly removes some redundant ifs caught by this linting rule.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

