### PR TITLE
feat: Making suffix in managed-by-label value configurable

### DIFF
--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -102,6 +102,13 @@ type PaasConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	ManagedByLabel string `json:"managed_by_label"`
 
+	// Deprecated: ManagedBySuffix is a temporary implementation, to be replaced by go template functionality
+	// once available
+	// Suffix to be appended to the managed-by-label
+	// +kubebuilder:default:=argocd
+	// +kubebuilder:validation:Optional
+	ManagedBySuffix string `json:"managed_by_suffix"`
+
 	// Deprecated: ArgoCD specific code will be removed from the operator
 	// Name of an ApplicationSet to be set as ignored in the ArgoCD bootstrap Application
 	// +kubebuilder:validation:MinLength=1

--- a/internal/controller/namespaces.go
+++ b/internal/controller/namespaces.go
@@ -85,7 +85,7 @@ func BackendNamespace(
 	logger.Info().Msgf("setting Quotagroup %s", quota)
 	ns.ObjectMeta.Labels[config.GetConfig().QuotaLabel] = quota
 
-	argoNameSpace := fmt.Sprintf("%s-argocd", paas.ManagedByPaas())
+	argoNameSpace := fmt.Sprintf("%s-%s", paas.ManagedByPaas(), config.GetConfig().ManagedBySuffix)
 	logger.Info().Msg("setting managed_by_label")
 	ns.ObjectMeta.Labels[config.GetConfig().ManagedByLabel] = argoNameSpace
 

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
@@ -238,6 +238,13 @@ spec:
                 description: Name of the label used to define by whom the resource
                   is managed.
                 type: string
+              managed_by_suffix:
+                default: argocd
+                description: |-
+                  Deprecated: ManagedBySuffix is a temporary implementation, to be replaced by go template functionality
+                  once available
+                  Suffix to be appended to the managed-by-label
+                type: string
               quota_label:
                 default: clusterquotagroup
                 description: Label which is added to clusterquotas

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -176,9 +176,10 @@ var examplePaasConfig = v1alpha1.PaasConfig{
 			Host: "ldap.example.com",
 			Port: 13,
 		},
-		ManagedByLabel: "argocd.argoproj.io/manby",
-		RequestorLabel: "o.lbl",
-		QuotaLabel:     "q.lbl",
+		ManagedByLabel:  "argocd.argoproj.io/manby",
+		ManagedBySuffix: "argocd",
+		RequestorLabel:  "o.lbl",
+		QuotaLabel:      "q.lbl",
 		RoleMappings: map[string][]string{
 			"default": {"admin"},
 			"viewer":  {"view"},


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- label key is configurable, but value is suffixed with a hardcoded value `-argocd`

## What is the new behavior?

- value suffix is configurable with a value from paas config defaulting to `-argocd`
- PaasConfig value is immediately deprecated, as we would ideally replace it by an implementation using go template

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

