### PR TITLE
feat: disable argo

### DIFF
--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -81,6 +81,12 @@ type PaasConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	ArgoPermissions ConfigArgoPermissions `json:"argopermissions"`
 
+	// Deprecated: ArgoCD specific code will be removed from the operator
+	// Option to enable or disable ArgoCD specific Code
+	// +kubebuilder:default:=true
+	// +kubebuilder:validation:Optional
+	ArgoEnabled bool `json:"argoenabled"`
+
 	// Namespace in which a clusterwide ArgoCD can be found for managing capabilities and appProjects
 	// Deprecated: ArgoCD specific code will be removed from the operator
 	// +kubebuilder:validation:MinLength=1

--- a/internal/controller/argo_projects.go
+++ b/internal/controller/argo_projects.go
@@ -27,6 +27,10 @@ func (r *PaasReconciler) EnsureAppProject(
 	paas *v1alpha1.Paas,
 ) error {
 	ctx, logger := logging.GetLogComponent(ctx, "appproject")
+	if !config.GetConfig().ArgoEnabled {
+		logger.Info().Msg("ArgoCD specific code is disabled")
+		return nil
+	}
 	logger.Info().Msg("creating Argo Project")
 	project, err := r.BackendAppProject(ctx, paas)
 	if err != nil {

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -241,7 +241,9 @@ func (pr *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 	if err = pr.ensureAppSetCaps(ctx, paas); err != nil {
 		return ctrl.Result{}, errors.Join(err, pr.setErrorCondition(ctx, paas, err))
 	} else if argoCap, exists := paas.Spec.Capabilities["argocd"]; exists {
-		if argoCap.IsEnabled() {
+		if !config.GetConfig().ArgoEnabled {
+			logger.Info().Msg("ArgoCD specific code is disabled")
+		} else if argoCap.IsEnabled() {
 			logger.Info().Msg("creating Argo App for client bootstrapping")
 
 			// Create bootstrap Argo App

--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -11,69 +11,102 @@ import (
 
 	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/internal/config"
+	"github.com/belastingdienst/opr-paas/internal/fields"
 	paasquota "github.com/belastingdienst/opr-paas/internal/quota"
-	appv1 "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
+	gitops "github.com/belastingdienst/opr-paas/internal/stubs/argoproj-labs/v1beta1"
+	argocd "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func patchAppSet(ctx context.Context, newAppSet *argocd.ApplicationSet) {
+	oldAppSet := &argocd.ApplicationSet{}
+	namespacedName := types.NamespacedName{
+		Name:      newAppSet.Name,
+		Namespace: newAppSet.Namespace,
+	}
+	err := k8sClient.Get(ctx, namespacedName, oldAppSet)
+	if err == nil {
+		// Patch
+		patch := client.MergeFrom(oldAppSet.DeepCopy())
+		oldAppSet.Spec = newAppSet.Spec
+		err = k8sClient.Patch(ctx, oldAppSet, patch)
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		Expect(err.Error()).To(MatchRegexp(`applicationsets.argoproj.io .* not found`))
+		err = k8sClient.Create(ctx, newAppSet)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func assureNamespace(ctx context.Context, namespaceName string) {
+	oldNs := &corev1.Namespace{}
+	namespacedName := types.NamespacedName{
+		Name: namespaceName,
+	}
+	err := k8sClient.Get(ctx, namespacedName, oldNs)
+	if err == nil {
+		return
+	}
+	Expect(err.Error()).To(MatchRegexp(`namespaces .* not found`))
+	err = k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespaceName},
+	})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func assurePaas(ctx context.Context, newPaas *api.Paas) {
+	oldPaas := &api.Paas{}
+	namespacedName := types.NamespacedName{
+		Name: newPaas.Name,
+	}
+	err := k8sClient.Get(ctx, namespacedName, oldPaas)
+	if err == nil {
+		return
+	}
+	Expect(err.Error()).To(MatchRegexp(`paas.cpet.belastingdienst.nl .* not found`))
+	err = k8sClient.Create(ctx, newPaas)
+	Expect(err).NotTo(HaveOccurred())
+}
 
 var _ = Describe("Paas Controller", Ordered, func() {
 	const (
-		paasName           = "paas-controller-paas"
 		paasRequestor      = "paas-controller"
+		paasNamePrefix     = paasRequestor + "-paas"
 		capAppSetNamespace = "asns"
 		capAppSetName      = "argoas"
+		capName            = "argocd"
 	)
 	var (
-		paas       *api.Paas
-		reconciler *PaasReconciler
-		request    controllerruntime.Request
-		myConfig   api.PaasConfig
+		paas         *api.Paas
+		appSet       *argocd.ApplicationSet
+		reconciler   *PaasReconciler
+		request      controllerruntime.Request
+		myConfig     api.PaasConfig
+		paasName     = paasRequestor
+		capNamespace = paasName + "-" + capName
 	)
 	ctx := context.Background()
 
 	BeforeAll(func() {
-		paas = &api.Paas{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: paasName,
-			},
-			Spec: api.PaasSpec{
-				Requestor: paasRequestor,
-				Capabilities: api.PaasCapabilities{
-					"argocd": api.PaasCapability{
-						Enabled: true,
-					},
-				},
-				Quota: paasquota.Quota{
-					"cpu": resourcev1.MustParse("1"),
-				},
-			},
-		}
-		err := k8sClient.Create(ctx, paas)
-		Expect(err).NotTo(HaveOccurred())
-		err = k8sClient.Create(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: "gsns"},
-		})
-		Expect(err).NotTo(HaveOccurred())
-		err = k8sClient.Create(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: paasName + "-argocd"},
-		})
-		Expect(err).NotTo(HaveOccurred())
-		appSet := &appv1.ApplicationSet{
+		assureNamespace(ctx, "gsns")
+		appSet = &argocd.ApplicationSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      capAppSetName,
 				Namespace: capAppSetNamespace,
 			},
-			Spec: appv1.ApplicationSetSpec{
-				Generators: []appv1.ApplicationSetGenerator{},
-				Template: appv1.ApplicationSetTemplate{
-					ApplicationSetTemplateMeta: appv1.ApplicationSetTemplateMeta{},
-					Spec: appv1.ApplicationSpec{
-						Destination: appv1.ApplicationDestination{
+			Spec: argocd.ApplicationSetSpec{
+				Generators: []argocd.ApplicationSetGenerator{},
+				Template: argocd.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argocd.ApplicationSetTemplateMeta{},
+					Spec: argocd.ApplicationSpec{
+						Destination: argocd.ApplicationDestination{
 							Server:    "somewhere.org",
 							Namespace: "default",
 							Name:      "somewhere",
@@ -83,17 +116,32 @@ var _ = Describe("Paas Controller", Ordered, func() {
 				},
 			},
 		}
-		err = k8sClient.Create(ctx, appSet)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	BeforeEach(func() {
+		paas = &api.Paas{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: paasName,
+			},
+			Spec: api.PaasSpec{
+				Requestor: paasRequestor,
+				Capabilities: api.PaasCapabilities{
+					capName: api.PaasCapability{
+						Enabled: true,
+					},
+				},
+				Quota: paasquota.Quota{
+					"cpu": resourcev1.MustParse("1"),
+				},
+			},
+		}
 		myConfig = api.PaasConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "paas-config",
 			},
 			Spec: api.PaasConfigSpec{
-				ClusterWideArgoCDNamespace: "asns",
+				ArgoEnabled:                true,
+				ClusterWideArgoCDNamespace: capAppSetNamespace,
 				ArgoPermissions: api.ConfigArgoPermissions{
 					ResourceName:  "argocd",
 					DefaultPolicy: "role:tester",
@@ -101,8 +149,8 @@ var _ = Describe("Paas Controller", Ordered, func() {
 					Header:        "g, system:cluster-admins, role:admin",
 				},
 				Capabilities: map[string]api.ConfigCapability{
-					"argocd": {
-						AppSet: "argoas",
+					capName: {
+						AppSet: capAppSetName,
 						QuotaSettings: api.ConfigQuotaSettings{
 							DefQuota: map[corev1.ResourceName]resourcev1.Quantity{
 								corev1.ResourceLimitsCPU: resourcev1.MustParse("5"),
@@ -127,14 +175,180 @@ var _ = Describe("Paas Controller", Ordered, func() {
 			Client: k8sClient,
 			Scheme: k8sClient.Scheme(),
 		}
-		request.Name = paasName
 	})
 
-	When("reconciling a Paas", func() {
+	When("reconciling a Paas with argocd capability", func() {
 		It("should not return an error", func() {
+			paasName = paasRequestor + "-normal"
+			paas.Name = paasName
+			request.Name = paasName
+			capNamespace = paasName + "-" + capName
+			assurePaas(ctx, paas)
+			assureNamespace(ctx, capNamespace)
+			patchAppSet(ctx, appSet)
 			result, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter.Microseconds()).To(BeZero())
+		})
+		It("should create an appset entry", func() {
+			appSet := &argocd.ApplicationSet{}
+			appSetName := types.NamespacedName{
+				Name:      capAppSetName,
+				Namespace: capAppSetNamespace,
+			}
+			err := k8sClient.Get(ctx, appSetName, appSet)
+			Expect(err).NotTo(HaveOccurred())
+			entries := make(fields.Entries)
+			for _, generator := range appSet.Spec.Generators {
+				generatorEntries, err := fields.EntriesFromJSON(generator.List.Elements)
+				Expect(err).NotTo(HaveOccurred())
+				entries = entries.Merge(generatorEntries)
+			}
+			Expect(entries).To(HaveKey(paasName))
+		})
+		It("should create an argo bootstrap app", func() {
+			app := &argocd.Application{}
+			appName := types.NamespacedName{
+				Name:      argoAppName,
+				Namespace: capNamespace,
+			}
+			err := k8sClient.Get(ctx, appName, app)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should create an argocd", func() {
+			argo := &gitops.ArgoCD{}
+			argoName := types.NamespacedName{
+				Name:      config.GetConfig().ArgoPermissions.ResourceName,
+				Namespace: capNamespace,
+			}
+			err := k8sClient.Get(ctx, argoName, argo)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should create an argo project", func() {
+			proj := &argocd.AppProject{}
+			projName := types.NamespacedName{
+				Name:      paasName,
+				Namespace: capAppSetNamespace,
+			}
+			err := k8sClient.Get(ctx, projName, proj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	When("reconciling a Paas without argocd capability", func() {
+		It("should not return an error", func() {
+			paasName = paasRequestor + "-nocap"
+			paas.Name = paasName
+			paas.Spec.Capabilities = make(api.PaasCapabilities)
+			request.Name = paasName
+			capNamespace = paasName + "-" + capName
+			assurePaas(ctx, paas)
+			assureNamespace(ctx, capNamespace)
+			patchAppSet(ctx, appSet)
+			paas.Spec.Capabilities = make(api.PaasCapabilities)
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter.Microseconds()).To(BeZero())
+		})
+
+		It("should not create an appset entry", func() {
+			appSet := &argocd.ApplicationSet{}
+			appSetName := types.NamespacedName{
+				Name:      capAppSetName,
+				Namespace: capAppSetNamespace,
+			}
+			err := k8sClient.Get(ctx, appSetName, appSet)
+			Expect(err).NotTo(HaveOccurred())
+			entries := make(fields.Entries)
+			for _, generator := range appSet.Spec.Generators {
+				generatorEntries, err := fields.EntriesFromJSON(generator.List.Elements)
+				Expect(err).NotTo(HaveOccurred())
+				entries = entries.Merge(generatorEntries)
+			}
+			Expect(entries).NotTo(HaveKey(paasName))
+		})
+
+		It("should not create an argo bootstrap app", func() {
+			app := &argocd.Application{}
+			appName := types.NamespacedName{
+				Name:      argoAppName,
+				Namespace: capNamespace,
+			}
+			err := k8sClient.Get(ctx, appName, app)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`applications.argoproj.io "` + argoAppName + `" not found`))
+		})
+
+		It("should not create an argocd", func() {
+			argocdName := config.GetConfig().ArgoPermissions.ResourceName
+			argo := &gitops.ArgoCD{}
+			argoName := types.NamespacedName{
+				Name:      argocdName,
+				Namespace: capNamespace,
+			}
+			err := k8sClient.Get(ctx, argoName, argo)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`argocds.argoproj.io "` + argocdName + `" not found`))
+		})
+		It("should create an argo project", func() {
+			proj := &argocd.AppProject{}
+			projName := types.NamespacedName{
+				Name:      paasName,
+				Namespace: capAppSetNamespace,
+			}
+			err := k8sClient.Get(ctx, projName, proj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	When("reconciling a Paas with argocd disabled", func() {
+		It("should not return an error", func() {
+			paasName = paasRequestor + "-nocode"
+			paas.Name = paasName
+			request.Name = paasName
+			capNamespace = paasName + "-" + capName
+			assurePaas(ctx, paas)
+			assureNamespace(ctx, capNamespace)
+			patchAppSet(ctx, appSet)
+			myConfig.Spec.ArgoEnabled = false
+			config.SetConfig(myConfig)
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter.Microseconds()).To(BeZero())
+		})
+
+		It("should not create an argo bootstrap app", func() {
+			app := &argocd.Application{}
+			appName := types.NamespacedName{
+				Name:      argoAppName,
+				Namespace: capNamespace,
+			}
+			err := k8sClient.Get(ctx, appName, app)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`applications.argoproj.io "` + argoAppName + `" not found`))
+		})
+
+		It("should not create an argocd", func() {
+			argocdName := config.GetConfig().ArgoPermissions.ResourceName
+			argo := &gitops.ArgoCD{}
+			argoName := types.NamespacedName{
+				Name:      argocdName,
+				Namespace: capNamespace,
+			}
+			err := k8sClient.Get(ctx, argoName, argo)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`argocds.argoproj.io "` + argocdName + `" not found`))
+		})
+
+		It("should not create an argo project", func() {
+			proj := &argocd.AppProject{}
+			projName := types.NamespacedName{
+				Name:      paasName,
+				Namespace: capAppSetNamespace,
+			}
+			err := k8sClient.Get(ctx, projName, proj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`appprojects.argoproj.io "` + paasName + `" not found`))
 		})
 	})
 })

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,8 +18,8 @@ import (
 	"slices"
 	"testing"
 
-	argocd "github.com/belastingdienst/opr-paas/internal/stubs/argoproj-labs/v1beta1"
-	"github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
+	gitops "github.com/belastingdienst/opr-paas/internal/stubs/argoproj-labs/v1beta1"
+	argocd "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
 
 	"github.com/go-logr/zerologr"
 	. "github.com/onsi/ginkgo/v2"
@@ -134,7 +134,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Add Argo to schema
-	err = v1alpha1.AddToScheme(scheme.Scheme)
+	err = gitops.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = quotav1.AddToScheme(scheme.Scheme)

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
@@ -37,6 +37,12 @@ spec:
             type: object
           spec:
             properties:
+              argoenabled:
+                default: true
+                description: |-
+                  Deprecated: ArgoCD specific code will be removed from the operator
+                  Option to enable or disable ArgoCD specific Code
+                type: boolean
               argopermissions:
                 description: |-
                   Deprecated: ArgoCD specific code will be removed from the operator

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -39,7 +39,7 @@ var examplePaasConfig = v1alpha1.PaasConfig{
 		Name: "paas-config",
 	},
 	Spec: v1alpha1.PaasConfigSpec{
-		ClusterWideArgoCDNamespace: "asns",
+		ArgoEnabled: true,
 		ArgoPermissions: v1alpha1.ConfigArgoPermissions{
 			ResourceName:  "argocd",
 			DefaultPolicy: "role:tester",
@@ -167,11 +167,18 @@ var examplePaasConfig = v1alpha1.PaasConfig{
 				},
 			},
 		},
-		Debug: false,
+		ClusterWideArgoCDNamespace: "asns",
+		Debug:                      false,
 		DecryptKeysSecret: v1alpha1.NamespacedName{
 			Name:      "example-keys",
 			Namespace: "paas-system",
 		},
+		ExcludeAppSetName: "whatever",
+		GroupSyncList: v1alpha1.NamespacedName{
+			Namespace: "gsns",
+			Name:      "wlname",
+		},
+		GroupSyncListKey: "groupsynclist.txt",
 		LDAP: v1alpha1.ConfigLdap{
 			Host: "ldap.example.com",
 			Port: 13,
@@ -184,12 +191,6 @@ var examplePaasConfig = v1alpha1.PaasConfig{
 			"default": {"admin"},
 			"viewer":  {"view"},
 		},
-		GroupSyncList: v1alpha1.NamespacedName{
-			Namespace: "gsns",
-			Name:      "wlname",
-		},
-		GroupSyncListKey:  "groupsynclist.txt",
-		ExcludeAppSetName: "whatever",
 	},
 }
 


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

ArgoCD specific code is always enabled

## What is the new behavior?

- In PaasConfig the ArgoCD specific code can be disabled

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This allows us to easily switch between ArgoCD management by opr-paas code and management by helm.