### PR TITLE
fix: Rollback providing groups as interface into appset generator fields

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -137,9 +137,17 @@ jobs:
           else
             echo "No open pull request found for this branch."
           fi
+      - name: create badge
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          profile: cover.out
+          threshold-total: 42
+          git-token: ${{ github.ref_name == 'main' && secrets.GITHUB_TOKEN || '' }}
+          git-branch: badges
       - name: post coverage report
         if: env.pull_request_id
         uses: thollander/actions-comment-pull-request@v3
+        continue-on-error: true #we need pull_request_target or this will fail when not running pr in BD organisation
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-tag: coverage-report
@@ -152,13 +160,6 @@ jobs:
         if: steps.coverage.outcome == 'failure'
         shell: bash
         run: echo "coverage check failed" && exit 1
-      - name: create badge
-        uses: vladopajic/go-test-coverage@v2
-        with:
-          profile: cover.out
-          threshold-total: 42
-          git-token: ${{ github.ref_name == 'main' && secrets.GITHUB_TOKEN || '' }}
-          git-branch: badges
 
   e2e-test:
     name: Run e2e tests against deployed image

--- a/.testcoverage.yaml
+++ b/.testcoverage.yaml
@@ -66,7 +66,7 @@ override:
   - path: internal/controller/argocd.go
     threshold: 35
   - path: internal/controller/capabilities.go
-    threshold: 59
+    threshold: 58
   - path: internal/controller/cluster_quotas.go
     threshold: 43
   - path: internal/controller/cluster_wide_quota.go

--- a/internal/controller/capabilities.go
+++ b/internal/controller/capabilities.go
@@ -111,7 +111,10 @@ func (r *PaasReconciler) ensureAppSetCap(
 	elements["subservice"] = subService
 	// TODO (portly-halicore-76) make this configurable via customfields using go-template
 	// TODO (portly-halicore-76) add a unittest for this
-	elements["groups"] = paas.Spec.Groups
+	// TODO (devotional-phoenix-97) temp rollback.
+	// argocd cannot cope with non-string values, unless key = "values" and contents is map[string]string
+	// Proper fix with go-template, but for now, don;t break things
+	//elements["groups"] = paas.Spec.Groups
 	patch := client.MergeFrom(appSet.DeepCopy())
 	if listGen = getListGen(appSet.Spec.Generators); listGen == nil {
 		// create the list

--- a/internal/controller/capabilities_test.go
+++ b/internal/controller/capabilities_test.go
@@ -157,12 +157,10 @@ var _ = Describe("Capabilities controller", Ordered, func() {
 						"git_path":      "",
 						"git_revision":  "",
 						"git_url":       "",
-						// revive:disable-next-line
-						"groups":     "map[ldapgroup:map[query:CN=group1OU=example roles:[admin]] usergroup:map[query: roles:[edit view] users:[user1 user2]]]",
-						"paas":       paasName,
-						"requestor":  "my",
-						"service":    serviceName,
-						"subservice": "paas",
+						"paas":          paasName,
+						"requestor":     "my",
+						"service":       serviceName,
+						"subservice":    "paas",
 					}))
 			})
 		})

--- a/test/e2e/capability_argocd_test.go
+++ b/test/e2e/capability_argocd_test.go
@@ -183,7 +183,6 @@ func assertArgoCDUpdated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 		"git_path":     paasArgoGitPath,
 		"git_revision": updatedRevision,
 		"git_url":      paasArgoGitURL,
-		"groups":       "map[mygroup:map[query: roles:[view] users:[user1]]]",
 		"paas":         paasWithArgo,
 		"requestor":    paasRequestor,
 		"service":      "paas",


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Fixes: #473

## What is the new behavior?

Rollback of feeding the group to appset

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

