### PR TITLE
chore: enable function-length linting rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -80,7 +80,6 @@ linters-settings:
       - name: exported
         disabled: true
       - name: function-length
-        disabled: true
       - name: if-return
 
       # hikarukin: Fixing is seperate PR's:

--- a/cmd/crypttool/paas_file_test.go
+++ b/cmd/crypttool/paas_file_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//revive:disable-next-line
 func TestReadPaasFile(t *testing.T) {
 	expectedPaas := &v1alpha1.Paas{
 		TypeMeta: metav1.TypeMeta{

--- a/cmd/crypttool/reencrypt.go
+++ b/cmd/crypttool/reencrypt.go
@@ -36,6 +36,7 @@ func reencryptSecret(srcCrypt *crypt.Crypt, dstCrypt *crypt.Crypt, secret string
 	return reencrypted, nil
 }
 
+//revive:disable-next-line
 func reencryptFiles(privateKeyFiles string, publicKeyFile string, outputFormat string, files []string) error {
 	var errNum int
 	for _, fileName := range files {

--- a/cmd/webservice/config_test.go
+++ b/cmd/webservice/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//revive:disable-next-line
 func Test_formatEndpoint(t *testing.T) {
 	// test: empty endpoint
 	output := formatEndpoint("")

--- a/test/e2e/capability_argocd_test.go
+++ b/test/e2e/capability_argocd_test.go
@@ -55,6 +55,7 @@ func TestCapabilityArgoCD(t *testing.T) {
 		t,
 		features.New("ArgoCD Capability").
 			Setup(createPaasFn(paasWithArgo, paasSpec)).
+			Assess("ArgoCD namespace is created", assertArgoCDNsCreated).
 			Assess("ArgoCD application is created", assertArgoCDCreated).
 			Assess("ArgoCD application is updated", assertArgoCDUpdated).
 			Assess("ArgoCD application has ClusterRoleBindings", assertArgoCRB).
@@ -63,8 +64,7 @@ func TestCapabilityArgoCD(t *testing.T) {
 	)
 }
 
-func assertArgoCDCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-	paas := getPaas(ctx, paasWithArgo, t, cfg)
+func assertArgoCDNsCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	argopaasns := &api.PaasNS{ObjectMeta: metav1.ObjectMeta{
 		Name:      argoCapName,
 		Namespace: paasWithArgo,
@@ -97,7 +97,11 @@ func assertArgoCDCreated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 		"ArgoCD namespace created",
 	)
 
-	// Assert ArgoCD creation
+	return ctx
+}
+
+func assertArgoCDCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	paas := getPaas(ctx, paasWithArgo, t, cfg)
 	argocd := getOrFail(ctx, argoCapName, paasArgoNs, &v1beta1.ArgoCD{}, t, cfg)
 	assert.Equal(t, paas.UID, argocd.OwnerReferences[0].UID)
 	assert.Equal(t, "role:tester", *argocd.Spec.RBAC.DefaultPolicy)


### PR DESCRIPTION
Enables `function-length` Revive linting rule. Disabled the linting errors in `crypttool` code to avoid conflicts with the work underway to extract that code to its own repo.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

