### PR TITLE
fix(webhook): PaasConfig webhook returns warnings

### DIFF
--- a/.testcoverage.yaml
+++ b/.testcoverage.yaml
@@ -36,8 +36,6 @@ override:
   # (default is 80, as configured above in this example).
   #- path: ^pkg/lib/foo$
   #  threshold: 100
-  - path: ^internal/webhook/v1alpha1$
-    threshold: 77
   - path: ^internal/controller$
     threshold: 32
   - path: ^api/v1alpha1$
@@ -97,8 +95,6 @@ override:
     threshold: 45
   - path: internal/validate/main.go
     threshold: 62
-  - path: internal/webhook/v1alpha1/paasconfig_webhook.go
-    threshold: 68
 
 # Holds regexp rules which will exclude matched files or packages
 # from coverage statistics.

--- a/internal/webhook/v1alpha1/paasconfig_webhook.go
+++ b/internal/webhook/v1alpha1/paasconfig_webhook.go
@@ -81,7 +81,7 @@ func (v *PaasConfigCustomValidator) ValidateCreate(
 	}
 
 	// Ensure all required fields and values are there
-	if warnings, flderr := validatePaasConfigSpec(ctx, v.client, paasconfig.Spec); flderr != nil {
+	if warnings, flderr := validatePaasConfigSpec(ctx, v.client, paasconfig.Spec); flderr != nil || len(warnings) > 0 {
 		warn = append(warn, warnings...)
 		allErrs = append(allErrs, flderr...)
 	}
@@ -112,7 +112,7 @@ func (v *PaasConfigCustomValidator) ValidateUpdate(
 	logger.Info().Msgf("validation for updating of PaasConfig %s", paasconfig.GetName())
 
 	// Ensure all required fields and values are there
-	if warnings, flderr := validatePaasConfigSpec(ctx, v.client, paasconfig.Spec); flderr != nil {
+	if warnings, flderr := validatePaasConfigSpec(ctx, v.client, paasconfig.Spec); flderr != nil || len(warnings) > 0 {
 		warn = append(warn, warnings...)
 		allErrs = append(allErrs, flderr...)
 	}

--- a/internal/webhook/v1alpha1/paasconfig_webhook_test.go
+++ b/internal/webhook/v1alpha1/paasconfig_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 var _ = Describe("Creating a PaasConfig", Ordered, func() {
@@ -195,7 +196,7 @@ var _ = Describe("Creating a PaasConfig", Ordered, func() {
 
 				warn, err := validator.ValidateCreate(ctx, obj)
 				Expect(err).Error().To(Not(HaveOccurred()))
-				Expect(warn).To(BeEmpty())
+				Expect(warn).To(Equal(admission.Warnings{"spec.excludeappsetname: deprecated"}))
 			})
 		})
 		Context("having a capability defined with a custom_field", func() {

--- a/internal/webhook/v1alpha1/paasconfig_webhook_test.go
+++ b/internal/webhook/v1alpha1/paasconfig_webhook_test.go
@@ -97,6 +97,27 @@ var _ = Describe("Creating a PaasConfig", Ordered, func() {
 				Expect(err.Error()).To(ContainSubstring(`failed to compile validation regexp for paas.groupName`))
 			})
 		})
+		Context("with deprecated fields", func() {
+			It("should raise an error", func() {
+				obj.Spec.ArgoPermissions = v1alpha1.ConfigArgoPermissions{
+					Header: "something",
+				}
+				obj.Spec.GroupSyncListKey = "something.txt"
+				obj.Spec.GroupSyncList = v1alpha1.NamespacedName{
+					Name: "something",
+				}
+				warn, err := validator.ValidateCreate(ctx, obj)
+
+				Expect(err).Error().NotTo(HaveOccurred())
+				Expect(warn).To(HaveLen(4))
+				Expect(warn).To(ContainElements(
+					"spec.argopermissions: deprecated",
+					"spec.excludeappsetname: deprecated",
+					"spec.groupsynclistkey: deprecated",
+					"spec.groupsynclist: deprecated",
+				))
+			})
+		})
 		Context("and a PaasConfig resource already exists", func() {
 			It("should deny creation", func() {
 				existing := &v1alpha1.PaasConfig{}
@@ -358,5 +379,40 @@ var _ = Describe("Updating a PaasConfig", Ordered, func() {
 					ContainSubstring(`failed to compile validation regexp for paas.groupName`))
 			})
 		})
+	})
+})
+
+var _ = Describe("Deleting a PaasConfig", Ordered, func() {
+	var (
+		obj       *v1alpha1.PaasConfig
+		validator PaasConfigCustomValidator
+	)
+
+	BeforeEach(func() {
+		obj = &v1alpha1.PaasConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "newPaasConfig"},
+			Spec: v1alpha1.PaasConfigSpec{
+				DecryptKeysSecret: v1alpha1.NamespacedName{
+					Name:      paasConfigPkSecret,
+					Namespace: paasConfigSystem,
+				},
+			},
+		}
+		validator = PaasConfigCustomValidator{client: k8sClient}
+	})
+
+	It("should not accept another resource type", func() {
+		obj := &corev1.Secret{}
+		warn, err := validator.ValidateDelete(ctx, obj)
+
+		Expect(warn).To(BeEmpty())
+		Expect(err).Error().To(MatchError("expected a PaasConfig object but got *v1.Secret"))
+	})
+
+	It("should not return warnings nor an error", func() {
+		warn, err := validator.ValidateDelete(ctx, obj)
+
+		Expect(warn).To(BeEmpty())
+		Expect(err).Error().To(Not(HaveOccurred()))
 	})
 })


### PR DESCRIPTION
I was trying to improve test coverage in the `webhook` package and found a small bug, so I've fixed it.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): Improve test coverage in webhooks

## What is the current behavior?

Creation or update of a `PaasConfig` doesn't return warnings from the admission webhook

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- When PaasConfig validation finds warnings, the admission webhook returns these.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
