### PR TITLE
feat: option to use go-templates in custom-fields

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -360,7 +360,7 @@ func (pc *PaasCapability) CapExtraFields(
 			}
 		} else if fieldConf.Required {
 			issues = append(issues, fmt.Errorf("value %s is required", key))
-		} else {
+		} else if fieldConf.Template == "" || fieldConf.Default != "" {
 			elements[key] = fieldConf.Default
 		}
 	}

--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -237,6 +237,9 @@ type ConfigCustomField struct {
 	// Only applies when Required is false.
 	// +kubebuilder:validation:Optional
 	Default string `json:"default"`
+	// You can now use a go-template string to use Paas and PaasConfig variables and compile a value
+	// +kubebuilder:validation:Optional
+	Template string `json:"template"`
 	// Define if the value must be specified in the PaaS.
 	// When set to true, and no value is set, PaasNs has error in status field, and capability is not built.
 	// When set to false, and no value is set, Default is used.

--- a/internal/controller/capabilities_test.go
+++ b/internal/controller/capabilities_test.go
@@ -75,9 +75,8 @@ var _ = Describe("Capabilities controller", Ordered, func() {
 
 	BeforeEach(func() {
 		const (
-			groupTemplate = `system:cluster-admins, role:admin
-{{ range $groupName, $group := .Paas.Spec.Groups }}g, {{ $groupName }}, role:admin
-{{end}}`
+			groupTemplate = `g, system:cluster-admins, role:admin{{ range $groupName, $group := .Paas.Spec.Groups }}
+g, {{ $groupName }}, role:admin{{end}}`
 		)
 		ctx = context.Background()
 		paasConfig = api.PaasConfig{
@@ -148,10 +147,9 @@ var _ = Describe("Capabilities controller", Ordered, func() {
 			})
 			It("should create an appset entry with proper data", func() {
 				const (
-					expectedPolicy = `system:cluster-admins, role:admin
+					expectedPolicy = `g, system:cluster-admins, role:admin
 g, ` + group1 + `, role:admin
-g, ` + group2 + `, role:admin
-`
+g, ` + group2 + `, role:admin`
 				)
 				err := reconciler.ensureAppSetCap(ctx, paas, capName)
 				Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -89,7 +89,6 @@ func createRoleBinding(
 		Any("subject", rb.Subjects).
 		Msg("creating RoleBinding")
 	err := r.Create(ctx, rb)
-
 	if err != nil {
 		// Creating the rolebinding failed
 		logger.Err(err).Msg("error creating rolebinding")

--- a/internal/templating/main.go
+++ b/internal/templating/main.go
@@ -52,3 +52,18 @@ func (t Templater) TemplateToMap(name string, templatedText string) (result Temp
 	}
 	return TemplateResult{name: yamlData}, nil
 }
+
+func (t Templater) CapCustomFieldsToMap(capName string) (result TemplateResult, err error) {
+	result = make(TemplateResult)
+	capConfig := t.Config.Spec.Capabilities[capName]
+	for name, fieldConfig := range capConfig.CustomFields {
+		if fieldConfig.Template != "" {
+			fieldResult, err := t.TemplateToMap(name, fieldConfig.Template)
+			if err != nil {
+				return nil, err
+			}
+			result = result.Merge(fieldResult)
+		}
+	}
+	return result, nil
+}

--- a/internal/templating/yaml_to.go
+++ b/internal/templating/yaml_to.go
@@ -3,12 +3,15 @@ package templating
 import (
 	"fmt"
 
+	"github.com/belastingdienst/opr-paas/internal/fields"
 	"gopkg.in/yaml.v3"
 )
 
-type TemplateMapResult map[string]interface{}
-type TemplateListResult []interface{}
-type TemplateResult map[string]string
+type (
+	TemplateMapResult  fields.Elements
+	TemplateListResult []interface{}
+	TemplateResult     map[string]string
+)
 
 func (tmr TemplateMapResult) AsResult(prefix string) (result TemplateResult) {
 	result = make(TemplateResult)
@@ -29,6 +32,25 @@ func (tlr TemplateListResult) AsResult(prefix string) (result TemplateResult) {
 	for i, value := range tlr {
 		key := fmt.Sprintf("%s%d", prefix, i)
 		result[key] = fmt.Sprintf("%v", value)
+	}
+	return result
+}
+
+func (tmr TemplateResult) Merge(other TemplateResult) (result TemplateResult) {
+	result = make(TemplateResult)
+	for key, value := range tmr {
+		result[key] = value
+	}
+	for key, value := range other {
+		result[key] = value
+	}
+	return result
+}
+
+func (tmr TemplateResult) AsFieldElements() (result fields.Elements) {
+	result = make(fields.Elements)
+	for key, value := range tmr {
+		result[key] = value
 	}
 	return result
 }

--- a/internal/templating/yaml_to_test.go
+++ b/internal/templating/yaml_to_test.go
@@ -7,14 +7,12 @@ import (
 )
 
 func TestYamlToMap(t *testing.T) {
-	var (
-		exampleYaml string = `
+	var exampleYaml string = `
 key1: val1
 key2: val2
 key3: valc
 key4: vald
 `
-	)
 	parsed, err := yamlToMap([]byte(exampleYaml))
 	assert.NoError(t, err)
 	expected := TemplateResult{
@@ -33,15 +31,32 @@ key4: vald
 	assert.Equal(t, expected, parsed.AsResult(""))
 }
 
-func TestYamlToList(t *testing.T) {
+func TestResultMerge(t *testing.T) {
 	var (
-		exampleYaml string = `
+		tr1 = TemplateResult{
+			"key1": "val1",
+			"key2": "val2",
+		}
+		tr2 = TemplateResult{
+			"key2": "1",
+			"key3": "val3",
+		}
+		expected = TemplateResult{
+			"key1": "val1",
+			"key2": "1",
+			"key3": "val3",
+		}
+	)
+	assert.Equal(t, expected, tr1.Merge(tr2))
+}
+
+func TestYamlToList(t *testing.T) {
+	var exampleYaml string = `
 - vala
 - valb
 - val3
 - val4
 `
-	)
 	parsed, err := yamlToList([]byte(exampleYaml))
 	assert.NoError(t, err)
 	expected := TemplateResult{

--- a/internal/webhook/v1alpha1/paasconfig_webhook.go
+++ b/internal/webhook/v1alpha1/paasconfig_webhook.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/internal/logging"
+	"github.com/belastingdienst/opr-paas/internal/templating"
 	"github.com/belastingdienst/opr-paas/internal/validate"
 	k8sv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -399,6 +400,17 @@ func validateConfigCustomField(
 					customfield.Default,
 					fmt.Sprintf("value does not match %s", customfield.Validation)))
 			}
+		}
+	}
+
+	if customfield.Template != "" {
+		err := templating.NewTemplater(v1alpha1.Paas{}, v1alpha1.PaasConfig{}).Verify(name, customfield.Template)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				childPath.Child("template"),
+				customfield.Template,
+				err.Error(),
+			))
 		}
 	}
 

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
@@ -98,6 +98,10 @@ spec:
                               When set to true, and no value is set, PaasNs has error in status field, and capability is not built.
                               When set to false, and no value is set, Default is used.
                             type: boolean
+                          template:
+                            description: You can now use a go-template string to use
+                              Paas and PaasConfig variables and compile a value
+                            type: string
                           validation:
                             description: Regular expression for validating input,
                               defaults to '', which means no validation.


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

You need to statically define custom fields in capabilities

## What is the new behavior?

- custom fields can now also specify go templates
- unittests are expanded

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

