### PR TITLE
fix: revert golangci/golangci-lint-action to 6.5.1

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -78,7 +78,7 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
         with:
           version: v1.64.5
           args: --verbose


### PR DESCRIPTION

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?


Seems like new version of golangci-lint action does not work with golangci-lint we currently use

## What is the new behavior?

This reverts update of gholangci-lint

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

