### PR TITLE
chore: Fixes #492 - Store entire PaasConfig for go-template feature

### DIFF
--- a/internal/config/paas_config_store.go
+++ b/internal/config/paas_config_store.go
@@ -16,22 +16,29 @@ import (
 
 // PaasConfigStore is a thread-safe store for the current PaasConfig
 type PaasConfigStore struct {
-	currentConfig v1alpha1.PaasConfigSpec
+	currentConfig v1alpha1.PaasConfig
 	mutex         sync.RWMutex
 }
 
 var cnf = &PaasConfigStore{}
 
-// GetConfig retrieves the current configuration
-func GetConfig() v1alpha1.PaasConfigSpec {
+// GetConfigSpec retrieVes the current configuration
+func GetConfig() v1alpha1.PaasConfig {
 	cnf.mutex.RLock()
 	defer cnf.mutex.RUnlock()
 	return cnf.currentConfig
+}
+
+// GetConfigSpec retrieVes the current configuration
+func GetConfigSpec() v1alpha1.PaasConfigSpec {
+	cnf.mutex.RLock()
+	defer cnf.mutex.RUnlock()
+	return cnf.currentConfig.Spec
 }
 
 // SetConfig updates the current configuration
 func SetConfig(newConfig v1alpha1.PaasConfig) {
 	cnf.mutex.Lock()
 	defer cnf.mutex.Unlock()
-	cnf.currentConfig = newConfig.Spec
+	cnf.currentConfig = newConfig
 }

--- a/internal/config/paas_config_store.go
+++ b/internal/config/paas_config_store.go
@@ -22,18 +22,11 @@ type PaasConfigStore struct {
 
 var cnf = &PaasConfigStore{}
 
-// GetConfigSpec retrieVes the current configuration
+// GetConfig retrieVes the current configuration
 func GetConfig() v1alpha1.PaasConfig {
 	cnf.mutex.RLock()
 	defer cnf.mutex.RUnlock()
 	return cnf.currentConfig
-}
-
-// GetConfigSpec retrieVes the current configuration
-func GetConfigSpec() v1alpha1.PaasConfigSpec {
-	cnf.mutex.RLock()
-	defer cnf.mutex.RUnlock()
-	return cnf.currentConfig.Spec
 }
 
 // SetConfig updates the current configuration

--- a/internal/config/paas_config_store_test.go
+++ b/internal/config/paas_config_store_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetConfigSpecWithEmptyConfigStore(t *testing.T) {
-	actual := GetConfigSpec()
+func TestGetConfigWithEmptyConfigStore(t *testing.T) {
+	actual := GetConfig()
 
 	assert.Empty(t, actual)
 }
 
-func TestGetConfigSpec(t *testing.T) {
+func TestGetConfig(t *testing.T) {
 	cnf = &PaasConfigStore{
 		currentConfig: v1alpha1.PaasConfig{
 			Spec: v1alpha1.PaasConfigSpec{
@@ -28,8 +28,8 @@ func TestGetConfigSpec(t *testing.T) {
 		},
 	}
 
-	actual := GetConfigSpec()
+	actual := GetConfig()
 
 	assert.NotEmpty(t, actual)
-	assert.True(t, actual.Debug)
+	assert.True(t, actual.Spec.Debug)
 }

--- a/internal/config/paas_config_store_test.go
+++ b/internal/config/paas_config_store_test.go
@@ -13,18 +13,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetConfigWithEmptyConfigStore(t *testing.T) {
-	actual := GetConfig()
+func TestGetConfigSpecWithEmptyConfigStore(t *testing.T) {
+	actual := GetConfigSpec()
 
 	assert.Empty(t, actual)
 }
 
-func TestGetConfig(t *testing.T) {
+func TestGetConfigSpec(t *testing.T) {
 	cnf = &PaasConfigStore{
-		currentConfig: v1alpha1.PaasConfigSpec{Debug: true},
+		currentConfig: v1alpha1.PaasConfig{
+			Spec: v1alpha1.PaasConfigSpec{
+				Debug: true,
+			},
+		},
 	}
 
-	actual := GetConfig()
+	actual := GetConfigSpec()
 
 	assert.NotEmpty(t, actual)
 	assert.True(t, actual.Debug)

--- a/internal/controller/argo_app.go
+++ b/internal/controller/argo_app.go
@@ -69,7 +69,7 @@ func (r *PaasReconciler) backendArgoApp(
 	namespace := fmt.Sprintf("%s-%s", paas.Name, argoCapName)
 	argoConfig := paas.Spec.Capabilities[argoCapName]
 	argoConfig.SetDefaults()
-	fields, err := argoConfig.CapExtraFields(config.GetConfig().Capabilities[argoCapName].CustomFields)
+	fields, err := argoConfig.CapExtraFields(config.GetConfigSpec().Capabilities[argoCapName].CustomFields)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (r *PaasReconciler) backendArgoApp(
 					Group:        "argoproj.io",
 					JSONPointers: []string{"/spec/generators"},
 					Kind:         "ApplicationSet",
-					Name:         config.GetConfig().ExcludeAppSetName,
+					Name:         config.GetConfigSpec().ExcludeAppSetName,
 				},
 			},
 			Project: "default",

--- a/internal/controller/argo_app.go
+++ b/internal/controller/argo_app.go
@@ -69,7 +69,7 @@ func (r *PaasReconciler) backendArgoApp(
 	namespace := fmt.Sprintf("%s-%s", paas.Name, argoCapName)
 	argoConfig := paas.Spec.Capabilities[argoCapName]
 	argoConfig.SetDefaults()
-	fields, err := argoConfig.CapExtraFields(config.GetConfigSpec().Capabilities[argoCapName].CustomFields)
+	fields, err := argoConfig.CapExtraFields(config.GetConfig().Spec.Capabilities[argoCapName].CustomFields)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (r *PaasReconciler) backendArgoApp(
 					Group:        "argoproj.io",
 					JSONPointers: []string{"/spec/generators"},
 					Kind:         "ApplicationSet",
-					Name:         config.GetConfigSpec().ExcludeAppSetName,
+					Name:         config.GetConfig().Spec.ExcludeAppSetName,
 				},
 			},
 			Project: "default",

--- a/internal/controller/argo_projects.go
+++ b/internal/controller/argo_projects.go
@@ -27,7 +27,7 @@ func (r *PaasReconciler) EnsureAppProject(
 	paas *v1alpha1.Paas,
 ) error {
 	ctx, logger := logging.GetLogComponent(ctx, "appproject")
-	if !config.GetConfigSpec().ArgoEnabled {
+	if !config.GetConfig().Spec.ArgoEnabled {
 		logger.Info().Msg("ArgoCD specific code is disabled")
 		return nil
 	}
@@ -80,7 +80,7 @@ func (r *PaasReconciler) BackendAppProject(
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: config.GetConfigSpec().ClusterWideArgoCDNamespace,
+			Namespace: config.GetConfig().Spec.ClusterWideArgoCDNamespace,
 			Labels:    paas.ClonedLabels(),
 			// Only removes appProject when apps no longer reference appProject
 			Finalizers: []string{

--- a/internal/controller/argo_projects.go
+++ b/internal/controller/argo_projects.go
@@ -27,7 +27,7 @@ func (r *PaasReconciler) EnsureAppProject(
 	paas *v1alpha1.Paas,
 ) error {
 	ctx, logger := logging.GetLogComponent(ctx, "appproject")
-	if !config.GetConfig().ArgoEnabled {
+	if !config.GetConfigSpec().ArgoEnabled {
 		logger.Info().Msg("ArgoCD specific code is disabled")
 		return nil
 	}
@@ -80,7 +80,7 @@ func (r *PaasReconciler) BackendAppProject(
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: config.GetConfig().ClusterWideArgoCDNamespace,
+			Namespace: config.GetConfigSpec().ClusterWideArgoCDNamespace,
 			Labels:    paas.ClonedLabels(),
 			// Only removes appProject when apps no longer reference appProject
 			Finalizers: []string{

--- a/internal/controller/argocd.go
+++ b/internal/controller/argocd.go
@@ -31,8 +31,8 @@ func (r *PaasReconciler) EnsureArgoCD(
 
 	namespace := fmt.Sprintf("%s-%s", paas.Name, "argocd")
 
-	defaultPolicy := config.GetConfig().ArgoPermissions.DefaultPolicy
-	policy := config.GetConfig().ArgoPermissions.FromGroups(paas.GroupNames())
+	defaultPolicy := config.GetConfigSpec().ArgoPermissions.DefaultPolicy
+	policy := config.GetConfigSpec().ArgoPermissions.FromGroups(paas.GroupNames())
 	scopes := "[groups]"
 
 	argo := &argocd.ArgoCD{
@@ -41,7 +41,7 @@ func (r *PaasReconciler) EnsureArgoCD(
 			APIVersion: "argoproj.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.GetConfig().ArgoPermissions.ResourceName,
+			Name:      config.GetConfigSpec().ArgoPermissions.ResourceName,
 			Namespace: namespace,
 		},
 		Spec: argocd.ArgoCDSpec{

--- a/internal/controller/argocd.go
+++ b/internal/controller/argocd.go
@@ -31,8 +31,8 @@ func (r *PaasReconciler) EnsureArgoCD(
 
 	namespace := fmt.Sprintf("%s-%s", paas.Name, "argocd")
 
-	defaultPolicy := config.GetConfigSpec().ArgoPermissions.DefaultPolicy
-	policy := config.GetConfigSpec().ArgoPermissions.FromGroups(paas.GroupNames())
+	defaultPolicy := config.GetConfig().Spec.ArgoPermissions.DefaultPolicy
+	policy := config.GetConfig().Spec.ArgoPermissions.FromGroups(paas.GroupNames())
 	scopes := "[groups]"
 
 	argo := &argocd.ArgoCD{
@@ -41,7 +41,7 @@ func (r *PaasReconciler) EnsureArgoCD(
 			APIVersion: "argoproj.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.GetConfigSpec().ArgoPermissions.ResourceName,
+			Name:      config.GetConfig().Spec.ArgoPermissions.ResourceName,
 			Namespace: namespace,
 		},
 		Spec: argocd.ArgoCDSpec{

--- a/internal/controller/capabilities.go
+++ b/internal/controller/capabilities.go
@@ -55,7 +55,7 @@ func (r *PaasReconciler) ensureAppSetCaps(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) error {
-	paasConfigSpec := config.GetConfigSpec()
+	paasConfigSpec := config.GetConfig().Spec
 	for capName := range paas.Spec.Capabilities {
 		if _, exists := paasConfigSpec.Capabilities[capName]; !exists {
 			return fmt.Errorf("capability not configured")
@@ -80,7 +80,7 @@ func (r *PaasReconciler) ensureAppSetCap(
 	var err error
 	var elements fields.Elements
 	// See if AppSet exists raise error if it doesn't
-	namespacedName := config.GetConfigSpec().CapabilityK8sName(capName)
+	namespacedName := config.GetConfig().Spec.CapabilityK8sName(capName)
 	appSet := &appv1.ApplicationSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Applicationset",
@@ -151,7 +151,7 @@ func (r *PaasNSReconciler) finalizeAppSetCap(
 ) error {
 	// See if AppSet exists raise error if it doesn't
 	as := &appv1.ApplicationSet{}
-	asNamespacedName := config.GetConfigSpec().CapabilityK8sName(paasns.Name)
+	asNamespacedName := config.GetConfig().Spec.CapabilityK8sName(paasns.Name)
 	ctx, logger := logging.GetLogComponent(ctx, "appset")
 	logger.Info().Msgf("reconciling %s Applicationset", paasns.Name)
 	err := r.Get(ctx, asNamespacedName, as)

--- a/internal/controller/capabilities.go
+++ b/internal/controller/capabilities.go
@@ -55,7 +55,7 @@ func (r *PaasReconciler) ensureAppSetCaps(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) error {
-	paasConfigSpec := config.GetConfig()
+	paasConfigSpec := config.GetConfigSpec()
 	for capName := range paas.Spec.Capabilities {
 		if _, exists := paasConfigSpec.Capabilities[capName]; !exists {
 			return fmt.Errorf("capability not configured")
@@ -80,7 +80,7 @@ func (r *PaasReconciler) ensureAppSetCap(
 	var err error
 	var elements fields.Elements
 	// See if AppSet exists raise error if it doesn't
-	namespacedName := config.GetConfig().CapabilityK8sName(capName)
+	namespacedName := config.GetConfigSpec().CapabilityK8sName(capName)
 	appSet := &appv1.ApplicationSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Applicationset",
@@ -102,13 +102,13 @@ func (r *PaasReconciler) ensureAppSetCap(
 	}
 
 	myConfig := config.GetConfig()
-	templater := templating.NewTemplater(*paas, v1alpha1.PaasConfig{Spec: myConfig})
+	templater := templating.NewTemplater(*paas, myConfig)
 	templatedElements, err := templater.CapCustomFieldsToMap(capName)
 	if err != nil {
 		return err
 	}
 	capability := paas.Spec.Capabilities[capName]
-	capElements, err := capability.CapExtraFields(myConfig.Capabilities[capName].CustomFields)
+	capElements, err := capability.CapExtraFields(myConfig.Spec.Capabilities[capName].CustomFields)
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func (r *PaasNSReconciler) finalizeAppSetCap(
 ) error {
 	// See if AppSet exists raise error if it doesn't
 	as := &appv1.ApplicationSet{}
-	asNamespacedName := config.GetConfig().CapabilityK8sName(paasns.Name)
+	asNamespacedName := config.GetConfigSpec().CapabilityK8sName(paasns.Name)
 	ctx, logger := logging.GetLogComponent(ctx, "appset")
 	logger.Info().Msgf("reconciling %s Applicationset", paasns.Name)
 	err := r.Get(ctx, asNamespacedName, as)

--- a/internal/controller/cluster_quotas.go
+++ b/internal/controller/cluster_quotas.go
@@ -87,7 +87,7 @@ func (r *PaasReconciler) backendQuota(
 			Selector: quotav1.ClusterResourceQuotaSelector{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						config.GetConfigSpec().QuotaLabel: quotaName,
+						config.GetConfig().Spec.QuotaLabel: quotaName,
 					},
 				},
 			},
@@ -110,7 +110,7 @@ func (r *PaasReconciler) BackendEnabledQuotas(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) (quotas []*quotav1.ClusterResourceQuota, err error) {
-	paasConfigSpec := config.GetConfigSpec()
+	paasConfigSpec := config.GetConfig().Spec
 	quotas = append(quotas, r.backendQuota(ctx, paas, "", paas.Spec.Quota))
 	for name, cap := range paas.Spec.Capabilities {
 		if capConfig, exists := paasConfigSpec.Capabilities[name]; !exists {
@@ -134,7 +134,7 @@ func (r *PaasReconciler) BackendUnneededQuotas(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) (quotas []string) {
-	paasConfigSpec := config.GetConfigSpec()
+	paasConfigSpec := config.GetConfig().Spec
 	for name, cap := range paas.Spec.Capabilities {
 		if capConfig, exists := paasConfigSpec.Capabilities[name]; !exists {
 			quotas = append(quotas, fmt.Sprintf("%s-%s", paas.Name, name))

--- a/internal/controller/cluster_quotas.go
+++ b/internal/controller/cluster_quotas.go
@@ -87,7 +87,7 @@ func (r *PaasReconciler) backendQuota(
 			Selector: quotav1.ClusterResourceQuotaSelector{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						config.GetConfig().QuotaLabel: quotaName,
+						config.GetConfigSpec().QuotaLabel: quotaName,
 					},
 				},
 			},
@@ -110,7 +110,7 @@ func (r *PaasReconciler) BackendEnabledQuotas(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) (quotas []*quotav1.ClusterResourceQuota, err error) {
-	paasConfigSpec := config.GetConfig()
+	paasConfigSpec := config.GetConfigSpec()
 	quotas = append(quotas, r.backendQuota(ctx, paas, "", paas.Spec.Quota))
 	for name, cap := range paas.Spec.Capabilities {
 		if capConfig, exists := paasConfigSpec.Capabilities[name]; !exists {
@@ -134,7 +134,7 @@ func (r *PaasReconciler) BackendUnneededQuotas(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) (quotas []string) {
-	paasConfigSpec := config.GetConfig()
+	paasConfigSpec := config.GetConfigSpec()
 	for name, cap := range paas.Spec.Capabilities {
 		if capConfig, exists := paasConfigSpec.Capabilities[name]; !exists {
 			quotas = append(quotas, fmt.Sprintf("%s-%s", paas.Name, name))

--- a/internal/controller/cluster_wide_quota.go
+++ b/internal/controller/cluster_wide_quota.go
@@ -69,7 +69,7 @@ func (r *PaasReconciler) UpdateClusterWideQuotaResources(
 	var allPaasResources paasquota.QuotaLists
 	if capabilityName, err := ClusterWideCapabilityName(quota.ObjectMeta.Name); err != nil {
 		return err
-	} else if configCapability, exists := config.GetConfigSpec().Capabilities[capabilityName]; !exists {
+	} else if configCapability, exists := config.GetConfig().Spec.Capabilities[capabilityName]; !exists {
 		return fmt.Errorf("missing capability config for %s", capabilityName)
 	} else if !configCapability.QuotaSettings.Clusterwide {
 		return fmt.Errorf("running UpdateClusterWideQuota for non-clusterwide quota %s", quota.ObjectMeta.Name)
@@ -106,7 +106,7 @@ func backendClusterWideQuota(
 			Selector: quotav1.ClusterResourceQuotaSelector{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						config.GetConfigSpec().QuotaLabel: quotaName,
+						config.GetConfig().Spec.QuotaLabel: quotaName,
 					},
 				},
 			},
@@ -170,7 +170,7 @@ func (r *PaasReconciler) addToClusterWideQuota(ctx context.Context, paas *v1alph
 	var quota *quotav1.ClusterResourceQuota
 	var exists bool
 	quotaName := ClusterWideQuotaName(capabilityName)
-	if paasConfigSpec, exists := config.GetConfigSpec().Capabilities[capabilityName]; !exists {
+	if paasConfigSpec, exists := config.GetConfig().Spec.Capabilities[capabilityName]; !exists {
 		return fmt.Errorf("capability %s does not seem to exist in configuration", capabilityName)
 	} else if !paasConfigSpec.QuotaSettings.Clusterwide {
 		return nil
@@ -209,7 +209,7 @@ func (r *PaasReconciler) removeFromClusterWideQuota(
 	quotaName := fmt.Sprintf("%s%s", cwqPrefix, capabilityName)
 	var capConfig v1alpha1.ConfigCapability
 	var exists bool
-	if capConfig, exists = config.GetConfigSpec().Capabilities[capabilityName]; !exists {
+	if capConfig, exists = config.GetConfig().Spec.Capabilities[capabilityName]; !exists {
 		// If a Paas was created with a capability that was nog yet configured, we should be able to delete it.
 		// Returning an error would block deletion.
 		return nil

--- a/internal/controller/cluster_wide_quota.go
+++ b/internal/controller/cluster_wide_quota.go
@@ -69,7 +69,7 @@ func (r *PaasReconciler) UpdateClusterWideQuotaResources(
 	var allPaasResources paasquota.QuotaLists
 	if capabilityName, err := ClusterWideCapabilityName(quota.ObjectMeta.Name); err != nil {
 		return err
-	} else if configCapability, exists := config.GetConfig().Capabilities[capabilityName]; !exists {
+	} else if configCapability, exists := config.GetConfigSpec().Capabilities[capabilityName]; !exists {
 		return fmt.Errorf("missing capability config for %s", capabilityName)
 	} else if !configCapability.QuotaSettings.Clusterwide {
 		return fmt.Errorf("running UpdateClusterWideQuota for non-clusterwide quota %s", quota.ObjectMeta.Name)
@@ -106,7 +106,7 @@ func backendClusterWideQuota(
 			Selector: quotav1.ClusterResourceQuotaSelector{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						config.GetConfig().QuotaLabel: quotaName,
+						config.GetConfigSpec().QuotaLabel: quotaName,
 					},
 				},
 			},
@@ -170,7 +170,7 @@ func (r *PaasReconciler) addToClusterWideQuota(ctx context.Context, paas *v1alph
 	var quota *quotav1.ClusterResourceQuota
 	var exists bool
 	quotaName := ClusterWideQuotaName(capabilityName)
-	if paasConfigSpec, exists := config.GetConfig().Capabilities[capabilityName]; !exists {
+	if paasConfigSpec, exists := config.GetConfigSpec().Capabilities[capabilityName]; !exists {
 		return fmt.Errorf("capability %s does not seem to exist in configuration", capabilityName)
 	} else if !paasConfigSpec.QuotaSettings.Clusterwide {
 		return nil
@@ -209,7 +209,7 @@ func (r *PaasReconciler) removeFromClusterWideQuota(
 	quotaName := fmt.Sprintf("%s%s", cwqPrefix, capabilityName)
 	var capConfig v1alpha1.ConfigCapability
 	var exists bool
-	if capConfig, exists = config.GetConfig().Capabilities[capabilityName]; !exists {
+	if capConfig, exists = config.GetConfigSpec().Capabilities[capabilityName]; !exists {
 		// If a Paas was created with a capability that was nog yet configured, we should be able to delete it.
 		// Returning an error would block deletion.
 		return nil

--- a/internal/controller/clusterrolebindings.go
+++ b/internal/controller/clusterrolebindings.go
@@ -164,7 +164,7 @@ func (r *PaasNSReconciler) ReconcileExtraClusterRoleBinding(
 ) (err error) {
 	var crb *rbac.ClusterRoleBinding
 	capability, capExists := paas.Spec.Capabilities[paasns.Name]
-	capConfig, capConfigExists := config.GetConfigSpec().Capabilities[paasns.Name]
+	capConfig, capConfigExists := config.GetConfig().Spec.Capabilities[paasns.Name]
 	if !(capConfigExists || capExists) {
 		return err
 	}
@@ -200,7 +200,7 @@ func (r *PaasReconciler) FinalizeExtraClusterRoleBindings(
 ) (err error) {
 	ctx, logger := logging.GetLogComponent(ctx, "clusterrolebinding")
 	var capRoles []string
-	for _, capConfig := range config.GetConfigSpec().Capabilities {
+	for _, capConfig := range config.GetConfig().Spec.Capabilities {
 		capRoles = append(capRoles, capConfig.ExtraPermissions.Roles()...)
 		capRoles = append(capRoles, capConfig.DefaultPermissions.Roles()...)
 	}

--- a/internal/controller/clusterrolebindings.go
+++ b/internal/controller/clusterrolebindings.go
@@ -164,7 +164,7 @@ func (r *PaasNSReconciler) ReconcileExtraClusterRoleBinding(
 ) (err error) {
 	var crb *rbac.ClusterRoleBinding
 	capability, capExists := paas.Spec.Capabilities[paasns.Name]
-	capConfig, capConfigExists := config.GetConfig().Capabilities[paasns.Name]
+	capConfig, capConfigExists := config.GetConfigSpec().Capabilities[paasns.Name]
 	if !(capConfigExists || capExists) {
 		return err
 	}
@@ -200,7 +200,7 @@ func (r *PaasReconciler) FinalizeExtraClusterRoleBindings(
 ) (err error) {
 	ctx, logger := logging.GetLogComponent(ctx, "clusterrolebinding")
 	var capRoles []string
-	for _, capConfig := range config.GetConfig().Capabilities {
+	for _, capConfig := range config.GetConfigSpec().Capabilities {
 		capRoles = append(capRoles, capConfig.ExtraPermissions.Roles()...)
 		capRoles = append(capRoles, capConfig.DefaultPermissions.Roles()...)
 	}

--- a/internal/controller/groups.go
+++ b/internal/controller/groups.go
@@ -105,12 +105,12 @@ func (r *PaasReconciler) backendGroup(
 			Annotations: map[string]string{
 				ldapUIDAnnotationKey: group.Query,
 				ldapURLAnnotationKey: fmt.Sprintf("%s:%d",
-					config.GetConfig().LDAP.Host,
-					config.GetConfig().LDAP.Port,
+					config.GetConfigSpec().LDAP.Host,
+					config.GetConfigSpec().LDAP.Port,
 				),
 			},
 		}
-		g.ObjectMeta.Labels[LdapHostLabelKey] = config.GetConfig().LDAP.Host
+		g.ObjectMeta.Labels[LdapHostLabelKey] = config.GetConfigSpec().LDAP.Host
 	} else {
 		g.ObjectMeta = metav1.ObjectMeta{
 			Name:   groupName,

--- a/internal/controller/groups.go
+++ b/internal/controller/groups.go
@@ -105,12 +105,12 @@ func (r *PaasReconciler) backendGroup(
 			Annotations: map[string]string{
 				ldapUIDAnnotationKey: group.Query,
 				ldapURLAnnotationKey: fmt.Sprintf("%s:%d",
-					config.GetConfigSpec().LDAP.Host,
-					config.GetConfigSpec().LDAP.Port,
+					config.GetConfig().Spec.LDAP.Host,
+					config.GetConfig().Spec.LDAP.Port,
 				),
 			},
 		}
-		g.ObjectMeta.Labels[LdapHostLabelKey] = config.GetConfigSpec().LDAP.Host
+		g.ObjectMeta.Labels[LdapHostLabelKey] = config.GetConfig().Spec.LDAP.Host
 	} else {
 		g.ObjectMeta = metav1.ObjectMeta{
 			Name:   groupName,

--- a/internal/controller/ldap_groups.go
+++ b/internal/controller/ldap_groups.go
@@ -26,7 +26,7 @@ func (r *PaasReconciler) ensureLdapGroupsConfigMap(
 	groupSynListKey string,
 ) error {
 	// Create the ConfigMap
-	wlConfigMap := config.GetConfig().GroupSyncList
+	wlConfigMap := config.GetConfigSpec().GroupSyncList
 	return r.Create(ctx, &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
@@ -37,7 +37,7 @@ func (r *PaasReconciler) ensureLdapGroupsConfigMap(
 			Namespace: wlConfigMap.Namespace,
 		},
 		Data: map[string]string{
-			config.GetConfig().GroupSyncListKey: groupSynListKey,
+			config.GetConfigSpec().GroupSyncListKey: groupSynListKey,
 		},
 	})
 }
@@ -50,7 +50,7 @@ func (r *PaasReconciler) EnsureLdapGroups(
 	ctx, logger := logging.GetLogComponent(ctx, "ldapgroup")
 	logger.Info().Msg("creating ldap groups for PAAS object ")
 	// See if group already exists and create if it doesn't
-	namespacedName := config.GetConfig().GroupSyncList
+	namespacedName := config.GetConfigSpec().GroupSyncList
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Configmap",
@@ -70,9 +70,9 @@ func (r *PaasReconciler) EnsureLdapGroups(
 	} else if err != nil {
 		logger.Err(err).Msg("could not retrieve groupsynclist configmap")
 		return err
-	} else if groupsynclist, exists := cm.Data[config.GetConfig().GroupSyncListKey]; !exists {
+	} else if groupsynclist, exists := cm.Data[config.GetConfigSpec().GroupSyncListKey]; !exists {
 		logger.Info().Msg("adding groupsynclist.txt to groupsynclist configmap")
-		cm.Data[config.GetConfig().GroupSyncListKey] = gs.AsString()
+		cm.Data[config.GetConfigSpec().GroupSyncListKey] = gs.AsString()
 	} else {
 		logger.Info().Msgf("reading group queries from groupsynclist %v", cm)
 		groupsynclistGroups := groups.NewGroups()
@@ -83,7 +83,7 @@ func (r *PaasReconciler) EnsureLdapGroups(
 			return nil
 		}
 		logger.Info().Msg("adding to groupsynclist configmap")
-		cm.Data[config.GetConfig().GroupSyncListKey] = groupsynclistGroups.AsString()
+		cm.Data[config.GetConfigSpec().GroupSyncListKey] = groupsynclistGroups.AsString()
 	}
 	logger.Info().Msgf("updating groupsynclist configmap: %v", cm)
 	return r.Update(ctx, cm)
@@ -96,7 +96,7 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 ) error {
 	ctx, logger := logging.GetLogComponent(ctx, "ldapgroup")
 	cm := &corev1.ConfigMap{}
-	wlConfigMap := config.GetConfig().GroupSyncList
+	wlConfigMap := config.GetConfigSpec().GroupSyncList
 	err := r.Get(ctx, types.NamespacedName{Name: wlConfigMap.Name, Namespace: wlConfigMap.Namespace}, cm)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info().Msg("groupsynclist configmap does not exist")
@@ -106,9 +106,9 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 		logger.Err(err).Msg("error retrieving groupsynclist configmap")
 		// Error that isn't due to the group not existing
 		return err
-	} else if groupsynclist, exists := cm.Data[config.GetConfig().GroupSyncListKey]; !exists {
+	} else if groupsynclist, exists := cm.Data[config.GetConfigSpec().GroupSyncListKey]; !exists {
 		// No groupsynclist.txt exists in the configmap, so nothing to clean
-		logger.Info().Msgf("%s does not exists in groupsynclist configmap", config.GetConfig().GroupSyncListKey)
+		logger.Info().Msgf("%s does not exists in groupsynclist configmap", config.GetConfigSpec().GroupSyncListKey)
 		return nil
 	} else {
 		var isChanged bool
@@ -126,7 +126,7 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 		if !isChanged {
 			return nil
 		}
-		cm.Data[config.GetConfig().GroupSyncListKey] = gs.AsString()
+		cm.Data[config.GetConfigSpec().GroupSyncListKey] = gs.AsString()
 	}
 	return r.Update(ctx, cm)
 }

--- a/internal/controller/ldap_groups.go
+++ b/internal/controller/ldap_groups.go
@@ -26,7 +26,7 @@ func (r *PaasReconciler) ensureLdapGroupsConfigMap(
 	groupSynListKey string,
 ) error {
 	// Create the ConfigMap
-	wlConfigMap := config.GetConfigSpec().GroupSyncList
+	wlConfigMap := config.GetConfig().Spec.GroupSyncList
 	return r.Create(ctx, &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
@@ -37,7 +37,7 @@ func (r *PaasReconciler) ensureLdapGroupsConfigMap(
 			Namespace: wlConfigMap.Namespace,
 		},
 		Data: map[string]string{
-			config.GetConfigSpec().GroupSyncListKey: groupSynListKey,
+			config.GetConfig().Spec.GroupSyncListKey: groupSynListKey,
 		},
 	})
 }
@@ -50,7 +50,7 @@ func (r *PaasReconciler) EnsureLdapGroups(
 	ctx, logger := logging.GetLogComponent(ctx, "ldapgroup")
 	logger.Info().Msg("creating ldap groups for PAAS object ")
 	// See if group already exists and create if it doesn't
-	namespacedName := config.GetConfigSpec().GroupSyncList
+	namespacedName := config.GetConfig().Spec.GroupSyncList
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Configmap",
@@ -70,9 +70,9 @@ func (r *PaasReconciler) EnsureLdapGroups(
 	} else if err != nil {
 		logger.Err(err).Msg("could not retrieve groupsynclist configmap")
 		return err
-	} else if groupsynclist, exists := cm.Data[config.GetConfigSpec().GroupSyncListKey]; !exists {
+	} else if groupsynclist, exists := cm.Data[config.GetConfig().Spec.GroupSyncListKey]; !exists {
 		logger.Info().Msg("adding groupsynclist.txt to groupsynclist configmap")
-		cm.Data[config.GetConfigSpec().GroupSyncListKey] = gs.AsString()
+		cm.Data[config.GetConfig().Spec.GroupSyncListKey] = gs.AsString()
 	} else {
 		logger.Info().Msgf("reading group queries from groupsynclist %v", cm)
 		groupsynclistGroups := groups.NewGroups()
@@ -83,7 +83,7 @@ func (r *PaasReconciler) EnsureLdapGroups(
 			return nil
 		}
 		logger.Info().Msg("adding to groupsynclist configmap")
-		cm.Data[config.GetConfigSpec().GroupSyncListKey] = groupsynclistGroups.AsString()
+		cm.Data[config.GetConfig().Spec.GroupSyncListKey] = groupsynclistGroups.AsString()
 	}
 	logger.Info().Msgf("updating groupsynclist configmap: %v", cm)
 	return r.Update(ctx, cm)
@@ -96,7 +96,7 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 ) error {
 	ctx, logger := logging.GetLogComponent(ctx, "ldapgroup")
 	cm := &corev1.ConfigMap{}
-	wlConfigMap := config.GetConfigSpec().GroupSyncList
+	wlConfigMap := config.GetConfig().Spec.GroupSyncList
 	err := r.Get(ctx, types.NamespacedName{Name: wlConfigMap.Name, Namespace: wlConfigMap.Namespace}, cm)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info().Msg("groupsynclist configmap does not exist")
@@ -106,9 +106,9 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 		logger.Err(err).Msg("error retrieving groupsynclist configmap")
 		// Error that isn't due to the group not existing
 		return err
-	} else if groupsynclist, exists := cm.Data[config.GetConfigSpec().GroupSyncListKey]; !exists {
+	} else if groupsynclist, exists := cm.Data[config.GetConfig().Spec.GroupSyncListKey]; !exists {
 		// No groupsynclist.txt exists in the configmap, so nothing to clean
-		logger.Info().Msgf("%s does not exists in groupsynclist configmap", config.GetConfigSpec().GroupSyncListKey)
+		logger.Info().Msgf("%s does not exists in groupsynclist configmap", config.GetConfig().Spec.GroupSyncListKey)
 		return nil
 	} else {
 		var isChanged bool
@@ -126,7 +126,7 @@ func (r *PaasReconciler) FinalizeLdapGroups(
 		if !isChanged {
 			return nil
 		}
-		cm.Data[config.GetConfigSpec().GroupSyncListKey] = gs.AsString()
+		cm.Data[config.GetConfig().Spec.GroupSyncListKey] = gs.AsString()
 	}
 	return r.Update(ctx, cm)
 }

--- a/internal/controller/namespaces.go
+++ b/internal/controller/namespaces.go
@@ -83,14 +83,14 @@ func BackendNamespace(
 		Spec: corev1.NamespaceSpec{},
 	}
 	logger.Info().Msgf("setting Quotagroup %s", quota)
-	ns.ObjectMeta.Labels[config.GetConfigSpec().QuotaLabel] = quota
+	ns.ObjectMeta.Labels[config.GetConfig().Spec.QuotaLabel] = quota
 
-	argoNameSpace := fmt.Sprintf("%s-%s", paas.ManagedByPaas(), config.GetConfigSpec().ManagedBySuffix)
+	argoNameSpace := fmt.Sprintf("%s-%s", paas.ManagedByPaas(), config.GetConfig().Spec.ManagedBySuffix)
 	logger.Info().Msg("setting managed_by_label")
-	ns.ObjectMeta.Labels[config.GetConfigSpec().ManagedByLabel] = argoNameSpace
+	ns.ObjectMeta.Labels[config.GetConfig().Spec.ManagedByLabel] = argoNameSpace
 
 	logger.Info().Msg("setting requestor_label")
-	ns.ObjectMeta.Labels[config.GetConfigSpec().RequestorLabel] = paas.Spec.Requestor
+	ns.ObjectMeta.Labels[config.GetConfig().Spec.RequestorLabel] = paas.Spec.Requestor
 
 	logger.Info().Str("Paas", paas.Name).Str("namespace", ns.Name).Msg("setting Owner")
 	if err := controllerutil.SetControllerReference(paas, ns, scheme); err != nil {
@@ -138,7 +138,7 @@ func (r *PaasNSReconciler) ReconcileNamespaces(
 ) (err error) {
 	nsName := paasns.NamespaceName()
 	var nsQuota string
-	if configCapability, exists := config.GetConfigSpec().Capabilities[paasns.Name]; !exists {
+	if configCapability, exists := config.GetConfig().Spec.Capabilities[paasns.Name]; !exists {
 		nsQuota = paas.Name
 	} else if !configCapability.QuotaSettings.Clusterwide {
 		nsQuota = nsName

--- a/internal/controller/namespaces.go
+++ b/internal/controller/namespaces.go
@@ -83,14 +83,14 @@ func BackendNamespace(
 		Spec: corev1.NamespaceSpec{},
 	}
 	logger.Info().Msgf("setting Quotagroup %s", quota)
-	ns.ObjectMeta.Labels[config.GetConfig().QuotaLabel] = quota
+	ns.ObjectMeta.Labels[config.GetConfigSpec().QuotaLabel] = quota
 
-	argoNameSpace := fmt.Sprintf("%s-%s", paas.ManagedByPaas(), config.GetConfig().ManagedBySuffix)
+	argoNameSpace := fmt.Sprintf("%s-%s", paas.ManagedByPaas(), config.GetConfigSpec().ManagedBySuffix)
 	logger.Info().Msg("setting managed_by_label")
-	ns.ObjectMeta.Labels[config.GetConfig().ManagedByLabel] = argoNameSpace
+	ns.ObjectMeta.Labels[config.GetConfigSpec().ManagedByLabel] = argoNameSpace
 
 	logger.Info().Msg("setting requestor_label")
-	ns.ObjectMeta.Labels[config.GetConfig().RequestorLabel] = paas.Spec.Requestor
+	ns.ObjectMeta.Labels[config.GetConfigSpec().RequestorLabel] = paas.Spec.Requestor
 
 	logger.Info().Str("Paas", paas.Name).Str("namespace", ns.Name).Msg("setting Owner")
 	if err := controllerutil.SetControllerReference(paas, ns, scheme); err != nil {
@@ -138,7 +138,7 @@ func (r *PaasNSReconciler) ReconcileNamespaces(
 ) (err error) {
 	nsName := paasns.NamespaceName()
 	var nsQuota string
-	if configCapability, exists := config.GetConfig().Capabilities[paasns.Name]; !exists {
+	if configCapability, exists := config.GetConfigSpec().Capabilities[paasns.Name]; !exists {
 		nsQuota = paas.Name
 	} else if !configCapability.QuotaSettings.Clusterwide {
 		nsQuota = nsName

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -110,7 +110,7 @@ func (pr *PaasReconciler) GetPaas(
 	// check if Config is set, as reconciling and finalizing without config, leaves object in limbo.
 	// this is only an issue when object is being removed, finalizers will not be removed
 	// causing the object to be in limbo.
-	if reflect.DeepEqual(v1alpha1.PaasConfigSpec{}, config.GetConfig()) {
+	if reflect.DeepEqual(v1alpha1.PaasConfigSpec{}, config.GetConfigSpec()) {
 		logger.Error().Msg(noConfigFoundMsg)
 		err = pr.setErrorCondition(
 			ctx,
@@ -241,7 +241,7 @@ func (pr *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 	if err = pr.ensureAppSetCaps(ctx, paas); err != nil {
 		return ctrl.Result{}, errors.Join(err, pr.setErrorCondition(ctx, paas, err))
 	} else if argoCap, exists := paas.Spec.Capabilities["argocd"]; exists {
-		if !config.GetConfig().ArgoEnabled {
+		if !config.GetConfigSpec().ArgoEnabled {
 			logger.Info().Msg("ArgoCD specific code is disabled")
 		} else if argoCap.IsEnabled() {
 			logger.Info().Msg("creating Argo App for client bootstrapping")

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -110,7 +110,7 @@ func (pr *PaasReconciler) GetPaas(
 	// check if Config is set, as reconciling and finalizing without config, leaves object in limbo.
 	// this is only an issue when object is being removed, finalizers will not be removed
 	// causing the object to be in limbo.
-	if reflect.DeepEqual(v1alpha1.PaasConfigSpec{}, config.GetConfigSpec()) {
+	if reflect.DeepEqual(v1alpha1.PaasConfigSpec{}, config.GetConfig().Spec) {
 		logger.Error().Msg(noConfigFoundMsg)
 		err = pr.setErrorCondition(
 			ctx,
@@ -241,7 +241,7 @@ func (pr *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 	if err = pr.ensureAppSetCaps(ctx, paas); err != nil {
 		return ctrl.Result{}, errors.Join(err, pr.setErrorCondition(ctx, paas, err))
 	} else if argoCap, exists := paas.Spec.Capabilities["argocd"]; exists {
-		if !config.GetConfigSpec().ArgoEnabled {
+		if !config.GetConfig().Spec.ArgoEnabled {
 			logger.Info().Msg("ArgoCD specific code is disabled")
 		} else if argoCap.IsEnabled() {
 			logger.Info().Msg("creating Argo App for client bootstrapping")

--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 		It("should create an argocd", func() {
 			argo := &gitops.ArgoCD{}
 			argoName := types.NamespacedName{
-				Name:      config.GetConfig().ArgoPermissions.ResourceName,
+				Name:      config.GetConfigSpec().ArgoPermissions.ResourceName,
 				Namespace: capNamespace,
 			}
 			err := k8sClient.Get(ctx, argoName, argo)
@@ -280,7 +280,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 		})
 
 		It("should not create an argocd", func() {
-			argocdName := config.GetConfig().ArgoPermissions.ResourceName
+			argocdName := config.GetConfigSpec().ArgoPermissions.ResourceName
 			argo := &gitops.ArgoCD{}
 			argoName := types.NamespacedName{
 				Name:      argocdName,
@@ -329,7 +329,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 		})
 
 		It("should not create an argocd", func() {
-			argocdName := config.GetConfig().ArgoPermissions.ResourceName
+			argocdName := config.GetConfigSpec().ArgoPermissions.ResourceName
 			argo := &gitops.ArgoCD{}
 			argoName := types.NamespacedName{
 				Name:      argocdName,

--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 		It("should create an argocd", func() {
 			argo := &gitops.ArgoCD{}
 			argoName := types.NamespacedName{
-				Name:      config.GetConfigSpec().ArgoPermissions.ResourceName,
+				Name:      config.GetConfig().Spec.ArgoPermissions.ResourceName,
 				Namespace: capNamespace,
 			}
 			err := k8sClient.Get(ctx, argoName, argo)
@@ -280,7 +280,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 		})
 
 		It("should not create an argocd", func() {
-			argocdName := config.GetConfigSpec().ArgoPermissions.ResourceName
+			argocdName := config.GetConfig().Spec.ArgoPermissions.ResourceName
 			argo := &gitops.ArgoCD{}
 			argoName := types.NamespacedName{
 				Name:      argocdName,
@@ -329,7 +329,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 		})
 
 		It("should not create an argocd", func() {
-			argocdName := config.GetConfigSpec().ArgoPermissions.ResourceName
+			argocdName := config.GetConfig().Spec.ArgoPermissions.ResourceName
 			argo := &gitops.ArgoCD{}
 			argoName := types.NamespacedName{
 				Name:      argocdName,

--- a/internal/controller/paasconfig_controller.go
+++ b/internal/controller/paasconfig_controller.go
@@ -86,8 +86,8 @@ func (pcr *PaasConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// As there can be reasons why we reconcile again, we check if there is a diff in the desired state vs GetConfig()
-	if reflect.DeepEqual(cfg.Spec, config.GetConfig()) {
+	// As there can be reasons why we reconcile again, we check if there is a diff in the desired state vs GetConfigSpec()
+	if reflect.DeepEqual(cfg.Spec, config.GetConfigSpec()) {
 		logger.Debug().Msg("Config already equals desired state")
 		// Reconciling succeeded, set appropriate Condition
 		err := pcr.setSuccessfulCondition(ctx, cfg)
@@ -99,7 +99,7 @@ func (pcr *PaasConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	logger.Info().Msg("configuration has changed")
-	if !reflect.DeepEqual(cfg.Spec.DecryptKeysSecret, config.GetConfig().DecryptKeysSecret) {
+	if !reflect.DeepEqual(cfg.Spec.DecryptKeysSecret, config.GetConfigSpec().DecryptKeysSecret) {
 		resetCrypts()
 	}
 	// Update the shared configuration store

--- a/internal/controller/paasconfig_controller.go
+++ b/internal/controller/paasconfig_controller.go
@@ -86,8 +86,8 @@ func (pcr *PaasConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// As there can be reasons why we reconcile again, we check if there is a diff in the desired state vs GetConfigSpec()
-	if reflect.DeepEqual(cfg.Spec, config.GetConfigSpec()) {
+	// As there can be reasons why we reconcile again, we check if there is a diff in the desired state vs GetConfig()
+	if reflect.DeepEqual(cfg.Spec, config.GetConfig().Spec) {
 		logger.Debug().Msg("Config already equals desired state")
 		// Reconciling succeeded, set appropriate Condition
 		err := pcr.setSuccessfulCondition(ctx, cfg)
@@ -99,7 +99,7 @@ func (pcr *PaasConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	logger.Info().Msg("configuration has changed")
-	if !reflect.DeepEqual(cfg.Spec.DecryptKeysSecret, config.GetConfigSpec().DecryptKeysSecret) {
+	if !reflect.DeepEqual(cfg.Spec.DecryptKeysSecret, config.GetConfig().Spec.DecryptKeysSecret) {
 		resetCrypts()
 	}
 	// Update the shared configuration store

--- a/internal/controller/paasnamespaces.go
+++ b/internal/controller/paasnamespaces.go
@@ -42,7 +42,7 @@ func (r *PaasReconciler) GetPaasNs(ctx context.Context, paas *v1alpha1.Paas, nam
 	}
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("defining")
-	pns.ObjectMeta.Labels[config.GetConfigSpec().RequestorLabel] = paas.Spec.Requestor
+	pns.ObjectMeta.Labels[config.GetConfig().Spec.RequestorLabel] = paas.Spec.Requestor
 
 	logger.Info().Msg("setting Owner")
 

--- a/internal/controller/paasnamespaces.go
+++ b/internal/controller/paasnamespaces.go
@@ -42,7 +42,7 @@ func (r *PaasReconciler) GetPaasNs(ctx context.Context, paas *v1alpha1.Paas, nam
 	}
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("defining")
-	pns.ObjectMeta.Labels[config.GetConfig().RequestorLabel] = paas.Spec.Requestor
+	pns.ObjectMeta.Labels[config.GetConfigSpec().RequestorLabel] = paas.Spec.Requestor
 
 	logger.Info().Msg("setting Owner")
 

--- a/internal/controller/paasns_controller.go
+++ b/internal/controller/paasns_controller.go
@@ -105,7 +105,7 @@ func (pnsr *PaasNSReconciler) GetPaasNs(ctx context.Context, req ctrl.Request) (
 	// check if Config is set, as reconciling and finalizing without config, leaves object in limbo.
 	// This is only an issue when object is being removed.
 	// Finalizers will not be removed causing the object to be in limbo.
-	if reflect.DeepEqual(v1alpha1.PaasConfigSpec{}, config.GetConfigSpec()) {
+	if reflect.DeepEqual(v1alpha1.PaasConfigSpec{}, config.GetConfig().Spec) {
 		logger.Error().Msg(noConfigFoundMsg)
 		err = pnsr.setErrorCondition(
 			ctx,
@@ -410,7 +410,7 @@ func (pnsr *PaasNSReconciler) paasFromPaasNs(
 func (pnsr *PaasNSReconciler) finalizePaasNs(ctx context.Context, paasns *v1alpha1.PaasNS) error {
 	ctx, logger := logging.GetLogComponent(ctx, paasNsComponentName)
 
-	cfg := config.GetConfigSpec()
+	cfg := config.GetConfig().Spec
 	// If PaasNs is related to a capability, remove it from appSet
 	if _, exists := cfg.Capabilities[paasns.Name]; exists {
 		if err := pnsr.finalizeAppSetCap(ctx, paasns); err != nil {

--- a/internal/controller/paasns_controller.go
+++ b/internal/controller/paasns_controller.go
@@ -105,7 +105,7 @@ func (pnsr *PaasNSReconciler) GetPaasNs(ctx context.Context, req ctrl.Request) (
 	// check if Config is set, as reconciling and finalizing without config, leaves object in limbo.
 	// This is only an issue when object is being removed.
 	// Finalizers will not be removed causing the object to be in limbo.
-	if reflect.DeepEqual(v1alpha1.PaasConfigSpec{}, config.GetConfig()) {
+	if reflect.DeepEqual(v1alpha1.PaasConfigSpec{}, config.GetConfigSpec()) {
 		logger.Error().Msg(noConfigFoundMsg)
 		err = pnsr.setErrorCondition(
 			ctx,
@@ -410,7 +410,7 @@ func (pnsr *PaasNSReconciler) paasFromPaasNs(
 func (pnsr *PaasNSReconciler) finalizePaasNs(ctx context.Context, paasns *v1alpha1.PaasNS) error {
 	ctx, logger := logging.GetLogComponent(ctx, paasNsComponentName)
 
-	cfg := config.GetConfig()
+	cfg := config.GetConfigSpec()
 	// If PaasNs is related to a capability, remove it from appSet
 	if _, exists := cfg.Capabilities[paasns.Name]; exists {
 		if err := pnsr.finalizeAppSetCap(ctx, paasns); err != nil {

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -180,7 +180,7 @@ func (r *PaasReconciler) reconcileRolebindings(
 
 		// Guarantee use of value for current iteration when referencing
 		paasns := paasns
-		for _, roleList := range config.GetConfigSpec().RoleMappings {
+		for _, roleList := range config.GetConfig().Spec.RoleMappings {
 			for _, role := range roleList {
 				roles[role] = []string{}
 			}
@@ -190,7 +190,7 @@ func (r *PaasReconciler) reconcileRolebindings(
 			logger.Info().Msgf("defining Rolebindings for Group %s", groupKey)
 			// Convert the groupKey to a groupName to map the rolebinding subjects to a group
 			groupName := paas.GroupKey2GroupName(groupKey)
-			for _, mappedRole := range config.GetConfigSpec().RoleMappings.Roles(groupRoles) {
+			for _, mappedRole := range config.GetConfig().Spec.RoleMappings.Roles(groupRoles) {
 				if role, exists := roles[mappedRole]; exists {
 					roles[mappedRole] = append(role, groupName)
 				} else {
@@ -235,7 +235,7 @@ func (r *PaasNSReconciler) ReconcileRolebindings(
 	for groupKey, groupRoles := range paas.Spec.Groups.Filtered(paasns.Spec.Groups).Roles() {
 		// Convert the groupKey to a groupName to map the rolebinding subjects to a group
 		groupName := paas.GroupKey2GroupName(groupKey)
-		for _, mappedRole := range config.GetConfigSpec().RoleMappings.Roles(groupRoles) {
+		for _, mappedRole := range config.GetConfig().Spec.RoleMappings.Roles(groupRoles) {
 			if role, exists := roles[mappedRole]; exists {
 				roles[mappedRole] = append(role, groupName)
 			} else {

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -180,7 +180,7 @@ func (r *PaasReconciler) reconcileRolebindings(
 
 		// Guarantee use of value for current iteration when referencing
 		paasns := paasns
-		for _, roleList := range config.GetConfig().RoleMappings {
+		for _, roleList := range config.GetConfigSpec().RoleMappings {
 			for _, role := range roleList {
 				roles[role] = []string{}
 			}
@@ -190,7 +190,7 @@ func (r *PaasReconciler) reconcileRolebindings(
 			logger.Info().Msgf("defining Rolebindings for Group %s", groupKey)
 			// Convert the groupKey to a groupName to map the rolebinding subjects to a group
 			groupName := paas.GroupKey2GroupName(groupKey)
-			for _, mappedRole := range config.GetConfig().RoleMappings.Roles(groupRoles) {
+			for _, mappedRole := range config.GetConfigSpec().RoleMappings.Roles(groupRoles) {
 				if role, exists := roles[mappedRole]; exists {
 					roles[mappedRole] = append(role, groupName)
 				} else {
@@ -235,7 +235,7 @@ func (r *PaasNSReconciler) ReconcileRolebindings(
 	for groupKey, groupRoles := range paas.Spec.Groups.Filtered(paasns.Spec.Groups).Roles() {
 		// Convert the groupKey to a groupName to map the rolebinding subjects to a group
 		groupName := paas.GroupKey2GroupName(groupKey)
-		for _, mappedRole := range config.GetConfig().RoleMappings.Roles(groupRoles) {
+		for _, mappedRole := range config.GetConfigSpec().RoleMappings.Roles(groupRoles) {
 			if role, exists := roles[mappedRole]; exists {
 				roles[mappedRole] = append(role, groupName)
 			} else {

--- a/internal/controller/rsa_controller.go
+++ b/internal/controller/rsa_controller.go
@@ -29,7 +29,7 @@ func (r *PaasNSReconciler) getRsaPrivateKeys(
 ) (*crypt.CryptPrivateKeys, error) {
 	ctx, logger := logging.GetLogComponent(ctx, "rolebinding")
 	rsaSecret := &corev1.Secret{}
-	cfg := config.GetConfigSpec()
+	cfg := config.GetConfig().Spec
 	namespacedName := cfg.DecryptKeysSecret
 
 	err := r.Get(ctx, types.NamespacedName{

--- a/internal/controller/rsa_controller.go
+++ b/internal/controller/rsa_controller.go
@@ -29,7 +29,7 @@ func (r *PaasNSReconciler) getRsaPrivateKeys(
 ) (*crypt.CryptPrivateKeys, error) {
 	ctx, logger := logging.GetLogComponent(ctx, "rolebinding")
 	rsaSecret := &corev1.Secret{}
-	cfg := config.GetConfig()
+	cfg := config.GetConfigSpec()
 	namespacedName := cfg.DecryptKeysSecret
 
 	err := r.Get(ctx, types.NamespacedName{

--- a/internal/webhook/v1alpha1/paas_webhook.go
+++ b/internal/webhook/v1alpha1/paas_webhook.go
@@ -107,7 +107,7 @@ type paasSpecValidator func(
 func (v *PaasCustomValidator) validate(ctx context.Context, paas *v1alpha1.Paas) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 	var warnings []string
-	conf := config.GetConfig()
+	conf := config.GetConfigSpec()
 	// Check for uninitialized config
 	if conf.DecryptKeysSecret.Name == "" {
 		return nil, apierrors.NewInternalError(fmt.Errorf("uninitialized PaasConfig"))
@@ -244,7 +244,7 @@ func validateCustomFields(
 
 	for cname, c := range paas.Spec.Capabilities {
 		// validateCaps() has already ensured the capability configuration exists
-		if _, err := c.CapExtraFields(config.GetConfig().Capabilities[cname].CustomFields); err != nil {
+		if _, err := c.CapExtraFields(config.GetConfigSpec().Capabilities[cname].CustomFields); err != nil {
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("capabilities").Key(cname),
 				"custom_fields",

--- a/internal/webhook/v1alpha1/paas_webhook.go
+++ b/internal/webhook/v1alpha1/paas_webhook.go
@@ -107,7 +107,7 @@ type paasSpecValidator func(
 func (v *PaasCustomValidator) validate(ctx context.Context, paas *v1alpha1.Paas) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 	var warnings []string
-	conf := config.GetConfigSpec()
+	conf := config.GetConfig().Spec
 	// Check for uninitialized config
 	if conf.DecryptKeysSecret.Name == "" {
 		return nil, apierrors.NewInternalError(fmt.Errorf("uninitialized PaasConfig"))
@@ -244,7 +244,7 @@ func validateCustomFields(
 
 	for cname, c := range paas.Spec.Capabilities {
 		// validateCaps() has already ensured the capability configuration exists
-		if _, err := c.CapExtraFields(config.GetConfigSpec().Capabilities[cname].CustomFields); err != nil {
+		if _, err := c.CapExtraFields(config.GetConfig().Spec.Capabilities[cname].CustomFields); err != nil {
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("capabilities").Key(cname),
 				"custom_fields",

--- a/internal/webhook/v1alpha1/paas_webhook_test.go
+++ b/internal/webhook/v1alpha1/paas_webhook_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should deny creation when a capability custom field is not configured", func() {
-			conf := config.GetConfig()
+			conf := config.GetConfigSpec()
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{
 				CustomFields: map[string]v1alpha1.ConfigCustomField{
 					"bar": {},
@@ -199,7 +199,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should deny creation when a capability is missing a required custom field", func() {
-			conf := config.GetConfig()
+			conf := config.GetConfigSpec()
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{
 				CustomFields: map[string]v1alpha1.ConfigCustomField{
 					"bar": {Required: true},
@@ -230,7 +230,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should deny creation when a custom field does not match validation regex", func() {
-			conf := config.GetConfig()
+			conf := config.GetConfigSpec()
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{
 				CustomFields: map[string]v1alpha1.ConfigCustomField{
 					"bar": {Validation: "^\\d+$"}, // Must be an integer
@@ -350,7 +350,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should warn when quota limits are set higher than requests", func() {
-			conf := config.GetConfig()
+			conf := config.GetConfigSpec()
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{}
 			config.SetConfig(v1alpha1.PaasConfig{Spec: conf})
 
@@ -383,7 +383,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should warn when extra permissions are requested for a capability that are not configured", func() {
-			conf := config.GetConfig()
+			conf := config.GetConfigSpec()
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{
 				ExtraPermissions: v1alpha1.ConfigCapPerm{
 					"bar": []string{"baz"},

--- a/internal/webhook/v1alpha1/paas_webhook_test.go
+++ b/internal/webhook/v1alpha1/paas_webhook_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should deny creation when a capability custom field is not configured", func() {
-			conf := config.GetConfigSpec()
+			conf := config.GetConfig().Spec
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{
 				CustomFields: map[string]v1alpha1.ConfigCustomField{
 					"bar": {},
@@ -199,7 +199,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should deny creation when a capability is missing a required custom field", func() {
-			conf := config.GetConfigSpec()
+			conf := config.GetConfig().Spec
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{
 				CustomFields: map[string]v1alpha1.ConfigCustomField{
 					"bar": {Required: true},
@@ -230,7 +230,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should deny creation when a custom field does not match validation regex", func() {
-			conf := config.GetConfigSpec()
+			conf := config.GetConfig().Spec
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{
 				CustomFields: map[string]v1alpha1.ConfigCustomField{
 					"bar": {Validation: "^\\d+$"}, // Must be an integer
@@ -350,7 +350,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should warn when quota limits are set higher than requests", func() {
-			conf := config.GetConfigSpec()
+			conf := config.GetConfig().Spec
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{}
 			config.SetConfig(v1alpha1.PaasConfig{Spec: conf})
 
@@ -383,7 +383,7 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 		})
 
 		It("Should warn when extra permissions are requested for a capability that are not configured", func() {
-			conf := config.GetConfigSpec()
+			conf := config.GetConfig().Spec
 			conf.Capabilities["foo"] = v1alpha1.ConfigCapability{
 				ExtraPermissions: v1alpha1.ConfigCapPerm{
 					"bar": []string{"baz"},

--- a/internal/webhook/v1alpha1/utils_webhook.go
+++ b/internal/webhook/v1alpha1/utils_webhook.go
@@ -35,7 +35,7 @@ func resetCrypts() {
 func getRsaPrivateKeys(ctx context.Context, _c client.Client) (*crypt.CryptPrivateKeys, error) {
 	ctx, logger := logging.GetLogComponent(ctx, "webhook_getRsaPrivateKeys")
 	rsaSecret := &corev1.Secret{}
-	config := cnf.GetConfigSpec()
+	config := cnf.GetConfig().Spec
 	namespacedName := config.DecryptKeysSecret
 
 	err := _c.Get(ctx, types.NamespacedName{

--- a/internal/webhook/v1alpha1/utils_webhook.go
+++ b/internal/webhook/v1alpha1/utils_webhook.go
@@ -35,7 +35,7 @@ func resetCrypts() {
 func getRsaPrivateKeys(ctx context.Context, _c client.Client) (*crypt.CryptPrivateKeys, error) {
 	ctx, logger := logging.GetLogComponent(ctx, "webhook_getRsaPrivateKeys")
 	rsaSecret := &corev1.Secret{}
-	config := cnf.GetConfig()
+	config := cnf.GetConfigSpec()
 	namespacedName := config.DecryptKeysSecret
 
 	err := _c.Get(ctx, types.NamespacedName{


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When we added go-template functionality, we decided to add PaasConfig too.
But the current PaasConfig watcher implementation only stores the PaasConfig Spec, and here we should use the entire PaasConfig block.
We now create a dummy PaasConfig, but that can bring unexpected behavior (as in .Config.Name returns a different value then the actual name).

## What is the new behavior?

Watcher code now stores the PaasConfig entirely.
Previous method is renamend for GetConfig to GetConfigSpec, amd all code uses that implementation.
A new function GetConfig returns the entire PaasConfig.
Templater code now has the complete PaasConfig including annotations, lables, and correct name.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

