### PR TITLE
chore: paasconfig webhook to fail when required and/or default is set together with template

### DIFF
--- a/internal/webhook/v1alpha1/paasconfig_webhook.go
+++ b/internal/webhook/v1alpha1/paasconfig_webhook.go
@@ -368,8 +368,10 @@ func validateConfigCustomField(
 	var allErrs field.ErrorList
 	childPath := rootPath.Child("customfields").Key(name)
 
-	// Can't set both Required and Default
-	if customfield.Required && customfield.Default != "" {
+	// Can't set a combination of Required, Default, and Template
+	if (customfield.Required && customfield.Default != "") ||
+		(customfield.Required && customfield.Template != "") ||
+		(customfield.Template != "" && customfield.Default != "") {
 		allErrs = append(allErrs, field.Invalid(
 			childPath,
 			"",


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Fixes: #491
- In PR #488 we have introduced go templating.
  With templating, adding defaults and require options together with template is not supported, but this is not fed back.

## What is the new behavior?

- We added webhook tests to return an error for a paasconfig with templating, and either default, require, or both.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

