### PR TITLE
feat(v1alpha2): implement conversion to and from v1alpha1

### DIFF
--- a/.testcoverage.yaml
+++ b/.testcoverage.yaml
@@ -40,8 +40,6 @@ override:
     threshold: 30
   - path: ^api/v1alpha1$
     threshold: 68
-  - path: ^api/v1alpha2$
-    threshold: 77
   - path: ^internal/crypt$
     threshold: 65
   - path: ^internal/config$

--- a/PROJECT
+++ b/PROJECT
@@ -41,7 +41,6 @@ resources:
   version: v1alpha1
 - api:
     crdVersion: v1
-    namespaced: true
   domain: cpet.belastingdienst.nl
   kind: Paas
   path: github.com/belastingdienst/opr-paas/api/v1alpha2

--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -427,8 +427,9 @@ func (ps *PaasStatus) GetMessages() []string {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:storageversion
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
+//+kubebuilder:conversion:hub
 //+kubebuilder:resource:path=paas,scope=Cluster
 
 // Paas is the Schema for the paas API

--- a/api/v1alpha2/paas_conversion.go
+++ b/api/v1alpha2/paas_conversion.go
@@ -8,6 +8,7 @@ package v1alpha2
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
@@ -20,7 +21,50 @@ func (p *Paas) ConvertTo(dstRaw conversion.Hub) error {
 		return fmt.Errorf("cannot convert to %s/%s: must be v1alpha1", dst.Namespace, dst.Name)
 	}
 
-	// TODO(AxiomaticFixedChimpanzee): Implement conversion logic from v1alpha2 to v1alpha1
+	dst.ObjectMeta = p.ObjectMeta
+	dst.Status.Conditions = p.Status.Conditions
+	dst.Spec.Requestor = p.Spec.Requestor
+	dst.Spec.Quota = p.Spec.Quota
+	dst.Spec.Capabilities = make(v1alpha1.PaasCapabilities)
+	dst.Spec.Groups = make(v1alpha1.PaasGroups)
+	dst.Spec.Namespaces = make([]string, 0)
+	dst.Spec.SSHSecrets = p.Spec.Secrets
+	dst.Spec.ManagedByPaas = p.Spec.ManagedByPaas
+
+	for name, capability := range p.Spec.Capabilities {
+		fields := capability.DeepCopy().CustomFields
+		gitUrl := fields["gitUrl"]
+		gitRevision := fields["gitRevision"]
+		gitPath := fields["gitPath"]
+		delete(fields, "gitUrl")
+		delete(fields, "gitRevision")
+		delete(fields, "gitPath")
+
+		dst.Spec.Capabilities[name] = v1alpha1.PaasCapability{
+			Enabled:          true,
+			GitURL:           gitUrl,
+			GitRevision:      gitRevision,
+			GitPath:          gitPath,
+			CustomFields:     fields,
+			Quota:            capability.Quota,
+			SSHSecrets:       capability.Secrets,
+			ExtraPermissions: capability.ExtraPermissions,
+		}
+	}
+
+	for name, group := range p.Spec.Groups {
+		dst.Spec.Groups[name] = v1alpha1.PaasGroup{
+			Query: group.Query,
+			Users: group.Users,
+			Roles: group.Roles,
+		}
+	}
+
+	for name := range p.Spec.Namespaces {
+		dst.Spec.Namespaces = append(dst.Spec.Namespaces, name)
+	}
+	sort.Strings(dst.Spec.Namespaces)
+
 	return nil
 }
 

--- a/api/v1alpha2/paas_conversion_test.go
+++ b/api/v1alpha2/paas_conversion_test.go
@@ -4,25 +4,143 @@ import (
 	"testing"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/internal/quota"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var exV1Alpha1 = &v1alpha1.Paas{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "foo",
+		Namespace: "bar",
+	},
+	Spec: v1alpha1.PaasSpec{
+		Requestor: "some-requestor",
+		Quota: quota.Quota{
+			corev1.ResourceLimitsCPU:      resource.MustParse("2"),
+			corev1.ResourceLimitsMemory:   resource.MustParse("2Gi"),
+			corev1.ResourceRequestsCPU:    resource.MustParse("500m"),
+			corev1.ResourceRequestsMemory: resource.MustParse("256Mi"),
+		},
+		Capabilities: v1alpha1.PaasCapabilities{
+			"argocd": {
+				Enabled:     true,
+				GitURL:      "ssh://git@example.com/some-repo.git",
+				GitRevision: "main",
+				GitPath:     ".",
+				CustomFields: map[string]string{
+					"field1": "value",
+				},
+				Quota: quota.Quota{
+					corev1.ResourceRequestsCPU: resource.MustParse("250m"),
+				},
+				SSHSecrets: map[string]string{
+					"secret1": "ZW5jcnlwdGVkIHZhbHVlCg==",
+				},
+				ExtraPermissions: true,
+			},
+		},
+		Groups: v1alpha1.PaasGroups{
+			"some-group": {
+				Query: "some query",
+				Users: []string{"user1", "user2"},
+				Roles: []string{"role1", "role2"},
+			},
+		},
+		Namespaces: []string{
+			"namespace1",
+			"namespace2",
+		},
+		ManagedByPaas: "some other paas",
+	},
+	Status: v1alpha1.PaasStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:   TypeReadyPaas,
+				Status: metav1.ConditionTrue,
+			},
+			{
+				Type:   TypeHasErrorsPaas,
+				Status: metav1.ConditionFalse,
+			},
+		},
+	},
+}
+var exV1Alpha2 = &Paas{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "foo",
+		Namespace: "bar",
+	},
+	Spec: PaasSpec{
+		Requestor: "some-requestor",
+		Quota: quota.Quota{
+			corev1.ResourceLimitsCPU:      resource.MustParse("2"),
+			corev1.ResourceLimitsMemory:   resource.MustParse("2Gi"),
+			corev1.ResourceRequestsCPU:    resource.MustParse("500m"),
+			corev1.ResourceRequestsMemory: resource.MustParse("256Mi"),
+		},
+		Capabilities: PaasCapabilities{
+			"argocd": {
+				CustomFields: map[string]string{
+					"field1":      "value",
+					"gitUrl":      "ssh://git@example.com/some-repo.git",
+					"gitRevision": "main",
+					"gitPath":     ".",
+				},
+				Quota: quota.Quota{
+					corev1.ResourceRequestsCPU: resource.MustParse("250m"),
+				},
+				Secrets: map[string]string{
+					"secret1": "ZW5jcnlwdGVkIHZhbHVlCg==",
+				},
+				ExtraPermissions: true,
+			},
+		},
+		Groups: PaasGroups{
+			"some-group": {
+				"some query",
+				[]string{"user1", "user2"},
+				[]string{"role1", "role2"},
+			},
+		},
+		Namespaces: PaasNamespaces{
+			"namespace1": {},
+			"namespace2": {},
+		},
+		ManagedByPaas: "some other paas",
+	},
+	Status: PaasStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:   TypeReadyPaas,
+				Status: metav1.ConditionTrue,
+			},
+			{
+				Type:   TypeHasErrorsPaas,
+				Status: metav1.ConditionFalse,
+			},
+		},
+	},
+}
+
 func TestConvertTo(t *testing.T) {
-	// TODO
+	src := exV1Alpha2.DeepCopy()
 	dst := &v1alpha1.Paas{}
-	src := &Paas{}
 
 	err := src.ConvertTo(dst)
 
 	assert.NoError(t, err)
+	assert.Equal(t, exV1Alpha1, dst)
 }
 
 func TestConvertFrom(t *testing.T) {
-	// TODO
-	src := &v1alpha1.Paas{}
+	src := exV1Alpha1.DeepCopy()
 	dst := &Paas{}
 
 	err := dst.ConvertFrom(src)
 
 	assert.NoError(t, err)
+	assert.Equal(t, exV1Alpha2, dst)
 }

--- a/api/v1alpha2/paas_types.go
+++ b/api/v1alpha2/paas_types.go
@@ -115,6 +115,7 @@ type PaasStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:path=paas,scope=Cluster
 
 // Paas is the Schema for the paas API
 type Paas struct {

--- a/examples/resources/_v1alpha2_paas.yaml
+++ b/examples/resources/_v1alpha2_paas.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: cpet.belastingdienst.nl/v1alpha2
+kind: Paas
+metadata:
+  labels:
+    app.kubernetes.io/name: paas
+    app.kubernetes.io/instance: paas-sample
+    app.kubernetes.io/part-of: opr-paas
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: opr-paas
+  name: aap-aap
+spec:
+  namespaces:
+    test: {}
+    prod:
+      groups:
+        - appa
+        - appart
+      secrets:
+        foo: c29tZXRoaW5nIHNlY3JldAo=
+  requestor: acme
+  groups:
+    appa:
+      users:
+        - aap
+        - paa
+    appart:
+      query: CN=appatest,OU=paas,OU=clusters,OU=corp,DC=prod,DC=acme,DC=org
+      roles:
+        - viewer
+    appart2:
+      query: CN=appatest,OU=paas,OU=clusters,OU=corp,DC=prod,DC=acme,DC=org
+      roles:
+        - viewer
+  quota:
+    limits.cpu: '13'
+    limits.memory: 42Gi
+    requests.cpu: '10'
+    requests.memory: 32Gi
+    requests.storage: 1024Gi
+    thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
+  capabilities:
+    argocd:
+      quota:
+        limits.cpu: '2'
+        limits.memory: 5Gi
+        requests.cpu: '1'
+        requests.memory: 4Gi
+        requests.storage: 20Gi
+      custom_fields:
+        gitUrl: https://scm.org/repo.git
+    sso: {}
+    tekton:
+      quota:
+        limits.cpu: '2'
+        limits.memory: 5Gi
+        requests.cpu: '1'
+        requests.memory: 4Gi
+        requests.storage: 20Gi

--- a/manifests/crd/kustomization.yaml
+++ b/manifests/crd/kustomization.yaml
@@ -2,14 +2,15 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/cpet.belastingdienst.nl_paasconfig.yaml
-- bases/cpet.belastingdienst.nl_paas.yaml
-- bases/cpet.belastingdienst.nl_paasns.yaml
+  - bases/cpet.belastingdienst.nl_paasconfig.yaml
+  - bases/cpet.belastingdienst.nl_paas.yaml
+  - bases/cpet.belastingdienst.nl_paasns.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
+  - path: patches/webhook_in_paas.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
@@ -20,5 +21,5 @@ patches:
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 
-#configurations:
-#- kustomizeconfig.yaml
+configurations:
+  - kustomizeconfig.yaml

--- a/manifests/crd/patches/webhook_in_paas.yaml
+++ b/manifests/crd/patches/webhook_in_paas.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: paas.cpet.belastingdienst.nl
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1


### PR DESCRIPTION
Implements the conversion between hub (v1alpha1) and spoke (v1alpha2) of Paas resources. This will be registered automatically by the v1alpha2 webhook once it is configured.

As noted in #508 , this conversion loses some information between the conversion from v1alpha2 to v1alpha1, in that the v1alpha1 version of the Paas does not yet have a place to put namespace fields like secrets and groups. That will need to be addressed in a followup.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
