### PR TITLE
test(e2e): conversions between Paas versions

### DIFF
--- a/.testcoverage.yaml
+++ b/.testcoverage.yaml
@@ -47,6 +47,8 @@ override:
 
   - path: api/v1alpha1/paasconfig_types.go
     threshold: 10
+  - path: api/v1alpha2/paas_types.go
+    threshold: 50
   - path: internal/config/watcher.go
     threshold: 0
   - path: internal/controller/argo_app.go

--- a/api/v1alpha2/paas_conversion.go
+++ b/api/v1alpha2/paas_conversion.go
@@ -14,6 +14,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
+const (
+	gitUrlKey      = "git_url"
+	gitRevisionKey = "git_revision"
+	gitPathKey     = "git_path"
+)
+
 // ConvertTo converts this Paas (v1alpha2) to the Hub version (v1alpha1).
 func (p *Paas) ConvertTo(dstRaw conversion.Hub) error {
 	dst, ok := dstRaw.(*v1alpha1.Paas)
@@ -33,12 +39,12 @@ func (p *Paas) ConvertTo(dstRaw conversion.Hub) error {
 
 	for name, capability := range p.Spec.Capabilities {
 		fields := capability.DeepCopy().CustomFields
-		gitUrl := fields["gitUrl"]
-		gitRevision := fields["gitRevision"]
-		gitPath := fields["gitPath"]
-		delete(fields, "gitUrl")
-		delete(fields, "gitRevision")
-		delete(fields, "gitPath")
+		gitUrl := fields[gitUrlKey]
+		gitRevision := fields[gitRevisionKey]
+		gitPath := fields[gitPathKey]
+		delete(fields, gitUrlKey)
+		delete(fields, gitRevisionKey)
+		delete(fields, gitPathKey)
 
 		dst.Spec.Capabilities[name] = v1alpha1.PaasCapability{
 			Enabled:          true,
@@ -91,13 +97,13 @@ func (p *Paas) ConvertFrom(srcRaw conversion.Hub) error {
 			fields[f] = capability.CustomFields[f]
 		}
 		if capability.GitURL != "" {
-			fields["gitUrl"] = capability.GitURL
+			fields[gitUrlKey] = capability.GitURL
 		}
 		if capability.GitRevision != "" {
-			fields["gitRevision"] = capability.GitRevision
+			fields[gitRevisionKey] = capability.GitRevision
 		}
 		if capability.GitPath != "" {
-			fields["gitPath"] = capability.GitPath
+			fields[gitPathKey] = capability.GitPath
 		}
 
 		p.Spec.Capabilities[name] = PaasCapability{

--- a/api/v1alpha2/paas_conversion_test.go
+++ b/api/v1alpha2/paas_conversion_test.go
@@ -84,10 +84,10 @@ var exV1Alpha2 = &Paas{
 		Capabilities: PaasCapabilities{
 			"argocd": {
 				CustomFields: map[string]string{
-					"field1":      "value",
-					"gitUrl":      "ssh://git@example.com/some-repo.git",
-					"gitRevision": "main",
-					"gitPath":     ".",
+					"field1":       "value",
+					"git_url":      "ssh://git@example.com/some-repo.git",
+					"git_revision": "main",
+					"git_path":     ".",
 				},
 				Quota: quota.Quota{
 					corev1.ResourceRequestsCPU: resource.MustParse("250m"),

--- a/api/v1alpha2/paas_types.go
+++ b/api/v1alpha2/paas_types.go
@@ -126,6 +126,10 @@ type Paas struct {
 	Status PaasStatus `json:"status,omitempty"`
 }
 
+func (p *Paas) GetConditions() []metav1.Condition {
+	return p.Status.Conditions
+}
+
 // +kubebuilder:object:root=true
 
 // PaasList contains a list of Paas

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -16,8 +16,10 @@ import (
 	argoprojv1alpha1 "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/api/v1alpha2"
 
 	quotav1 "github.com/openshift/api/quota/v1"
 	userv1 "github.com/openshift/api/user/v1"
@@ -277,16 +279,15 @@ func registerSchemes(cfg *envconf.Config) error {
 	}
 	scheme := r.GetScheme()
 
-	if err = v1alpha1.AddToScheme(scheme); err != nil {
-		return err
-	} else if err = quotav1.AddToScheme(scheme); err != nil {
-		return err
-	} else if err = userv1.AddToScheme(scheme); err != nil {
-		return err
-	} else if err = argoprojv1alpha1.AddToScheme(scheme); err != nil {
-		return err
-	} else if err = argoprojlabsv1beta1.AddToScheme(scheme); err != nil {
-		return err
+	for _, install := range []func(*runtime.Scheme) error{
+		v1alpha1.AddToScheme,
+		v1alpha2.AddToScheme,
+		quotav1.Install,
+		userv1.Install,
+		argoprojv1alpha1.AddToScheme,
+		argoprojlabsv1beta1.AddToScheme,
+	} {
+		install(scheme)
 	}
 
 	return nil

--- a/test/e2e/paas_conversion_test.go
+++ b/test/e2e/paas_conversion_test.go
@@ -1,0 +1,143 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/belastingdienst/opr-paas/api/v1alpha1"
+	"github.com/belastingdienst/opr-paas/api/v1alpha2"
+	"github.com/belastingdienst/opr-paas/internal/quota"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	paasv1Name = "paas-v1alpha1"
+	paasv2Name = "paas-v1alpha2"
+)
+
+func TestPaasConversion(t *testing.T) {
+	v1Spec := v1alpha1.PaasSpec{
+		Requestor: "paas-user",
+		Quota:     make(quota.Quota),
+		Capabilities: v1alpha1.PaasCapabilities{
+			"argocd": {
+				Enabled:     true,
+				GitURL:      "ssh://git@scm/repo.git",
+				GitRevision: "main",
+				CustomFields: map[string]string{
+					"git_path": ".",
+				},
+			},
+			"sso": {Enabled: true},
+			"tekton": {
+				Enabled: false,
+				SSHSecrets: map[string]string{
+					paasArgoGitURL: paasArgoSecret,
+				},
+			},
+		},
+		Namespaces: []string{"foo", "bar"},
+	}
+
+	testenv.Test(
+		t,
+		features.New("Conversion between Paas versions").
+			Setup(createPaasFn(paasv1Name, v1Spec)).
+			Assess("converted to v1alpha2 when requested", assertV2Conversion).
+			Assess("v1alpha2 can be created", assertV2Created).
+			Assess("v1alpha2 retrieved as v1alpha1", assertV1Conversion).
+			Teardown(teardownPaasFn(paasv1Name)).
+			Teardown(teardownPaasFn(paasv2Name)).
+			Feature(),
+	)
+}
+
+func assertV2Conversion(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	paas := v1alpha2.Paas{}
+	require.NoError(t, cfg.Client().Resources().Get(ctx, paasv1Name, cfg.Namespace(), &paas))
+
+	assert.Len(t, paas.Spec.Capabilities, 3)
+	assert.Equal(
+		t,
+		map[string]string{
+			"git_url":      "ssh://git@scm/repo.git",
+			"git_revision": "main",
+			"git_path":     ".",
+		},
+		paas.Spec.Capabilities["argocd"].CustomFields,
+	)
+	assert.Equal(
+		t,
+		map[string]string{
+			paasArgoGitURL: paasArgoSecret,
+		},
+		paas.Spec.Capabilities["tekton"].Secrets,
+	)
+
+	assert.Len(t, paas.Spec.Namespaces, 2)
+	assert.Contains(t, paas.Spec.Namespaces, "foo")
+	assert.Contains(t, paas.Spec.Namespaces, "bar")
+
+	return ctx
+}
+
+func assertV2Created(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	paasv2 := v1alpha2.Paas{
+		ObjectMeta: metav1.ObjectMeta{Name: paasv2Name},
+		Spec: v1alpha2.PaasSpec{
+			Requestor: "paas-user",
+			Quota:     make(quota.Quota),
+			Capabilities: v1alpha2.PaasCapabilities{
+				"argocd": {
+					CustomFields: map[string]string{
+						"git_url":      "ssh://git@scm/repo.git",
+						"git_revision": "main",
+					},
+				},
+				"sso": {},
+				"tekton": {
+					Secrets: map[string]string{
+						paasArgoGitURL: paasArgoSecret,
+					},
+				},
+			},
+			Namespaces: v1alpha2.PaasNamespaces{
+				"foo": {},
+				"bar": {
+					Secrets: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, createSync(ctx, cfg, &paasv2, v1alpha2.TypeReadyPaas))
+
+	return ctx
+}
+
+func assertV1Conversion(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	paas := v1alpha1.Paas{}
+	require.NoError(t, cfg.Client().Resources().Get(ctx, paasv2Name, cfg.Namespace(), &paas))
+
+	assert.Len(t, paas.Spec.Capabilities, 3)
+	assert.Len(t, paas.Spec.Capabilities["argocd"].CustomFields, 0)
+	assert.Equal(t, "ssh://git@scm/repo.git", paas.Spec.Capabilities["argocd"].GitURL)
+	assert.Equal(t, "main", paas.Spec.Capabilities["argocd"].GitRevision)
+	assert.Equal(
+		t,
+		map[string]string{
+			paasArgoGitURL: paasArgoSecret,
+		},
+		paas.Spec.Capabilities["tekton"].SSHSecrets,
+	)
+
+	assert.Equal(t, []string{"bar", "foo"}, paas.Spec.Namespaces)
+
+	return ctx
+}


### PR DESCRIPTION
Tests transparent conversion between versions of `Paas` resources (v1alpha1 and v1alpha2) on creation and retrieval.

Also fixes a small bug in the conversion where custom field names were incorrectly-cased.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): New end-to-end test scenarios

#