### PR TITLE
chore: upgrade golangci-lint

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -78,9 +78,9 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.64.5
+          version: v2.0.2
           args: --verbose
 
   code-gen:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,98 +1,89 @@
+---
+version: "2"
 run:
-  timeout: 5m
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: 'internal/*'
-      linters:
-        - dupl
 linters:
-  disable-all: true
+  default: none
   enable:
-    #- dupl
-    #- errcheck
-    # WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
-    # ERRO [linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports.
-    #- exportloopref
     - ginkgolinter
-    #- goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
-    # - lll
     - misspell
-    #- nakedret
-    #- prealloc
     - revive
-    #- staticcheck
-    - typecheck
-    #- unconvert
-    #- unparam
+    # - staticcheck
     - unused
-
-linters-settings:
-  revive:
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+        - name: add-constant
+          arguments:
+            - allowInts: 0,1,2,3
+              allowStrs: '""'
+              ignoreFuncs: assert\.Len,require\.Len
+              maxLitCount: "5"
+        - name: line-length-limit
+          arguments:
+            - 120
+          severity: warning
+          exclude:
+            - ""
+        - name: comment-spacings
+          disabled: true
+        - name: indent-error-flow
+          disabled: true
+        - name: use-errors-new
+          disabled: true
+        - name: bare-return
+        - name: cognitive-complexity
+          disabled: true
+        - name: context-as-argument
+        - name: cyclomatic
+          disabled: true
+        - name: dot-imports
+          arguments:
+            - allowedPackages:
+                - github.com/onsi/ginkgo/v2
+                - github.com/onsi/gomega
+        - name: early-return
+        - name: empty-block
+        - name: empty-lines
+        - name: exported
+          disabled: true
+        - name: function-length
+        - name: if-return
+        - name: import-alias-naming
+        - name: import-shadowing
+        - name: increment-decrement
+        - name: max-control-nesting
+        - name: max-public-structs
+          arguments:
+            - 14
+        - name: redefines-builtin-id
+        - name: receiver-naming
+        - name: redundant-import-alias
+        - name: struct-tag
+        - name: superfluous-else
+        - name: unchecked-type-assertion
+        - name: unexported-naming
+  exclusions:
+    generated: lax
     rules:
-      - name: comment-spacings
-      - name: add-constant
-        arguments:
-          - allowStrs: '""'
-            allowInts: '0,1,2,3'
-            ignoreFuncs: "assert\\.Len,require\\.Len"
-            maxLitCount: '5'
-      - name: line-length-limit
-        severity: warning
-        exclude: ['']
-        arguments: [120]
-
-      # devotional-phoenix: Fixing is seperate PR's:
-      - name: comment-spacings
-        disabled: true
-      - name: indent-error-flow
-        disabled: true
-      - name: use-errors-new
-        disabled: true
-
-      # axiomatic-fixed-chimpanzee: Fixing is seperate PR's:
-      - name: bare-return
-      - name: cognitive-complexity
-        disabled: true
-      - name: context-as-argument
-      - name: cyclomatic
-        disabled: true
-      - name: dot-imports
-        arguments:
-          - allowedPackages:
-              - github.com/onsi/ginkgo/v2
-              - github.com/onsi/gomega
-      - name: early-return
-      - name: empty-block
-      - name: empty-lines
-      - name: exported
-        disabled: true
-      - name: function-length
-      - name: if-return
-
-      # hikarukin: Fixing is seperate PR's:
-      - name: import-alias-naming
-      - name: import-shadowing
-      - name: increment-decrement
-      - name: max-control-nesting
-      - name: max-public-structs
-        arguments: [14]
-      - name: redefines-builtin-id
-      - name: receiver-naming
-      - name: redundant-import-alias
-      - name: struct-tag
-      - name: superfluous-else
-      - name: unchecked-type-assertion
-      - name: unexported-naming
+      - linters:
+          - dupl
+        path: internal/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Sets the toolchain to the version of go from this project's go.mod.
+GOTOOLCHAIN=$(shell go env GOVERSION)
+
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
@@ -232,7 +235,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.64.5
+GOLANGCI_LINT_VERSION ?= v2.0.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -252,7 +255,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary
@@ -264,7 +267,7 @@ set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOBIN=$(LOCALBIN) GOTOOLCHAIN=$(GOTOOLCHAIN) go install $${package} ;\
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)


### PR DESCRIPTION
Upgrade `golangci-lint` to v2. Config file migrated with `bin/golangci-lint migrate`.

Fixes #497 

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
