### PR TITLE
ci: Improving of coverage on paas_controller

### DIFF
--- a/.testcoverage.yaml
+++ b/.testcoverage.yaml
@@ -37,7 +37,7 @@ override:
   #- path: ^pkg/lib/foo$
   #  threshold: 100
   - path: ^internal/controller$
-    threshold: 42
+    threshold: 73
   - path: ^api/v1alpha1$
     threshold: 68
   - path: ^api/v1alpha2$
@@ -81,7 +81,7 @@ override:
   - path: internal/controller/namespaces.go
     threshold: 33
   - path: internal/controller/paas_controller.go
-    threshold: 27
+    threshold: 61
   - path: internal/controller/paasconfig_controller.go
     threshold: 0
   - path: internal/controller/paasnamespaces.go

--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -492,7 +492,7 @@ func (p Paas) WithoutMe(references []metav1.OwnerReference) (withoutMe []metav1.
 }
 
 // GetConditions is required for Paas to be used as v1alpha1.Resource
-func (p Paas) GetConditions() *[]metav1.Condition {
+func (p *Paas) GetConditions() *[]metav1.Condition {
 	return &p.Status.Conditions
 }
 

--- a/internal/controller/main.go
+++ b/internal/controller/main.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	requeueTimeout   = time.Minute * 10
-	noConfigFoundMsg = "no config found"
+	requeueTimeout = time.Minute * 10
 )
 
 // intersect finds the intersection of 2 lists of strings

--- a/internal/controller/namespace_def_test.go
+++ b/internal/controller/namespace_def_test.go
@@ -56,7 +56,7 @@ var _ = Describe("NamespaceDef", func() {
 				},
 			},
 		}
-		assurePaas(ctx, &paas)
+		assurePaas(ctx, paas)
 		paasConfig = api.PaasConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "paas-config",

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -93,7 +93,19 @@ func (r *PaasReconciler) getPaasFromRequest(
 
 	if paas.GetDeletionTimestamp() != nil {
 		logger.Info().Msg("paas marked for deletion")
-		return nil, r.updateFinalizer(ctx, paas)
+		if !controllerutil.ContainsFinalizer(paas, paasFinalizer) {
+			return nil, nil
+		}
+		for _, finalizationFunc := range []func(context.Context, *v1alpha1.Paas) error{
+			r.setFinalizing,
+			r.finalizePaas,
+			r.removeFinalizer,
+		} {
+			if err = finalizationFunc(ctx, paas); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
 	}
 
 	// Started reconciling, reset status
@@ -135,53 +147,52 @@ func (r *PaasReconciler) getPaasFromRequest(
 	return paas, nil
 }
 
-func (r *PaasReconciler) updateFinalizer(
+func (r *PaasReconciler) setFinalizing(
 	ctx context.Context,
 	paas *v1alpha1.Paas,
 ) error {
 	logger := log.Ctx(ctx)
 
-	if controllerutil.ContainsFinalizer(paas, paasFinalizer) {
-		logger.Info().Msg("finalizing Paas")
-		// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
-		meta.SetStatusCondition(paas.GetConditions(), metav1.Condition{
-			Type:   v1alpha1.TypeDegradedPaas,
-			Status: metav1.ConditionUnknown, Reason: "Finalizing", ObservedGeneration: paas.GetGeneration(),
-			Message: fmt.Sprintf("Performing finalizer operations for Paas: %s ", paas.GetName()),
-		})
+	logger.Info().Msg("finalizing Paas")
+	// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
+	meta.SetStatusCondition(paas.GetConditions(), metav1.Condition{
+		Type:   v1alpha1.TypeDegradedPaas,
+		Status: metav1.ConditionUnknown, Reason: "Finalizing", ObservedGeneration: paas.GetGeneration(),
+		Message: fmt.Sprintf("Performing finalizer operations for Paas: %s ", paas.GetName()),
+	})
 
-		if err := r.Status().Update(ctx, paas); err != nil {
-			logger.Err(err).Msg("Failed to update Paas status")
-			return err
-		}
-		// Run finalization logic for paasFinalizer. If the
-		// finalization logic fails, don't remove the finalizer so
-		// that we can retry during the next reconciliation.
-		if err := r.finalizePaas(ctx, paas); err != nil {
-			return err
-		}
-
-		meta.SetStatusCondition(paas.GetConditions(), metav1.Condition{
-			Type:   v1alpha1.TypeDegradedPaas,
-			Status: metav1.ConditionTrue, Reason: "Finalizing", ObservedGeneration: paas.GetGeneration(),
-			Message: fmt.Sprintf("Finalizer operations for Paas %s name were successfully accomplished",
-				paas.GetName()),
-		})
-
-		if err := r.Status().Update(ctx, paas); err != nil {
-			logger.Err(err).Msg("Failed to update Paas status")
-			return err
-		}
-
-		logger.Info().Msg("removing finalizer")
-		// Remove paasFinalizer. Once all finalizers have been
-		// removed, the object will be deleted.
-		controllerutil.RemoveFinalizer(paas, paasFinalizer)
-		if err := r.Update(ctx, paas); err != nil {
-			return err
-		}
-		logger.Info().Msg("finalization finished")
+	if err := r.Status().Update(ctx, paas); err != nil {
+		logger.Err(err).Msg("Failed to update Paas status")
+		return err
 	}
+	return nil
+}
+
+func (r *PaasReconciler) removeFinalizer(
+	ctx context.Context,
+	paas *v1alpha1.Paas,
+) error {
+	logger := log.Ctx(ctx)
+	meta.SetStatusCondition(paas.GetConditions(), metav1.Condition{
+		Type:   v1alpha1.TypeDegradedPaas,
+		Status: metav1.ConditionTrue, Reason: "Finalizing", ObservedGeneration: paas.GetGeneration(),
+		Message: fmt.Sprintf("Finalizer operations for Paas %s name were successfully accomplished",
+			paas.GetName()),
+	})
+
+	if err := r.Status().Update(ctx, paas); err != nil {
+		logger.Err(err).Msg("Failed to update Paas status")
+		return err
+	}
+
+	logger.Info().Msg("removing finalizer")
+	// Remove paasFinalizer. Once all finalizers have been
+	// removed, the object will be deleted.
+	controllerutil.RemoveFinalizer(paas, paasFinalizer)
+	if err := r.Update(ctx, paas); err != nil {
+		return err
+	}
+	logger.Info().Msg("finalization finished")
 
 	return nil
 }
@@ -194,11 +205,6 @@ func (r *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	ctx, logger := logging.SetControllerLogger(ctx, paas, r.Scheme, req)
 
 	if paas, err = r.getPaasFromRequest(ctx, req); err != nil {
-		// TODO(portly-halicore-76) move to admission webhook once available
-		// Don't requeue that often when no config is found
-		if strings.Contains(err.Error(), noConfigFoundMsg) {
-			return ctrl.Result{RequeueAfter: requeueTimeout}, nil
-		}
 		logger.Err(err).Msg("could not get Paas from k8s")
 		return ctrl.Result{}, err
 	}
@@ -244,10 +250,10 @@ func (r *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	}
 
 	// Reconciling succeeded, set appropriate Condition
-	return ctrl.Result{}, r.setSuccesfullCondition(ctx, paas)
+	return ctrl.Result{}, r.setSuccessfulCondition(ctx, paas)
 }
 
-func (r *PaasReconciler) setSuccesfullCondition(ctx context.Context, paas *v1alpha1.Paas) error {
+func (r *PaasReconciler) setSuccessfulCondition(ctx context.Context, paas *v1alpha1.Paas) error {
 	meta.SetStatusCondition(&paas.Status.Conditions, metav1.Condition{
 		Type:   v1alpha1.TypeReadyPaas,
 		Status: metav1.ConditionTrue, Reason: "Reconciling", ObservedGeneration: paas.Generation,
@@ -276,19 +282,7 @@ func (r *PaasReconciler) setErrorCondition(ctx context.Context, resource paasres
 	return r.Status().Update(ctx, resource)
 }
 
-func paasFromPaasNs(mgr ctrl.Manager, obj client.Object) []reconcile.Request {
-	// Enqueue all Paas objects
-	var reqs []reconcile.Request
-	var ns corev1.Namespace
-	logger := mgr.GetLogger()
-	if err := mgr.GetClient().Get(
-		context.Background(),
-		types.NamespacedName{Name: obj.GetNamespace()},
-		&ns,
-	); err != nil {
-		logger.Error(err, "unable to get namespace where paasns resides")
-		return nil
-	}
+func paasFromNs(ns corev1.Namespace) (string, error) {
 	var paasNames []string
 	for _, ref := range ns.OwnerReferences {
 		if ref.Kind == "Paas" && *ref.Controller {
@@ -296,39 +290,19 @@ func paasFromPaasNs(mgr ctrl.Manager, obj client.Object) []reconcile.Request {
 		}
 	}
 	if len(paasNames) == 0 {
-		logger.Error(
-			errors.New("failed to get owner reference with kind paas and controller=true from namespace resource"),
-			"finding paas for paasns without owner reference",
-			"ns",
-			ns,
-		)
+		return "", errors.New("failed to get owner reference with kind paas and controller=true from namespace")
 	} else if len(paasNames) > 1 {
-		logger.Error(
-			errors.New("found multiple owner references with kind paas and controller=true"),
-			"finding paas for paasns without owner reference",
-			"ns",
-			ns,
-		)
+		return "", errors.New("found multiple owner references with kind paas and controller=true")
 	}
 	paasName := paasNames[0]
 	if !strings.HasPrefix(ns.Name, paasName+"-") {
-		logger.Error(
-			errors.New("namespace is not prefixed with paasName in owner reference"),
-			"finding paas for paasns without owner reference",
-			"ns",
-			ns,
-		)
+		return "", errors.New("namespace is not prefixed with paasName in owner reference")
 	}
-
-	reqs = append(reqs, reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name: paasName,
-		},
-	})
-
-	return reqs
+	return paasName, nil
 }
 
+// allPaases is a simple wrapper to collect all Paas'es and created requests for them on PaasConfig changes
+// allPaases is not unittests ATM. We might add a e2e test for this instead.
 func allPaases(mgr ctrl.Manager) []reconcile.Request {
 	// Enqueue all Paas objects
 	var reqs []reconcile.Request
@@ -351,6 +325,7 @@ func allPaases(mgr ctrl.Manager) []reconcile.Request {
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// SetupWithManager is not unittesterd ATM. Mostly already covered by e2e tests.
 func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Paas{}, builder.WithPredicates(
@@ -364,8 +339,24 @@ func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&v1alpha1.PaasNS{},
 			handler.EnqueueRequestsFromMapFunc(
-				func(_ context.Context, obj client.Object) []reconcile.Request {
-					return paasFromPaasNs(mgr, obj)
+				func(_ context.Context, paasNsObj client.Object) []reconcile.Request {
+					var ns corev1.Namespace
+					logger := mgr.GetLogger()
+					if err := mgr.GetClient().Get(
+						context.Background(),
+						types.NamespacedName{Name: paasNsObj.GetNamespace()},
+						&ns,
+					); err != nil {
+						logger.Error(err, "unable to get namespace where paasns resides")
+						return nil
+					}
+					paasName, err := paasFromNs(ns)
+					if err != nil {
+						logger.Error(err, "finding paas for paasns without owner reference", "ns", ns)
+						return nil
+					}
+					return []reconcile.Request{{
+						NamespacedName: types.NamespacedName{Name: paasName}}}
 				},
 			),
 			builder.WithPredicates(v1alpha1.ActivePaasConfigUpdated()),
@@ -385,11 +376,12 @@ func (r *PaasReconciler) finalizePaas(ctx context.Context, paas *v1alpha1.Paas) 
 	logger.Debug().Msg("inside Paas finalizer")
 
 	paasReconcilers := []func(context.Context, *v1alpha1.Paas) error{
-		// r.finalizeClusterQuotas,
+		r.finalizeClusterQuotas,
 		r.finalizeGroups,
 		r.finalizePaasClusterRoleBindings,
 		r.finalizeClusterWideQuotas,
 		r.finalizeAppSetCaps,
+		r.finalizeNamespaces,
 	}
 
 	for _, reconciler := range paasReconcilers {

--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -8,7 +8,11 @@ package controller
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
+	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
 	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/internal/config"
 	"github.com/belastingdienst/opr-paas/internal/fields"
@@ -16,12 +20,110 @@ import (
 	argocd "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	quotav1 "github.com/openshift/api/quota/v1"
+	userv1 "github.com/openshift/api/user/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+func getConditionsFromPaas(paas *api.Paas) map[string]metav1.Condition {
+	conditions := map[string]metav1.Condition{}
+	for _, condition := range paas.Status.Conditions {
+		conditions[condition.Type] = condition
+	}
+	return conditions
+}
+
+var _ = Describe("Get paas from ns", func() {
+	const (
+		paasName = "my-paas"
+		nsName   = paasName + "-myns"
+	)
+	var (
+		controller    = true
+		notController = false
+	)
+	When("using proper reference", func() {
+		It("should return the name, and nil", func() {
+			ns := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Paas", Name: paasName, Controller: &controller},
+						{Kind: "SomethingElse", Name: paasName + "2", Controller: &controller},
+						{Kind: "Paas", Name: paasName + "3", Controller: &notController},
+					},
+				},
+			}
+			name, err := paasFromNs(ns)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal(paasName))
+		})
+	})
+	When("having no Paas references", func() {
+		It("should return empty string and error", func() {
+			ns := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "SomethingElse", Name: paasName + "2", Controller: &controller},
+						{Kind: "Paas", Name: paasName + "3", Controller: &notController},
+					},
+				},
+			}
+			name, err := paasFromNs(ns)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(
+				"failed to get owner reference with kind paas and controller=true from namespace")))
+			Expect(name).To(BeEmpty())
+		})
+	})
+	When("having multiple Paas references", func() {
+		It("should return empty string and error", func() {
+			ns := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Paas", Name: paasName, Controller: &controller},
+						{Kind: "SomethingElse", Name: paasName + "2", Controller: &controller},
+						{Kind: "Paas", Name: paasName + "3", Controller: &notController},
+						{Kind: "Paas", Name: paasName + "4", Controller: &controller},
+					},
+				},
+			}
+			name, err := paasFromNs(ns)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(
+				"found multiple owner references with kind paas and controller=true")))
+			Expect(name).To(BeEmpty())
+		})
+	})
+	When("having improper prefix", func() {
+		It("should return empty string and error", func() {
+			ns := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-" + nsName,
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Paas", Name: paasName, Controller: &controller},
+						{Kind: "SomethingElse", Name: paasName + "2", Controller: &controller},
+						{Kind: "Paas", Name: paasName + "3", Controller: &notController},
+					},
+				},
+			}
+			name, err := paasFromNs(ns)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(
+				"namespace is not prefixed with paasName in owner reference")))
+			Expect(name).To(BeEmpty())
+		})
+	})
+})
 
 var _ = Describe("Paas Controller", Ordered, func() {
 	const (
@@ -29,6 +131,9 @@ var _ = Describe("Paas Controller", Ordered, func() {
 		capAppSetNamespace = "asns"
 		capAppSetName      = "argoas"
 		capName            = "argocd"
+		paasSystem         = "paasnssystem"
+		paasPkSecret       = "paasns-pk-secret"
+		paasWithArgoCDName = paasRequestor + "-with-argocd"
 	)
 	var (
 		paas         *api.Paas
@@ -38,10 +143,22 @@ var _ = Describe("Paas Controller", Ordered, func() {
 		myConfig     api.PaasConfig
 		paasName     = paasRequestor
 		capNamespace = paasName + "-" + capName
+		privateKey   []byte
+		mycrypt      *crypt.Crypt
+		paasSecret   string
 	)
 	ctx := context.Background()
 
 	BeforeAll(func() {
+		var err error
+		assureNamespace(ctx, paasSystem)
+		mycrypt, privateKey, err = newGeneratedCrypt(paasName)
+		if err != nil {
+			Fail(err.Error())
+		}
+		createPaasPrivateKeySecret(ctx, paasSystem, paasPkSecret, privateKey)
+		paasSecret, err = mycrypt.Encrypt([]byte("paasSecret"))
+		Expect(err).NotTo(HaveOccurred())
 		assureNamespace(ctx, "gsns")
 		appSet = &argocd.ApplicationSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -55,6 +172,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 	})
 
 	BeforeEach(func() {
+		paasName = paasRequestor
 		paas = &api.Paas{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: paasName,
@@ -87,7 +205,11 @@ var _ = Describe("Paas Controller", Ordered, func() {
 						},
 					},
 				},
-				Debug:           false,
+				Debug: false,
+				DecryptKeysSecret: api.NamespacedName{
+					Name:      paasPkSecret,
+					Namespace: paasSystem,
+				},
 				ManagedByLabel:  "argocd.argoproj.io/manby",
 				ManagedBySuffix: "argocd",
 				RequestorLabel:  "o.lbl",
@@ -113,13 +235,244 @@ var _ = Describe("Paas Controller", Ordered, func() {
 		})
 	})
 
-	When("reconciling a Paas with argocd capability", func() {
-		It("should not return an error", func() {
-			paasName = paasRequestor + "-normal"
+	// getPaasFromRequest
+	When("getting a Paas from a request", func() {
+		It("should return nil when paas does not exist", func() {
+			var err error
+			paasName = paasRequestor + "-request-does-not-exist"
 			paas.Name = paasName
 			request.Name = paasName
-			capNamespace = paasName + "-" + capName
-			assurePaas(ctx, paas)
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			paas, err = reconciler.getPaasFromRequest(ctx, request)
+			// Expect(err).To(HaveOccurred())
+			// Expect(err.Error()).To(MatchRegexp(`paas.cpet.belastingdienst.nl .* not found`))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(paas).To(BeNil())
+		})
+
+		It("should return nil when paas is being deleted", func() {
+			var gracePeriodSeconds = int64(2)
+			paasName = paasRequestor + "-request-being-deleted"
+			paas.Name = paasName
+			assurePaas(ctx, *paas)
+			err := reconciler.Delete(ctx, paas, &client.DeleteOptions{GracePeriodSeconds: &gracePeriodSeconds})
+			Expect(err).NotTo(HaveOccurred())
+			request.Name = paasName
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			paas, err = reconciler.getPaasFromRequest(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(paas).To(BeNil())
+		})
+
+		It("should properly get a Paas from the request", func() {
+			var err error
+			paasName = paasRequestor + "-request"
+			paas.Name = paasName
+			assurePaas(ctx, *paas)
+			request.Name = paasName
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			paas, err = reconciler.getPaasFromRequest(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(paas).NotTo(BeNil())
+			Expect(paas.Name).To(Equal(paasName))
+			Expect(controllerutil.ContainsFinalizer(paas, paasFinalizer)).To(BeTrue())
+		})
+	})
+
+	When("setting state on a Paas", func() {
+		// setFinalizing
+		It("can set state to finalizing", func() {
+			var err error
+			paasName = paasRequestor + "-set-finalizing"
+			paas.Name = paasName
+			assurePaas(ctx, *paas)
+			request.Name = paasName
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			paas, err = reconciler.getPaasFromRequest(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			preConditions := getConditionsFromPaas(paas)
+			Expect(preConditions).To(HaveKey(api.TypeReadyPaas))
+			Expect(preConditions).NotTo(HaveKey(api.TypeDegradedPaas))
+
+			err = reconciler.setFinalizing(ctx, paas)
+			Expect(err).NotTo(HaveOccurred())
+			paas = getPaas(ctx, paasName)
+
+			postConditions := getConditionsFromPaas(paas)
+			Expect(postConditions).To(HaveKey(api.TypeDegradedPaas))
+			finalizingCondition := postConditions[api.TypeDegradedPaas]
+			Expect(finalizingCondition.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(finalizingCondition.Reason).To(Equal("Finalizing"))
+			Expect(finalizingCondition.Message).To(Equal(
+				fmt.Sprintf("Performing finalizer operations for Paas: %s ", paasName)))
+		})
+		// setErrorCondition
+		It("can set and reset an error and set finalizing state", func() {
+			var err error
+			paasName = paasRequestor + "-set-error"
+			paas.Name = paasName
+			assurePaas(ctx, *paas)
+			request.Name = paasName
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			paas, err = reconciler.getPaasFromRequest(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			preConditions := getConditionsFromPaas(paas)
+			Expect(preConditions).To(HaveKey(api.TypeReadyPaas))
+			Expect(preConditions).NotTo(HaveKey(api.TypeHasErrorsPaas))
+			Expect(preConditions).NotTo(HaveKey(api.TypeDegradedPaas))
+			preReadyCondition := preConditions[api.TypeReadyPaas]
+			Expect(preReadyCondition.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(preReadyCondition.Reason).To(Equal("Reconciling"))
+			Expect(preReadyCondition.Message).To(Equal("Starting reconciliation"))
+
+			myError := errors.New("my custom error")
+			err = reconciler.setErrorCondition(ctx, paas, myError)
+			Expect(err).NotTo(HaveOccurred())
+			paas = getPaas(ctx, paasName)
+
+			errorConditions := getConditionsFromPaas(paas)
+			Expect(errorConditions).To(HaveKey(api.TypeReadyPaas))
+			errorReadyCondition := errorConditions[api.TypeReadyPaas]
+			Expect(errorReadyCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(errorReadyCondition.Reason).To(Equal("ReconcilingError"))
+			Expect(errorReadyCondition.Message).To(Equal(fmt.Sprintf("Reconciling (%s) failed", paasName)))
+			Expect(errorConditions).To(HaveKey(api.TypeHasErrorsPaas))
+			errorErrorsCondition := errorConditions[api.TypeHasErrorsPaas]
+			Expect(errorErrorsCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(errorErrorsCondition.Reason).To(Equal("ReconcilingError"))
+			Expect(errorErrorsCondition.Message).To(Equal(myError.Error()))
+			Expect(errorConditions).NotTo(HaveKey(api.TypeDegradedPaas))
+
+			err = reconciler.setSuccessfulCondition(ctx, paas)
+			Expect(err).NotTo(HaveOccurred())
+			paas = getPaas(ctx, paasName)
+
+			resetConditions := getConditionsFromPaas(paas)
+			Expect(resetConditions).To(HaveKey(api.TypeReadyPaas))
+			resetReadyCondition := resetConditions[api.TypeReadyPaas]
+			Expect(resetReadyCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(resetReadyCondition.Reason).To(Equal("Reconciling"))
+			Expect(resetReadyCondition.Message).To(Equal(fmt.Sprintf("Reconciled (%s) successfully", paasName)))
+			Expect(resetConditions).To(HaveKey(api.TypeHasErrorsPaas))
+			resetErrorsCondition := resetConditions[api.TypeHasErrorsPaas]
+			Expect(resetErrorsCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(resetErrorsCondition.Reason).To(Equal("Reconciling"))
+			Expect(resetErrorsCondition.Message).To(Equal(fmt.Sprintf("Reconciled (%s) successfully", paasName)))
+			Expect(resetConditions).NotTo(HaveKey(api.TypeDegradedPaas))
+
+			err = reconciler.setFinalizing(ctx, paas)
+			Expect(err).NotTo(HaveOccurred())
+			paas = getPaas(ctx, paasName)
+
+			finalizingConditions := getConditionsFromPaas(paas)
+			Expect(finalizingConditions).To(HaveKey(api.TypeDegradedPaas))
+			finalizingCondition := finalizingConditions[api.TypeDegradedPaas]
+			Expect(finalizingCondition.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(finalizingCondition.Reason).To(Equal("Finalizing"))
+			Expect(finalizingCondition.Message).To(Equal(
+				fmt.Sprintf("Performing finalizer operations for Paas: %s ", paasName)))
+		})
+	})
+
+	When("finalizing a Paas", func() {
+		// setFinalizing > see 'setting state' above
+		// finalizePaas skipped (only calling sub methods which are tested elsewhere)
+		// removeFinalizer
+		It("should successfully remove the finalizer", func() {
+			var err error
+			paasName = paasRequestor + "-remove-finalizer"
+			paas.Name = paasName
+			assurePaas(ctx, *paas)
+			request.Name = paasName
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			paas, err = reconciler.getPaasFromRequest(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(paas.Finalizers).To(ContainElement(paasFinalizer))
+
+			err = reconciler.removeFinalizer(ctx, paas)
+			Expect(err).NotTo(HaveOccurred())
+			paas = getPaas(ctx, paasName)
+			Expect(paas.Finalizers).NotTo(ContainElement(paasFinalizer))
+		})
+	})
+	// Reconcile
+	When("reconciling a Paas", func() {
+		It("should succeed for normal paas", func() {
+			var err error
+			var result controllerruntime.Result
+			request.Name = paasName
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			paas.Spec.SSHSecrets = map[string]string{"validSecret": paasSecret}
+			result, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(controllerruntime.Result{}))
+		})
+
+		// getPaasFromRequest (paas==nil)
+		It("should return nil when paas does not exist", func() {
+			var err error
+			var result controllerruntime.Result
+			paasName = paasRequestor + "-non-existent"
+			paas.Name = paasName
+			// assurePaas(ctx, paas)
+			request.Name = paasName
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			result, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(controllerruntime.Result{}))
+		})
+
+		// paasReconcilers return err (checking failure when cap does not exist)
+		It("should return error when a paasReconciler method returns an error", func() {
+			var err error
+			var result controllerruntime.Result
+			paasName = paasRequestor + "-non-existent-cap"
+			brokenPaas := paas.DeepCopy()
+			brokenPaas.Name = paasName
+			brokenPaas.Spec.Capabilities["non-existent"] = api.PaasCapability{
+				Enabled: true,
+			}
+			assurePaas(ctx, *brokenPaas)
+			request.Name = paasName
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			result, err = reconciler.Reconcile(ctx, request)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("a capability is requested, but not configured")))
+			Expect(result).To(Equal(controllerruntime.Result{}))
+		})
+
+		// error from nsDefsFromPaas not unittested.
+		// Only occurs if cap does not exist, which is prevented by webhook, and a paasReconciler error raises first
+		// It("should return error when nsDefsFromPaas method returns an error", func() {
+		// })
+
+		// paasNsReconcilers returns error
+		It("should return error when a paasNsReconciler method returns an error", func() {
+			var err error
+			var result controllerruntime.Result
+			paasName = paasRequestor + "-secret-failure"
+			brokenPaas := paas.DeepCopy()
+			brokenPaas.Name = paasName
+			brokenPaas.Spec.SSHSecrets = map[string]string{"broken": paasSecret}
+			assurePaas(ctx, *brokenPaas)
+			request.Name = paasName
+			request.NamespacedName = types.NamespacedName{Name: paasName}
+			assureAppSet(ctx, capAppSetName, capAppSetNamespace)
+			result, err = reconciler.Reconcile(ctx, request)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("failed to decrypt secret")))
+			Expect(result).To(Equal(controllerruntime.Result{}))
+		})
+
+		// ensureAppSetCaps returns error is very difficult to test on it's own. Skipping.
+	})
+
+	When("reconciling a Paas with argocd capability", func() {
+		It("should not return an error", func() {
+			paas.Name = paasWithArgoCDName
+			request.Name = paasWithArgoCDName
+			capNamespace = paasWithArgoCDName + "-" + capName
+			assurePaas(ctx, *paas)
 			assureNamespace(ctx, capNamespace)
 			patchAppSet(ctx, appSet)
 			result, err := reconciler.Reconcile(ctx, request)
@@ -140,7 +493,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				entries = entries.Merge(generatorEntries)
 			}
-			Expect(entries).To(HaveKey(paasName))
+			Expect(entries).To(HaveKey(paasWithArgoCDName))
 		})
 	})
 
@@ -151,7 +504,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 			paas.Spec.Capabilities = make(api.PaasCapabilities)
 			request.Name = paasName
 			capNamespace = paasName + "-" + capName
-			assurePaas(ctx, paas)
+			assurePaas(ctx, *paas)
 			assureNamespace(ctx, capNamespace)
 			patchAppSet(ctx, appSet)
 			paas.Spec.Capabilities = make(api.PaasCapabilities)
@@ -175,6 +528,292 @@ var _ = Describe("Paas Controller", Ordered, func() {
 				entries = entries.Merge(generatorEntries)
 			}
 			Expect(entries).NotTo(HaveKey(paasName))
+		})
+	})
+})
+
+var _ = Describe("Paas Reconclie", Ordered, func() {
+	const (
+		paasName           = "paas-reconcile"
+		capAppSetNamespace = paasName + "-asns"
+		capAppSetName      = "argoas"
+		capName            = "recon"
+		paasSystem         = "recon-nssystem"
+		paasPkSecret       = "recon-secret"
+		nsName             = "myns"
+		paasNSName         = "mypaasns"
+		groupName          = "mygroup"
+		ldapGroupName      = "my-ldap-group"
+		ldapGroupQuery     = "CN=" + ldapGroupName + ",OU=org_unit,DC=example,DC=org"
+		funcRoleName1      = "myfuncrole1"
+		funcRoleName2      = "myfuncrole2"
+		techRoleName1      = "mytechrole1"
+		techRoleName2      = "mytechrole2"
+		defaultPermSA      = "def-perm-service-account"
+		defaultPermCR      = "def-parm-cluster-role"
+		extraPermSA        = "extra-perm-service-account"
+		extraPermCR        = "extra-parm-cluster-role"
+		gsNamespace        = "gsns"
+		gsName             = "gsname"
+		gsKey              = "gskey"
+	)
+	var (
+		paas                 *api.Paas
+		reconciler           *PaasReconciler
+		request              controllerruntime.Request
+		myConfig             api.PaasConfig
+		capNamespace         = paasName + "-" + capName
+		privateKey           []byte
+		mycrypt              *crypt.Crypt
+		secretValue          string
+		secretEncryptedValue string
+		secretName           = "my-secret"
+		secretHashedName     = fmt.Sprintf("paas-ssh-%s", strings.ToLower(hashData(secretName)[:8]))
+		quotas               = []string{paasName, capNamespace}
+		groups               = []string{ldapGroupName, join(paasName, groupName)}
+		namespaces           = []string{paasName, join(paasName, nsName), join(paasName, capName), join(paasName,
+			paasNSName)}
+		rolebindings        = []string{techRoleName1, techRoleName2}
+		clusterRolebindings = map[string][]string{
+			defaultPermSA: {defaultPermCR}, extraPermSA: {extraPermCR}}
+	)
+	ctx := context.Background()
+	BeforeAll(func() {
+		var err error
+		assureNamespace(ctx, paasSystem)
+		mycrypt, privateKey, err = newGeneratedCrypt(paasName)
+		if err != nil {
+			Fail(err.Error())
+		}
+		createPaasPrivateKeySecret(ctx, paasSystem, paasPkSecret, privateKey)
+		secretEncryptedValue, err = mycrypt.Encrypt([]byte(secretValue))
+		Expect(err).NotTo(HaveOccurred())
+		assureNamespace(ctx, gsNamespace)
+		assureNamespace(ctx, capAppSetNamespace)
+		assureAppSet(ctx, capAppSetName, capAppSetNamespace)
+		paas = &api.Paas{
+			// We need to set this for AmIOwner to work properly
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Paas",
+				APIVersion: api.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: paasName,
+			},
+			Spec: api.PaasSpec{
+				Requestor: paasName,
+				Capabilities: api.PaasCapabilities{
+					capName: api.PaasCapability{
+						Enabled:          true,
+						ExtraPermissions: true,
+					},
+				},
+				Quota:      paasquota.Quota{"cpu": resourcev1.MustParse("1")},
+				Namespaces: []string{nsName},
+				Groups: api.PaasGroups{
+					groupName:     api.PaasGroup{Roles: []string{funcRoleName1}},
+					ldapGroupName: api.PaasGroup{Roles: []string{funcRoleName2}, Query: ldapGroupQuery},
+				},
+				SSHSecrets: map[string]string{secretName: secretEncryptedValue},
+			},
+		}
+		Expect(paas.Kind).To(Equal("Paas"))
+		request.Name = paasName
+		assurePaas(ctx, *paas)
+		Expect(paas.Kind).To(Equal("Paas"))
+		myConfig = api.PaasConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "paas-config",
+			},
+			Spec: api.PaasConfigSpec{
+				ClusterWideArgoCDNamespace: capAppSetNamespace,
+				Capabilities: map[string]api.ConfigCapability{
+					capName: {
+						AppSet: capAppSetName,
+						QuotaSettings: api.ConfigQuotaSettings{
+							DefQuota: map[corev1.ResourceName]resourcev1.Quantity{
+								corev1.ResourceLimitsCPU: resourcev1.MustParse("5"),
+							},
+						},
+						DefaultPermissions: api.ConfigCapPerm{defaultPermSA: []string{defaultPermCR}},
+						ExtraPermissions:   api.ConfigCapPerm{extraPermSA: []string{extraPermCR}},
+					},
+				},
+				DecryptKeysSecret: api.NamespacedName{Name: paasPkSecret, Namespace: paasSystem},
+				ManagedByLabel:    "argocd.argoproj.io/manby",
+				ManagedBySuffix:   "argocd",
+				RequestorLabel:    "o.lbl",
+				QuotaLabel:        "q.lbl",
+				GroupSyncList:     api.NamespacedName{Namespace: gsNamespace, Name: gsName},
+				GroupSyncListKey:  gsKey,
+				RoleMappings: api.ConfigRoleMappings{
+					funcRoleName1: []string{techRoleName1},
+					funcRoleName2: []string{techRoleName2},
+				},
+			},
+		}
+		config.SetConfig(myConfig)
+		reconciler = &PaasReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+	})
+	// create Paas
+	When("creating a Paas and PaasNS", func() {
+		It("should reconcile successfully", func() {
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(controllerruntime.Result{}))
+			assurePaasNS(ctx, api.PaasNS{ObjectMeta: metav1.ObjectMeta{Name: paasNSName, Namespace: paasName}})
+			result, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(controllerruntime.Result{}))
+		})
+		It("should have created paas quotas", func() {
+			for _, quotaName := range quotas {
+				var quota quotav1.ClusterResourceQuota
+				err := reconciler.Get(ctx, types.NamespacedName{Name: quotaName}, &quota)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+		It("should have created paas groups", func() {
+			for _, groupName := range groups {
+				var group userv1.Group
+				err := reconciler.Get(ctx, types.NamespacedName{Name: groupName}, &group)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+		It("should have created paas ldap entries", func() {
+			var configMap corev1.ConfigMap
+			err := reconciler.Get(ctx, types.NamespacedName{Namespace: gsNamespace, Name: gsName}, &configMap)
+			Expect(err).ToNot(HaveOccurred())
+			list, exists := configMap.Data[gsKey]
+			Expect(exists).To(BeTrue())
+			Expect(list).To(ContainSubstring(ldapGroupQuery))
+		})
+		It("should have created paas namespaces", func() {
+			for _, nsName := range namespaces {
+				var ns corev1.Namespace
+				err := reconciler.Get(ctx, types.NamespacedName{Name: nsName}, &ns)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+		It("should have created paas clusterrolebindings", func() {
+			for crbSAName, crbRoleNames := range clusterRolebindings {
+				for _, crbRoleName := range crbRoleNames {
+					var crb rbac.ClusterRoleBinding
+					err := reconciler.Get(ctx, types.NamespacedName{Name: join("paas", crbRoleName)}, &crb)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(crb.Subjects).To(ContainElement(
+						rbac.Subject{
+							Kind:      "ServiceAccount",
+							APIGroup:  "",
+							Name:      crbSAName,
+							Namespace: capNamespace,
+						},
+					))
+				}
+			}
+		})
+		It("should have created paas appset list generator entries", func() {
+			var capAppSet argocd.ApplicationSet
+			err := reconciler.Get(ctx,
+				types.NamespacedName{Namespace: capAppSetNamespace, Name: capAppSetName}, &capAppSet)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(capAppSet.Spec.Generators).To(HaveLen(1))
+			list := getListGen(capAppSet.Spec.Generators)
+			Expect(list).NotTo(BeNil())
+			entries, err := fields.EntriesFromJSON(list.List.Elements)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(entries).To(HaveLen(1))
+			Expect(entries).To(HaveKey(paasName))
+		})
+		It("should have created paas rolebindings", func() {
+			for _, nsName := range namespaces {
+				if nsName == paasName {
+					continue
+				}
+				fmt.Fprintf(GinkgoWriter, "DEBUG - Namespace: %v", nsName)
+				for _, rbName := range rolebindings {
+					var rb rbac.RoleBinding
+					err := reconciler.Get(ctx,
+						types.NamespacedName{Namespace: nsName, Name: join("paas", rbName)}, &rb)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+		})
+		It("should have created paas secrets", func() {
+			for _, nsName := range namespaces {
+				if nsName == paasName {
+					continue
+				}
+				var secret corev1.Secret
+				err := reconciler.Get(ctx, types.NamespacedName{Namespace: nsName, Name: secretHashedName}, &secret)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
+	When("finalizing a Paas", Ordered, func() {
+		It("should finalize successfully", func() {
+			Expect(paas.Kind).To(Equal("Paas"))
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(controllerruntime.Result{}))
+			assurePaasNS(ctx, api.PaasNS{ObjectMeta: metav1.ObjectMeta{Name: paasNSName, Namespace: paasName}})
+			result, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(controllerruntime.Result{}))
+			// If we don't read it back from k8s, Kind and APIVersion are not set, and deleting groups does not work
+			err = reconciler.finalizePaas(ctx, paas)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should have deleted paas quotas", func() {
+			for _, quotaName := range quotas {
+				var quota quotav1.ClusterResourceQuota
+				err := reconciler.Get(ctx, types.NamespacedName{Name: quotaName}, &quota)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(
+					"clusterresourcequotas.quota.openshift.io \"" + quotaName + "\" not found"))
+			}
+		})
+		It("should have deleted paas groups", func() {
+			for _, groupName := range groups {
+				var group userv1.Group
+				err := reconciler.Get(ctx, types.NamespacedName{Name: groupName}, &group)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("groups.user.openshift.io \"" + groupName + "\" not found"))
+			}
+		})
+		It("should have deleted paas ldap entries", func() {
+			var configMap corev1.ConfigMap
+			err := reconciler.Get(ctx, types.NamespacedName{Namespace: gsNamespace, Name: gsName}, &configMap)
+			Expect(err).ToNot(HaveOccurred())
+			list, exists := configMap.Data[gsKey]
+			Expect(exists).To(BeTrue())
+			Expect(list).NotTo(ContainSubstring(ldapGroupQuery))
+		})
+		It("should have deleted paas namespaces", func() {
+			for _, nsName := range namespaces {
+				var ns corev1.Namespace
+				err := reconciler.Get(ctx, types.NamespacedName{Name: nsName}, &ns)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ns.DeletionTimestamp).NotTo(BeNil())
+			}
+		})
+		It("should have deleted paas clusterrolebindings", func() {
+			for _, crbRoleNames := range clusterRolebindings {
+				for _, crbRoleName := range crbRoleNames {
+					var crb rbac.ClusterRoleBinding
+					err := reconciler.Get(ctx, types.NamespacedName{Name: join("paas", crbRoleName)}, &crb)
+					Expect(err).To(HaveOccurred())
+				}
+			}
+		})
+		It("should have deleted paas appset list generator entries", func() {
+			var capAppSet argocd.ApplicationSet
+			err := reconciler.Get(ctx,
+				types.NamespacedName{Namespace: capAppSetNamespace, Name: capAppSetName}, &capAppSet)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(capAppSet.Spec.Generators).To(HaveLen(1))
+			list := getListGen(capAppSet.Spec.Generators)
+			Expect(list).To(BeNil())
 		})
 	})
 })

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -223,8 +223,8 @@ func (r *PaasReconciler) reconcileNamespaceRolebindings(
 		// Convert the groupKey to a groupName to map the rolebinding subjects to a group
 		groupName := paas.GroupKey2GroupName(groupKey)
 		for _, mappedRole := range config.GetConfig().Spec.RoleMappings.Roles(groupRoles) {
-			if role, exists := roles[mappedRole]; exists {
-				roles[mappedRole] = append(role, groupName)
+			if groups, exists := roles[mappedRole]; exists {
+				roles[mappedRole] = append(groups, groupName)
 			} else {
 				roles[mappedRole] = []string{groupName}
 			}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -12,7 +12,9 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -175,6 +177,42 @@ func patchAppSet(ctx context.Context, newAppSet *appv1.ApplicationSet) {
 	}
 }
 
+func createPaasPrivateKeySecret(ctx context.Context, ns string, name string, privateKey []byte) {
+	// Set up private key
+	err := k8sClient.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: map[string][]byte{"privatekey0": privateKey},
+	})
+	if err != nil {
+		Fail(fmt.Errorf("failed to create %s.%s secret: %w", ns, name, err).Error())
+	}
+}
+
+func newGeneratedCrypt(ctx string) (myCrypt *crypt.Crypt, privateKey []byte, err error) {
+	tmpFileError := "failed to get new tmp private key file: %w"
+	privateKeyFile, err := os.CreateTemp("", "private")
+	if err != nil {
+		return nil, nil, fmt.Errorf(tmpFileError, err)
+	}
+	publicKeyFile, err := os.CreateTemp("", "public")
+	if err != nil {
+		return nil, nil, fmt.Errorf(tmpFileError, err)
+	}
+	myCrypt, err = crypt.NewGeneratedCrypt(privateKeyFile.Name(), publicKeyFile.Name(), ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf(tmpFileError, err)
+	}
+	privateKey, err = os.ReadFile(privateKeyFile.Name())
+	if err != nil {
+		return nil, nil, errors.New("failed to read private key from file")
+	}
+
+	return myCrypt, privateKey, nil
+}
+
 func assureNamespace(ctx context.Context, namespaceName string) {
 	oldNs := &corev1.Namespace{}
 	namespacedName := types.NamespacedName{
@@ -188,26 +226,6 @@ func assureNamespace(ctx context.Context, namespaceName string) {
 	err = k8sClient.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: namespaceName},
 	})
-	Expect(err).NotTo(HaveOccurred())
-}
-
-func assurePaas(ctx context.Context, newPaas *api.Paas) {
-	oldPaas := &api.Paas{}
-	namespacedName := types.NamespacedName{
-		Name: newPaas.Name,
-	}
-	err := k8sClient.Get(ctx, namespacedName, oldPaas)
-	if err == nil {
-		return
-	}
-	Expect(err.Error()).To(MatchRegexp(`paas.cpet.belastingdienst.nl .* not found`))
-	err = k8sClient.Create(ctx, newPaas)
-	Expect(err).NotTo(HaveOccurred())
-}
-
-func validatePaasNSExists(ctx context.Context, namespaceName string, paasNSName string) {
-	pns := api.PaasNS{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: paasNSName, Namespace: namespaceName}, &pns)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -227,6 +245,54 @@ func assureNamespaceWithPaasReference(ctx context.Context, namespaceName string,
 		Expect(err).NotTo(HaveOccurred())
 	}
 }
+
+func assurePaas(ctx context.Context, newPaas api.Paas) {
+	oldPaas := &api.Paas{}
+	namespacedName := types.NamespacedName{
+		Name: newPaas.Name,
+	}
+	err := k8sClient.Get(ctx, namespacedName, oldPaas)
+	if err == nil {
+		return
+	}
+	Expect(err.Error()).To(MatchRegexp(`paas.cpet.belastingdienst.nl .* not found`))
+	err = k8sClient.Create(ctx, &newPaas)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func validatePaasNSExists(ctx context.Context, namespaceName string, paasNSName string) {
+	pns := api.PaasNS{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: paasNSName, Namespace: namespaceName}, &pns)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func assurePaasNS(ctx context.Context, paasNs api.PaasNS) {
+	assureNamespace(ctx, paasNs.GetNamespace())
+	oldPaasNS := &api.PaasNS{}
+	namespacedName := types.NamespacedName{Name: paasNs.GetName(), Namespace: paasNs.GetNamespace()}
+	err := k8sClient.Get(ctx, namespacedName, oldPaasNS)
+	if err == nil {
+		return
+	}
+	Expect(err.Error()).To(MatchRegexp(`paasns.cpet.belastingdienst.nl .* not found`))
+	if paasNs.Spec.Paas == "" {
+		paasNs.Spec.Paas = paasNs.GetNamespace()
+	}
+	err = k8sClient.Create(ctx, &paasNs)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func getPaas(ctx context.Context, paasName string) *api.Paas {
+	paas := &api.Paas{}
+	namespacedName := types.NamespacedName{
+		Name: paasName,
+	}
+	err := k8sClient.Get(ctx, namespacedName, paas)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(paas).NotTo(BeNil())
+	return paas
+}
+
 func assureAppSet(ctx context.Context, name string, namespace string) {
 	appSet := &appv1.ApplicationSet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION

## Pull Request type


Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- We currently have bare minimum unittest coverage on internal/controller/paas_controller.go
- We have moved controller code from paasns controller to paas_controller and have no coverage on that either. We might have a degration in v1alpha2 which we are unaware of.
- We want to upgrade controller from managing v1alpha1 to managing v1alpha2, and would like to have improved coverage on internal/controller
- We want to use ginkgo / gomega for unittesting of controller logic

## What is the new behavior?

- We have on par unittest coverage on internal/controller/paas_controller.go
- We have insights in degradations and resolved them
- We are one step closer to upgrading controller from managing v1alpha1 to managing v1alpha2 with minimal toil
- We use ginkgo / gomega for unittesting of paas controller logic

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

