### PR TITLE
chore: moving all controller unittest funcs to suite_test.go

### DIFF
--- a/internal/controller/namespace_def_test.go
+++ b/internal/controller/namespace_def_test.go
@@ -8,37 +8,9 @@ import (
 	"github.com/belastingdienst/opr-paas/internal/quota"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
-
-func validatePaasNSExists(ctx context.Context, namespaceName string, paasNSName string) {
-	pns := api.PaasNS{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: paasNSName, Namespace: namespaceName}, &pns)
-	Expect(err).NotTo(HaveOccurred())
-}
-
-func assureNamespaceWithPaasReference(ctx context.Context, namespaceName string, paasName string) {
-	assureNamespace(ctx, namespaceName)
-	paas := &api.Paas{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: paasName}, paas)
-	Expect(err).NotTo(HaveOccurred())
-	ns := &corev1.Namespace{}
-	err = k8sClient.Get(ctx, types.NamespacedName{Name: namespaceName}, ns)
-	Expect(err).NotTo(HaveOccurred())
-
-	if !paas.AmIOwner(ns.GetOwnerReferences()) {
-		patchedNs := client.MergeFrom(ns.DeepCopy())
-		controllerutil.SetControllerReference(paas, ns, scheme.Scheme)
-		err = k8sClient.Patch(ctx, ns, patchedNs)
-		Expect(err).NotTo(HaveOccurred())
-	}
-}
 
 var _ = Describe("NamespaceDef", func() {
 	const (


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- funcs used for staging and running unittests are spread across all _test.go files
- we risk duplicating functions
- we risk changing functions in one test module which breaks unittests in other modules
- we risk defining them multiple times wich slightly different definition without us meaning to


## What is the new behavior?

- these functiions are moved to suite_test.go
- we have a common place
- we leviate teh risk of duplication, redefining, etc.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is updating v1alpha2, the updates to main are in #574 .
It is probably wise to first merge #574 to main, the merge main to v1alpha2, rebase and then merge this into main.