### PR TITLE
chore: moving all controller unittest funcs to suite_test.go

### DIFF
--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -21,58 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func patchAppSet(ctx context.Context, newAppSet *argocd.ApplicationSet) {
-	oldAppSet := &argocd.ApplicationSet{}
-	namespacedName := types.NamespacedName{
-		Name:      newAppSet.Name,
-		Namespace: newAppSet.Namespace,
-	}
-	err := k8sClient.Get(ctx, namespacedName, oldAppSet)
-	if err == nil {
-		// Patch
-		patch := client.MergeFrom(oldAppSet.DeepCopy())
-		oldAppSet.Spec = newAppSet.Spec
-		err = k8sClient.Patch(ctx, oldAppSet, patch)
-		Expect(err).NotTo(HaveOccurred())
-	} else {
-		Expect(err.Error()).To(MatchRegexp(`applicationsets.argoproj.io .* not found`))
-		err = k8sClient.Create(ctx, newAppSet)
-		Expect(err).NotTo(HaveOccurred())
-	}
-}
-
-func assureNamespace(ctx context.Context, namespaceName string) {
-	oldNs := &corev1.Namespace{}
-	namespacedName := types.NamespacedName{
-		Name: namespaceName,
-	}
-	err := k8sClient.Get(ctx, namespacedName, oldNs)
-	if err == nil {
-		return
-	}
-	Expect(err.Error()).To(MatchRegexp(`namespaces .* not found`))
-	err = k8sClient.Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: namespaceName},
-	})
-	Expect(err).NotTo(HaveOccurred())
-}
-
-func assurePaas(ctx context.Context, newPaas *api.Paas) {
-	oldPaas := &api.Paas{}
-	namespacedName := types.NamespacedName{
-		Name: newPaas.Name,
-	}
-	err := k8sClient.Get(ctx, namespacedName, oldPaas)
-	if err == nil {
-		return
-	}
-	Expect(err.Error()).To(MatchRegexp(`paas.cpet.belastingdienst.nl .* not found`))
-	err = k8sClient.Create(ctx, newPaas)
-	Expect(err).NotTo(HaveOccurred())
-}
 
 var _ = Describe("Paas Controller", Ordered, func() {
 	const (


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- funcs used for staging and running unittests are spread across all _test.go files
- we risk duplicating functions
- we risk changing functions in one test module which breaks unittests in other modules
- we risk defining them multiple times wich slightly different definition without us meaning to


## What is the new behavior?

- these functiions are moved to suite_test.go
- we have a common place
- we leviate teh risk of duplication, redefining, etc.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is updating main, the updates to v1alpha2 are in #573 