### PR TITLE
chore: Defining assureAppSet

### DIFF
--- a/internal/controller/capabilities_test.go
+++ b/internal/controller/capabilities_test.go
@@ -22,7 +22,6 @@ import (
 var _ = Describe("Capabilities controller", Ordered, func() {
 	const (
 		serviceName        = "my"
-		subServiceName     = "cap"
 		capName            = serviceName
 		capAppSetName      = capName + "-as"
 		capAppSetNamespace = "asns"
@@ -41,7 +40,6 @@ var _ = Describe("Capabilities controller", Ordered, func() {
 		ctx         context.Context
 		paas        *api.Paas
 		reconciler  *PaasReconciler
-		appSet      *appv1.ApplicationSet
 		paasConfig  api.PaasConfig
 		group1Roles = []string{"admin"}
 		group2Users = []string{"user1", "user2"}
@@ -110,21 +108,16 @@ g, {{ $groupName }}, role:admin{{end}}`
 			Client: k8sClient,
 			Scheme: k8sClient.Scheme(),
 		}
-		appSet = &appv1.ApplicationSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      capAppSetName,
-				Namespace: capAppSetNamespace,
-			},
-			Spec: appv1.ApplicationSetSpec{
-				Generators: []appv1.ApplicationSetGenerator{},
-			},
-		}
-		err := k8sClient.Create(ctx, appSet)
-		Expect(err).NotTo(HaveOccurred())
+		assureAppSet(ctx, capAppSetName, capAppSetNamespace)
 	})
 
 	AfterEach(func() {
-		err := k8sClient.Delete(ctx, appSet)
+		appset := &appv1.ApplicationSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      capAppSetName,
+				Namespace: capAppSetNamespace,
+			}}
+		err := k8sClient.Delete(ctx, appset)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -142,7 +135,7 @@ g, ` + group2 + `, role:admin`
 				)
 				err := reconciler.ensureAppSetCap(ctx, paas, capName)
 				Expect(err).NotTo(HaveOccurred())
-				appSet = &appv1.ApplicationSet{}
+				appSet := &appv1.ApplicationSet{}
 				appSetName := types.NamespacedName{
 					Name:      capAppSetName,
 					Namespace: capAppSetNamespace,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,7 +18,7 @@ import (
 	"slices"
 	"testing"
 
-	argocd "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
+	appv1 "github.com/belastingdienst/opr-paas/internal/stubs/argoproj/v1alpha1"
 
 	"github.com/go-logr/zerologr"
 	. "github.com/onsi/ginkgo/v2"
@@ -136,7 +136,7 @@ var _ = BeforeSuite(func() {
 	err = quotav1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = argocd.AddToScheme(scheme.Scheme)
+	err = appv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
@@ -154,8 +154,8 @@ var _ = AfterSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
-func patchAppSet(ctx context.Context, newAppSet *argocd.ApplicationSet) {
-	oldAppSet := &argocd.ApplicationSet{}
+func patchAppSet(ctx context.Context, newAppSet *appv1.ApplicationSet) {
+	oldAppSet := &appv1.ApplicationSet{}
 	namespacedName := types.NamespacedName{
 		Name:      newAppSet.Name,
 		Namespace: newAppSet.Namespace,
@@ -201,5 +201,19 @@ func assurePaas(ctx context.Context, newPaas *api.Paas) {
 	}
 	Expect(err.Error()).To(MatchRegexp(`paas.cpet.belastingdienst.nl .* not found`))
 	err = k8sClient.Create(ctx, newPaas)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func assureAppSet(ctx context.Context, name string, namespace string) {
+	appSet := &appv1.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appv1.ApplicationSetSpec{
+			Generators: []appv1.ApplicationSetGenerator{},
+		},
+	}
+	err := k8sClient.Create(ctx, appSet)
 	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- We have code for creating an AppSet in unittests but it is specific in capabilities_test.go

## What is the new behavior?

- We have definedd assureAppSet which can be reused by unittestcoee in capabilities_test.go or other unittest files.
- specific code is relaced by calling the method.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

