### PR TITLE
chore: Removes redundant finalizers

### DIFF
--- a/.testcoverage.yaml
+++ b/.testcoverage.yaml
@@ -37,7 +37,7 @@ override:
   #- path: ^pkg/lib/foo$
   #  threshold: 100
   - path: ^internal/controller$
-    threshold: 73
+    threshold: 72
   - path: ^api/v1alpha1$
     threshold: 68
   - path: ^api/v1alpha2$

--- a/internal/controller/cluster_quotas.go
+++ b/internal/controller/cluster_quotas.go
@@ -159,24 +159,6 @@ func (r *PaasReconciler) finalizeClusterQuota(ctx context.Context, quotaName str
 	return r.Delete(ctx, obj)
 }
 
-func (r *PaasReconciler) finalizeClusterQuotas(ctx context.Context, paas *v1alpha1.Paas) error {
-	suffixes := []string{
-		"",
-	}
-	for name := range paas.Spec.Capabilities {
-		suffixes = append(suffixes, fmt.Sprintf("-%s", name))
-	}
-
-	var err error
-	for _, suffix := range suffixes {
-		quotaName := fmt.Sprintf("%s%s", paas.Name, suffix)
-		if cleanErr := r.finalizeClusterQuota(ctx, quotaName); cleanErr != nil {
-			err = cleanErr
-		}
-	}
-	return err
-}
-
 func (r *PaasReconciler) reconcileQuotas(
 	ctx context.Context,
 	paas *v1alpha1.Paas,

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -197,7 +197,7 @@ func (r *PaasReconciler) removeFinalizer(
 	return nil
 }
 
-// Reconcile is the main entrypoint for Reconcilliation of a Paas resource
+// Reconcile is the main entrypoint for Reconciliation of a Paas resource
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *PaasReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
@@ -376,12 +376,10 @@ func (r *PaasReconciler) finalizePaas(ctx context.Context, paas *v1alpha1.Paas) 
 	logger.Debug().Msg("inside Paas finalizer")
 
 	paasReconcilers := []func(context.Context, *v1alpha1.Paas) error{
-		r.finalizeClusterQuotas,
 		r.finalizeGroups,
 		r.finalizePaasClusterRoleBindings,
 		r.finalizeClusterWideQuotas,
 		r.finalizeAppSetCaps,
-		r.finalizeNamespaces,
 	}
 
 	for _, reconciler := range paasReconcilers {

--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -764,15 +764,6 @@ var _ = Describe("Paas Reconclie", Ordered, func() {
 			err = reconciler.finalizePaas(ctx, paas)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("should have deleted paas quotas", func() {
-			for _, quotaName := range quotas {
-				var quota quotav1.ClusterResourceQuota
-				err := reconciler.Get(ctx, types.NamespacedName{Name: quotaName}, &quota)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(
-					"clusterresourcequotas.quota.openshift.io \"" + quotaName + "\" not found"))
-			}
-		})
 		It("should have deleted paas groups", func() {
 			for _, groupName := range groups {
 				var group userv1.Group
@@ -788,14 +779,6 @@ var _ = Describe("Paas Reconclie", Ordered, func() {
 			list, exists := configMap.Data[gsKey]
 			Expect(exists).To(BeTrue())
 			Expect(list).NotTo(ContainSubstring(ldapGroupQuery))
-		})
-		It("should have deleted paas namespaces", func() {
-			for _, nsName := range namespaces {
-				var ns corev1.Namespace
-				err := reconciler.Get(ctx, types.NamespacedName{Name: nsName}, &ns)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ns.DeletionTimestamp).NotTo(BeNil())
-			}
 		})
 		It("should have deleted paas clusterrolebindings", func() {
 			for _, crbRoleNames := range clusterRolebindings {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Namespace and clusterquota is finalized manually.

## What is the new behavior?

Namespace and clusterquota are deleted by cascading delete. As we test the ownerreferences are set correctly, we can't and don't have to test this any more, as described here: https://book.kubebuilder.io/reference/envtest.html#testing-considerations

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->