### PR TITLE
fix: Removes predicate in Watched PaasNs, as that predicate is unrelated.

### DIFF
--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -358,7 +358,13 @@ func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return []reconcile.Request{{
 						NamespacedName: types.NamespacedName{Name: paasName}}}
 				},
-			)).
+			), builder.WithPredicates(
+				predicate.Or(
+					// Spec updated
+					predicate.GenerationChangedPredicate{},
+					// Labels updated
+					predicate.LabelChangedPredicate{},
+				))).
 		Watches(
 			&v1alpha1.PaasConfig{},
 			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -325,7 +325,7 @@ func allPaases(mgr ctrl.Manager) []reconcile.Request {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-// SetupWithManager is not unittesterd ATM. Mostly already covered by e2e tests.
+// SetupWithManager is not unit-tested ATM. Mostly covered by e2e-tests.
 func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Paas{}, builder.WithPredicates(
@@ -358,9 +358,7 @@ func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return []reconcile.Request{{
 						NamespacedName: types.NamespacedName{Name: paasName}}}
 				},
-			),
-			builder.WithPredicates(v1alpha1.ActivePaasConfigUpdated()),
-		).
+			)).
 		Watches(
 			&v1alpha1.PaasConfig{},
 			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

PaasNs changes are not picked up by the Paas controller watch. As there is a wrong predicate used.

Fixes: # (issue)

## What is the new behavior?

PaasNs changes are filtered by the correct predicate.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->