### PR TITLE
fix: PaasConfig webhooks

### DIFF
--- a/internal/config/informer.go
+++ b/internal/config/informer.go
@@ -11,7 +11,6 @@ import (
 	cache2 "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/api/v1alpha2"
 )
 
@@ -28,7 +27,7 @@ func SetupPaasConfigInformer(mgr manager.Manager) error {
 func (w *configInformer) Start(ctx context.Context) error {
 	log.Info().Msg("starting config informer")
 
-	informer, err := w.mgr.GetCache().GetInformer(ctx, &v1alpha1.PaasConfig{})
+	informer, err := w.mgr.GetCache().GetInformer(ctx, &v1alpha2.PaasConfig{})
 	if err != nil {
 		return fmt.Errorf("failed to get informer for PaasConfig: %w", err)
 	}

--- a/internal/config/informer_test.go
+++ b/internal/config/informer_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"testing"
 
-	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/api/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -46,7 +45,7 @@ func TestHandleUpdate_NoChangeToInactiveConfig(t *testing.T) {
 	// inactive config
 	newCfg.Status.Conditions = []metav1.Condition{
 		{
-			Type:   v1alpha1.TypeActivePaasConfig,
+			Type:   v1alpha2.TypeActivePaasConfig,
 			Status: metav1.ConditionUnknown,
 		},
 	}

--- a/internal/controller/paasconfig_controller.go
+++ b/internal/controller/paasconfig_controller.go
@@ -53,7 +53,7 @@ func (pcr PaasConfigReconciler) GetScheme() *runtime.Scheme {
 // SetupWithManager sets up the controller with the Manager.
 func (pcr *PaasConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.PaasConfig{}).
+		For(&v1alpha2.PaasConfig{}).
 		WithEventFilter(
 			predicate.GenerationChangedPredicate{}, // Spec changed .
 		).

--- a/internal/controller/paasconfig_controller.go
+++ b/internal/controller/paasconfig_controller.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/internal/config"
 	"github.com/belastingdienst/opr-paas/internal/logging"
@@ -73,7 +72,7 @@ func (pcr *PaasConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	meta.SetStatusCondition(
 		&cfg.Status.Conditions,
 		metav1.Condition{
-			Type:               v1alpha1.TypeHasErrorsPaasConfig,
+			Type:               v1alpha2.TypeHasErrorsPaasConfig,
 			Status:             metav1.ConditionUnknown,
 			ObservedGeneration: cfg.Generation,
 			Reason:             "Reconciling",
@@ -159,7 +158,7 @@ func (pcr *PaasConfigReconciler) finalize(
 	if controllerutil.ContainsFinalizer(cfg, paasconfigFinalizer) {
 		// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-			Type:   v1alpha1.TypeDegradedPaasConfig,
+			Type:   v1alpha2.TypeDegradedPaasConfig,
 			Status: metav1.ConditionUnknown, Reason: "Finalizing", ObservedGeneration: cfg.Generation,
 			Message: fmt.Sprintf("Performing finalizer operations for PaasConfig: %s ", cfg.Name),
 		})
@@ -171,7 +170,7 @@ func (pcr *PaasConfigReconciler) finalize(
 
 		logger.Info().Msg("config reset successfully")
 		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-			Type:   v1alpha1.TypeDegradedPaasConfig,
+			Type:   v1alpha2.TypeDegradedPaasConfig,
 			Status: metav1.ConditionTrue, Reason: "Finalizing", ObservedGeneration: cfg.Generation,
 			Message: fmt.Sprintf(
 				"Finalizer operations for PaasConfig %s name were successfully accomplished",
@@ -198,12 +197,12 @@ func (pcr *PaasConfigReconciler) finalize(
 
 func (pcr *PaasConfigReconciler) setSuccessfulCondition(ctx context.Context, paasConfig *v1alpha2.PaasConfig) error {
 	meta.SetStatusCondition(&paasConfig.Status.Conditions, metav1.Condition{
-		Type:   v1alpha1.TypeActivePaasConfig,
+		Type:   v1alpha2.TypeActivePaasConfig,
 		Status: metav1.ConditionTrue, Reason: "Reconciling", ObservedGeneration: paasConfig.Generation,
 		Message: "This config is the active config!",
 	})
 	meta.SetStatusCondition(&paasConfig.Status.Conditions, metav1.Condition{
-		Type:   v1alpha1.TypeHasErrorsPaasConfig,
+		Type:   v1alpha2.TypeHasErrorsPaasConfig,
 		Status: metav1.ConditionFalse, Reason: "Reconciling", ObservedGeneration: paasConfig.Generation,
 		Message: fmt.Sprintf("Reconciled (%s) successfully", paasConfig.Name),
 	})

--- a/manifests/crd/kustomization.yaml
+++ b/manifests/crd/kustomization.yaml
@@ -11,6 +11,7 @@ patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
   - path: patches/webhook_in_paas.yaml
+  - path: patches/webhook_in_paasconfig.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.

--- a/manifests/crd/patches/webhook_in_paasconfig.yaml
+++ b/manifests/crd/patches/webhook_in_paasconfig.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: paasconfig.cpet.belastingdienst.nl
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1


### PR DESCRIPTION
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

E2E tests fails on uninitialized PaasConfig

## What is the new behavior?

* Adds missing manifests for conversion webhook
* Adds patch to CRD
* Updates informer.go to use v1alpha2

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->