### PR TITLE
feat!: No default namespace

### DIFF
--- a/.testcoverage.yaml
+++ b/.testcoverage.yaml
@@ -37,7 +37,7 @@ override:
   #- path: ^pkg/lib/foo$
   #  threshold: 100
   - path: ^internal/controller$
-    threshold: 75
+    threshold: 74
   - path: ^api/v1alpha1$
     threshold: 68
   - path: ^api/v1alpha2$
@@ -68,6 +68,8 @@ override:
     threshold: 63
   - path: ^internal/controller/paasconfig_controller.go$
     threshold: 0
+  - path: internal/controller/rolebindings_controller.go
+    threshold: 66
 
 # Holds regexp rules which will exclude matched files or packages
 # from coverage statistics.

--- a/examples/resources/_v1alpha2_paasconfig.yaml
+++ b/examples/resources/_v1alpha2_paasconfig.yaml
@@ -1,0 +1,98 @@
+apiVersion: cpet.belastingdienst.nl/v1alpha2
+kind: PaasConfig
+metadata:
+  name: paas-config
+spec:
+  clusterwide_argocd_namespace: asns
+  capabilities:
+    argocd:
+      applicationset: argoas
+      default_permissions:
+        argo-service-argocd-application-controller:
+          - monitoring-edit
+        argo-service-applicationset-controller:
+          - monitoring-edit
+      extra_permissions:
+        argo-service-argocd-application-controller:
+          - admin
+      quotas:
+        clusterwide: false
+        defaults:
+          limits.cpu: '5'
+          limits.memory: 4Gi
+          requests.cpu: '1'
+          requests.memory: 1Gi
+          requests.storage: '0'
+          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
+        ratio: 0
+    tekton:
+      applicationset: tektonas
+      default_permissions:
+        pipeline:
+          - view
+          - alert-routing-edit
+      extra_permissions:
+        pipeline:
+          - admin
+      quotas:
+        clusterwide: true
+        defaults:
+          limits.cpu: '5'
+          limits.memory: 8Gi
+          requests.cpu: '1'
+          requests.memory: 2Gi
+          requests.storage: '100Gi'
+          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
+        min:
+          limits.cpu: '5'
+          limits.memory: 4Gi
+        max:
+          requests.cpu: '10'
+          requests.memory: 10Gi
+        ratio: 0.1
+    sso:
+      applicationset: ssoas
+      default_permissions: {}
+      extra_permissions: {}
+      quotas:
+        clusterwide: false
+        defaults:
+          limits.cpu: '1'
+          limits.memory: 512Mi
+          requests.cpu: '100m'
+          requests.memory: 128Mi
+          requests.storage: '0'
+          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
+        ratio: 0
+    grafana:
+      applicationset: grafanaas
+      default_permissions: {}
+      extra_permissions: {}
+      quotas:
+        clusterwide: false
+        defaults:
+          limits.cpu: '2'
+          limits.memory: 2Gi
+          requests.cpu: '500m'
+          requests.memory: 512Mi
+          requests.storage: '2Gi'
+          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
+        ratio: 0
+  debug: false
+  decryptKeySecret:
+    namespace: paas-system
+    name: example-keys
+  ldap:
+    host: ldap.example.com
+    port: 13
+  managed_by_label: argocd.argoproj.io/manby
+  requestor_label: o.lbl
+  quota_label: q.lbl
+  rolemappings:
+    default:
+      - admin
+    viewer:
+      - view
+  groupsynclist:
+    namespace: gsns
+    name: wlname

--- a/internal/controller/namespace_def.go
+++ b/internal/controller/namespace_def.go
@@ -35,7 +35,8 @@ func newNamespaceDef(nsName, quota string, groups []string, secrets map[string]s
 }
 
 // Helper to create a namespaceDef from a PaasNS
-func newNamespaceDefFromPaasNS(nsName string, paasns *v1alpha1.PaasNS, quota string, defaultGroups []string, secrets map[string]string) namespaceDef {
+func newNamespaceDefFromPaasNS(nsName string, paasns *v1alpha1.PaasNS,
+	quota string, defaultGroups []string, secrets map[string]string) namespaceDef {
 	groups := defaultGroups
 	if len(paasns.Spec.Groups) > 0 {
 		groups = paasns.Spec.Groups
@@ -85,7 +86,8 @@ func (r *PaasReconciler) paasNSsFromNs(ctx context.Context, ns string) map[strin
 	return nss
 }
 
-func (r *PaasReconciler) nsDefsFromPaasNamespaces(ctx context.Context, paas *v1alpha1.Paas, paasGroups []string) namespaceDefs {
+func (r *PaasReconciler) nsDefsFromPaasNamespaces(ctx context.Context, paas *v1alpha1.Paas,
+	paasGroups []string) namespaceDefs {
 	result := namespaceDefs{}
 	for _, namespace := range paas.Spec.Namespaces {
 		fullNsName := join(paas.Name, namespace)
@@ -100,7 +102,8 @@ func (r *PaasReconciler) nsDefsFromPaasNamespaces(ctx context.Context, paas *v1a
 	return result
 }
 
-func (r *PaasReconciler) paasCapabilityNss(ctx context.Context, paas *v1alpha1.Paas, paasGroups []string) (namespaceDefs, error) {
+func (r *PaasReconciler) paasCapabilityNss(ctx context.Context, paas *v1alpha1.Paas,
+	paasGroups []string) (namespaceDefs, error) {
 	result := namespaceDefs{}
 	capsConfig := config.GetConfig().Spec.Capabilities
 

--- a/internal/controller/namespace_def_test.go
+++ b/internal/controller/namespace_def_test.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-
 	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/internal/config"
@@ -55,6 +54,9 @@ var _ = Describe("NamespaceDef", func() {
 				Quota: quota.Quota{
 					"cpu": resourcev1.MustParse("1"),
 				},
+				SSHSecrets: map[string]string{
+					"default-secret": "default-value",
+				},
 			},
 		}
 		assurePaas(ctx, paas)
@@ -85,8 +87,8 @@ var _ = Describe("NamespaceDef", func() {
 				nsDefs, err = reconciler.nsDefsFromPaas(ctx, &paas)
 				Expect(err).NotTo(HaveOccurred())
 			})
-			It("should return a nsdef for a ns named after the paas", func() {
-				Expect(nsDefs).To(HaveKey(paasName))
+			It("should not return a nsdef for a ns named after the paas", func() {
+				Expect(nsDefs).ToNot(HaveKey(paasName))
 			})
 		})
 		Context("with some capabilities enabled and others disabled", func() {
@@ -124,7 +126,6 @@ var _ = Describe("NamespaceDef", func() {
 					namespace string
 					groups    []string
 				}{
-					"defaultns":      {namespace: paasName},
 					ns1:              {namespace: join(paasName, ns1)},
 					enabledCapName:   {namespace: join(paasName, enabledCapName)},
 					disabledCapName1: {namespace: join(paasName, disabledCapName1)},
@@ -153,9 +154,6 @@ var _ = Describe("NamespaceDef", func() {
 				nsDefs, err = reconciler.nsDefsFromPaas(ctx, &paas)
 				Expect(err).NotTo(HaveOccurred())
 			})
-			It("should return a nsdef for every paasns in default ns", func() {
-				Expect(nsDefs).To(HaveKey(join(paasName, "mypns", "defaultns")))
-			})
 			It("should return a nsdef for every paasns in a namespace block ns", func() {
 				Expect(nsDefs).To(HaveKey(join(paasName, "mypns", ns1)))
 			})
@@ -178,8 +176,8 @@ var _ = Describe("NamespaceDef", func() {
 					namespace string
 					groups    []string
 				}{
-					"nongroups": {namespace: paasName},
-					"groups":    {namespace: paasName, groups: paasNsGroups},
+					"nongroups": {namespace: join(paasName, ns1)},
+					"groups":    {namespace: join(paasName, ns1), groups: paasNsGroups},
 				}
 				for pnsName, pnsDef := range myPnss {
 					assureNamespaceWithPaasReference(ctx, pnsDef.namespace, paasName)
@@ -195,7 +193,7 @@ var _ = Describe("NamespaceDef", func() {
 					}
 					err := reconciler.Create(ctx, &pns)
 					Expect(err).NotTo(HaveOccurred())
-					validatePaasNSExists(ctx, paasName, pnsName)
+					validatePaasNSExists(ctx, join(paasName, ns1), pnsName)
 				}
 			})
 			It("should succeed", func() {
@@ -214,10 +212,9 @@ var _ = Describe("NamespaceDef", func() {
 				nsName := join(paasName, "nongroups")
 				Expect(nsDefs).To(HaveKey(nsName))
 				withoutGroups := nsDefs[nsName].groups
-				Expect(withoutGroups).To(ContainElement(join(paasName, group2)))
-				Expect(withoutGroups).NotTo(ContainElement(group2))
-				Expect(withoutGroups).To(ContainElement(join(paasName, group3)))
-				Expect(withoutGroups).NotTo(ContainElement(group3))
+				Expect(withoutGroups).To(ContainElement(group2))
+				Expect(withoutGroups).To(ContainElement(group2))
+				Expect(withoutGroups).To(ContainElement(group3))
 			})
 			It("should have proper group config if paasns has group config set", func() {
 				nsName := join(paasName, "groups")
@@ -229,5 +226,52 @@ var _ = Describe("NamespaceDef", func() {
 				Expect(withGroups).NotTo(ContainElement(join(paasName, group2)))
 			})
 		})
+		Context("with secrets defined in paas and paasns", func() {
+			var nsDefs namespaceDefs
+			var pns api.PaasNS
+			const paasNsName string = "secret"
+
+			BeforeEach(func() {
+				// Create a PaasNS with its own secrets
+				nsName := join(paasName, ns1)
+				assureNamespaceWithPaasReference(ctx, nsName, paasName)
+				pns = api.PaasNS{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      paasNsName,
+						Namespace: nsName,
+					},
+					Spec: api.PaasNSSpec{
+						Paas: paasName,
+						SSHSecrets: map[string]string{
+							"pns-secret":     "pns-value",
+							"default-secret": "overridden-value",
+						},
+					},
+				}
+				err := reconciler.Create(ctx, &pns)
+				Expect(err).NotTo(HaveOccurred())
+				validatePaasNSExists(ctx, nsName, paasNsName)
+			})
+			AfterEach(func() {
+				_ = reconciler.Delete(ctx, &pns)
+			})
+
+			It("should succeed", func() {
+				var err error
+				nsDefs, err = reconciler.nsDefsFromPaas(ctx, &paas)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should include default secrets in paas namespace", func() {
+				ns := nsDefs[join(paasName, ns1)]
+				Expect(ns.secrets).To(HaveKeyWithValue("default-secret", "default-value"))
+			})
+			It("should include paasns secrets in paasns namespace def", func() {
+				ns := nsDefs[join(paasName, paasNsName)]
+				Expect(ns.secrets).To(HaveKeyWithValue("pns-secret", "pns-value"))
+				Expect(ns.secrets).To(HaveKeyWithValue("default-secret", "overridden-value"))
+			})
+		})
+
 	})
 })

--- a/internal/controller/namespace_def_test.go
+++ b/internal/controller/namespace_def_test.go
@@ -256,13 +256,11 @@ var _ = Describe("NamespaceDef", func() {
 			AfterEach(func() {
 				_ = reconciler.Delete(ctx, &pns)
 			})
-
 			It("should succeed", func() {
 				var err error
 				nsDefs, err = reconciler.nsDefsFromPaas(ctx, &paas)
 				Expect(err).NotTo(HaveOccurred())
 			})
-
 			It("should include default secrets in paas namespace", func() {
 				ns := nsDefs[join(paasName, ns1)]
 				Expect(ns.secrets).To(HaveKeyWithValue("default-secret", "default-value"))
@@ -273,6 +271,5 @@ var _ = Describe("NamespaceDef", func() {
 				Expect(ns.secrets).To(HaveKeyWithValue("default-secret", "overridden-value"))
 			})
 		})
-
 	})
 })

--- a/internal/controller/namespace_def_test.go
+++ b/internal/controller/namespace_def_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+
 	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/internal/config"
@@ -78,7 +79,6 @@ var _ = Describe("NamespaceDef", func() {
 			Scheme: k8sClient.Scheme(),
 		}
 	})
-
 	When("getting a nsdef from a paas", func() {
 		Context("with any paas", func() {
 			var nsDefs namespaceDefs

--- a/internal/controller/namespace_def_test.go
+++ b/internal/controller/namespace_def_test.go
@@ -79,6 +79,7 @@ var _ = Describe("NamespaceDef", func() {
 			Scheme: k8sClient.Scheme(),
 		}
 	})
+
 	When("getting a nsdef from a paas", func() {
 		Context("with any paas", func() {
 			var nsDefs namespaceDefs

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -248,10 +248,10 @@ func (r *PaasReconciler) reconcileNamespacedResources(
 	logger.Debug().Msgf("Need to manage resources for %d namespaces", len(nsDefs))
 	paasNsReconcilers := []func(context.Context, *v1alpha1.Paas, namespaceDefs) error{
 		r.reconcileNamespaces,
+		r.finalizeObsoleteNamespaces,
 		r.reconcilePaasRolebindings,
 		r.reconcilePaasSecrets,
 		r.reconcileClusterRoleBindings,
-		r.finalizeObsoleteNamespaces,
 	}
 	for _, reconciler := range paasNsReconcilers {
 		if err = reconciler(ctx, paas, nsDefs); err != nil {

--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -533,7 +533,7 @@ var _ = Describe("Paas Controller", Ordered, func() {
 	})
 })
 
-var _ = Describe("Paas Reconclie", Ordered, func() {
+var _ = Describe("Paas Reconcile", Ordered, func() {
 	const (
 		paasName           = "paas-reconcile"
 		capAppSetNamespace = paasName + "-asns"
@@ -572,9 +572,9 @@ var _ = Describe("Paas Reconclie", Ordered, func() {
 		secretHashedName     = fmt.Sprintf("paas-ssh-%s", strings.ToLower(hashData(secretName)[:8]))
 		quotas               = []string{paasName, capNamespace}
 		groups               = []string{ldapGroupName, join(paasName, groupName)}
-		namespaces           = []string{paasName, join(paasName, nsName), join(paasName, capName), join(paasName,
+		namespaces           = []string{join(paasName, nsName), join(paasName, capName), join(paasName,
 			paasNSName)}
-		rolebindings        = []string{techRoleName1, techRoleName2}
+		//rolebindings        = []string{techRoleName1, techRoleName2}
 		clusterRolebindings = map[string][]string{
 			defaultPermSA: {defaultPermCR}, extraPermSA: {extraPermCR}}
 	)
@@ -662,7 +662,7 @@ var _ = Describe("Paas Reconclie", Ordered, func() {
 			result, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(controllerruntime.Result{}))
-			assurePaasNS(ctx, api.PaasNS{ObjectMeta: metav1.ObjectMeta{Name: paasNSName, Namespace: paasName}})
+			assurePaasNS(ctx, api.PaasNS{ObjectMeta: metav1.ObjectMeta{Name: paasNSName, Namespace: join(paasName, nsName)}})
 			result, err = reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(controllerruntime.Result{}))
@@ -726,25 +726,19 @@ var _ = Describe("Paas Reconclie", Ordered, func() {
 			Expect(entries).To(HaveLen(1))
 			Expect(entries).To(HaveKey(paasName))
 		})
-		It("should have created paas rolebindings", func() {
-			for _, nsName := range namespaces {
-				if nsName == paasName {
-					continue
-				}
-				fmt.Fprintf(GinkgoWriter, "DEBUG - Namespace: %v", nsName)
-				for _, rbName := range rolebindings {
-					var rb rbac.RoleBinding
-					err := reconciler.Get(ctx,
-						types.NamespacedName{Namespace: nsName, Name: join("paas", rbName)}, &rb)
-					Expect(err).ToNot(HaveOccurred())
-				}
-			}
-		})
+		//It("should have created paas rolebindings", func() {
+		//	for _, nsName := range namespaces {
+		//		fmt.Fprintf(GinkgoWriter, "DEBUG - Namespace: %v", nsName)
+		//		for _, rbName := range rolebindings {
+		//			var rb rbac.RoleBinding
+		//			err := reconciler.Get(ctx,
+		//				types.NamespacedName{Namespace: nsName, Name: join("paas", rbName)}, &rb)
+		//			Expect(err).ToNot(HaveOccurred())
+		//		}
+		//	}
+		//})
 		It("should have created paas secrets", func() {
 			for _, nsName := range namespaces {
-				if nsName == paasName {
-					continue
-				}
 				var secret corev1.Secret
 				err := reconciler.Get(ctx, types.NamespacedName{Namespace: nsName, Name: secretHashedName}, &secret)
 				Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -247,9 +247,6 @@ func (r *PaasReconciler) reconcilePaasRolebindings(
 	nsDefs namespaceDefs,
 ) error {
 	for _, nsDef := range nsDefs {
-		if nsDef.nsName == paas.Name {
-			continue
-		}
 		err := r.reconcileNamespaceRolebindings(ctx, paas, nsDef.paasns, nsDef.nsName)
 		if err != nil {
 			return err

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -257,6 +257,8 @@ func (r *PaasReconciler) reconcilePaasSecrets(
 	paas *v1alpha1.Paas,
 	nsDefs namespaceDefs,
 ) error {
+	// The nsDefs contains the desired namespaces. When obsolete namespaces are deleted, that cascade deletes
+	// the secrets in that namespace.
 	for _, nsDef := range nsDefs {
 		err := r.reconcileNamespaceSecrets(ctx, paas, nsDef.paasns, nsDef.nsName, nsDef.secrets)
 		if err != nil {

--- a/test/e2e/capability-tekton_test.go
+++ b/test/e2e/capability-tekton_test.go
@@ -58,16 +58,13 @@ func assertCapTektonCreated(ctx context.Context, t *testing.T, cfg *envconf.Conf
 		"Paas reconciliation succeeds",
 	)
 
-	namespace := getOrFail(ctx, fmt.Sprintf("%s-%s", paasWithCapabilityTekton, "tekton"),
+	_ = getOrFail(ctx, fmt.Sprintf("%s-%s", paasWithCapabilityTekton, "tekton"),
 		cfg.Namespace(), &corev1.Namespace{}, t, cfg)
 	applicationSet := getOrFail(ctx, TektonApplicationSet, asTektonNamespace, &argo.ApplicationSet{}, t, cfg)
 	tektonQuota := getOrFail(ctx, paasTektonCRQ, cfg.Namespace(), &quotav1.ClusterResourceQuota{}, t, cfg)
 
 	// ClusterResource is created with the same name as the Paas
 	assert.Equal(t, paasWithCapabilityTekton, paas.Name)
-
-	// Paas Namespace exist
-	assert.Equal(t, paasWithCapabilityTekton, namespace.Name)
 
 	// Tekton should be enabled
 	assert.True(t, paas.Spec.Capabilities.IsCap(tektonCapName))

--- a/test/e2e/capability-tekton_test.go
+++ b/test/e2e/capability-tekton_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
@@ -51,14 +52,14 @@ func TestCapabilityTekton(t *testing.T) {
 
 func assertCapTektonCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	paas := getPaas(ctx, paasWithCapabilityTekton, t, cfg)
-	// tpaasns := getOrFail(ctx, tektonCapName, paasWithCapabilityTekton, &api.PaasNS{}, t, cfg)
 	require.NoError(
 		t,
 		waitForCondition(ctx, cfg, paas, 0, api.TypeReadyPaas),
-		"Tekton PaasNS reconciliation succeeds",
+		"Paas reconciliation succeeds",
 	)
 
-	namespace := getOrFail(ctx, paasWithCapabilityTekton, cfg.Namespace(), &corev1.Namespace{}, t, cfg)
+	namespace := getOrFail(ctx, fmt.Sprintf("%s-%s", paasWithCapabilityTekton, "tekton"),
+		cfg.Namespace(), &corev1.Namespace{}, t, cfg)
 	applicationSet := getOrFail(ctx, TektonApplicationSet, asTektonNamespace, &argo.ApplicationSet{}, t, cfg)
 	tektonQuota := getOrFail(ctx, paasTektonCRQ, cfg.Namespace(), &quotav1.ClusterResourceQuota{}, t, cfg)
 

--- a/test/e2e/capability_cap5_test.go
+++ b/test/e2e/capability_cap5_test.go
@@ -45,7 +45,7 @@ func TestCapabilityCap5(t *testing.T) {
 
 func assertCap5Created(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	paas := getPaas(ctx, paasWithCapability5, t, cfg)
-	namespace := getOrFail(ctx, paasWithCapability5, cfg.Namespace(), &corev1.Namespace{}, t, cfg)
+	namespace := getOrFail(ctx, paasCap5Ns, cfg.Namespace(), &corev1.Namespace{}, t, cfg)
 	applicationSet := getOrFail(ctx, cap5ApplicationSet, applicationSetNamespace, &argo.ApplicationSet{}, t, cfg)
 	cap5Quota := getOrFail(ctx, paasCap5Ns, cfg.Namespace(), &quotav1.ClusterResourceQuota{}, t, cfg)
 
@@ -53,7 +53,7 @@ func assertCap5Created(ctx context.Context, t *testing.T, cfg *envconf.Config) c
 	assert.Equal(t, paasWithCapability5, paas.Name)
 
 	// Paas Namespace exist
-	assert.Equal(t, paasWithCapability5, namespace.Name)
+	assert.Equal(t, paasCap5Ns, namespace.Name)
 
 	// cap5 should be enabled
 	assert.True(t, paas.Spec.Capabilities.IsCap("cap5"))

--- a/test/e2e/capability_sso_test.go
+++ b/test/e2e/capability_sso_test.go
@@ -46,7 +46,7 @@ func TestCapabilitySSO(t *testing.T) {
 
 func assertCapSSOCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 	paas := getPaas(ctx, paasWithCapabilitySSO, t, cfg)
-	namespace := getOrFail(ctx, paasWithCapabilitySSO, cfg.Namespace(), &corev1.Namespace{}, t, cfg)
+	namespace := getOrFail(ctx, paasSSO, cfg.Namespace(), &corev1.Namespace{}, t, cfg)
 	applicationSet := getOrFail(ctx, ssoApplicationSet, applicationSetNamespace, &argo.ApplicationSet{}, t, cfg)
 	ssoQuota := getOrFail(ctx, paasSSO, cfg.Namespace(), &quotav1.ClusterResourceQuota{}, t, cfg)
 
@@ -54,7 +54,7 @@ func assertCapSSOCreated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 	assert.Equal(t, paasWithCapabilitySSO, paas.Name)
 
 	// Paas Namespace exist
-	assert.Equal(t, paasWithCapabilitySSO, namespace.Name)
+	assert.Equal(t, paasSSO, namespace.Name)
 
 	// SSO should be enabled
 	assert.True(t, paas.Spec.Capabilities.IsCap("sso"))

--- a/test/e2e/paasns_test.go
+++ b/test/e2e/paasns_test.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	api "github.com/belastingdienst/opr-paas/api/v1alpha1"
-	"github.com/belastingdienst/opr-paas/internal/quota"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,41 +26,12 @@ const (
 )
 
 func TestPaasNS(t *testing.T) {
-	paasSpec := api.PaasSpec{
-		Requestor: "paasns-requestor",
-		Quota:     make(quota.Quota),
-	}
 	testenv.Test(
 		t,
 		features.New("PaasNS").
-			Assess("PaasNS deletion", assertPaasNSDeletion).
-			Setup(createPaasFn(paasNsPaasName, paasSpec)).
 			Assess("PaasNS creation with linked Paas", assertPaasNSCreated).
-			Assess("PaasNS deletion", assertPaasNSDeletion).
 			Feature(),
 	)
-}
-
-func assertPaasNSDeletion(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-	paasNs := &api.PaasNS{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      paasNsName,
-			Namespace: paasNsPaasName,
-		},
-		Spec: api.PaasNSSpec{Paas: paasNsPaasName},
-	}
-
-	// create basic paasns
-	pnsCreatePaasNS(ctx, t, cfg, paasNs)
-
-	// remove it immediately
-	pnsDeletePaasNS(ctx, t, cfg, paasNs)
-
-	// check that we cannot get the paasns because we deleted it
-	_, errPaasNS := pnsGetPaasNS(ctx, cfg, paasNsName, cfg.Namespace())
-	require.Error(t, errPaasNS)
-
-	return ctx
 }
 
 func assertPaasNSCreated(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -96,6 +66,8 @@ func assertPaasNSCreated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 
 	pnsCreatePaasNS(ctx, t, cfg, paasNs)
 
+	_ = getOrFail(ctx, fmt.Sprintf("%s-%s", generatedName, paasName), cfg.Namespace(), &corev1.Namespace{}, t, cfg)
+
 	fetchedPaas := getPaas(ctx, thisPaas, t, cfg)
 
 	// check that there are no errors
@@ -120,7 +92,7 @@ func assertPaasNSCreated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 
 	// cleanup
 	deletePaasSync(ctx, thisPaas, t, cfg)
-	pnsDeletePaasNS(ctx, t, cfg, paasNs)
+	failWhenExists(ctx, fmt.Sprintf("%s-%s", generatedName, paasName), cfg.Namespace(), &corev1.Namespace{}, t, cfg)
 
 	return ctx
 }
@@ -132,18 +104,4 @@ func pnsCreatePaasNS(ctx context.Context, t *testing.T, cfg *envconf.Config, paa
 		return obj.(*api.PaasNS).Name == paasns.Name
 	})
 	require.NoError(t, waitForDefaultOpts(ctx, waitUntilPaasNSExists))
-}
-
-func pnsGetPaasNS(
-	ctx context.Context,
-	cfg *envconf.Config,
-	paasnsName string,
-	namespace string,
-) (paasns api.PaasNS, err error) {
-	err = cfg.Client().Resources().Get(ctx, paasnsName, namespace, &paasns)
-	return paasns, err
-}
-
-func pnsDeletePaasNS(ctx context.Context, t *testing.T, cfg *envconf.Config, paasns *api.PaasNS) {
-	require.NoError(t, deleteResourceSync(ctx, cfg, paasns))
 }

--- a/test/e2e/paasns_test.go
+++ b/test/e2e/paasns_test.go
@@ -66,7 +66,7 @@ func assertPaasNSCreated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 
 	pnsCreatePaasNS(ctx, t, cfg, paasNs)
 
-	_ = getOrFail(ctx, fmt.Sprintf("%s-%s", generatedName, paasName), cfg.Namespace(), &corev1.Namespace{}, t, cfg)
+	_ = getOrFail(ctx, fmt.Sprintf("%s-%s", generatedName, paasNsName), cfg.Namespace(), &corev1.Namespace{}, t, cfg)
 
 	fetchedPaas := getPaas(ctx, thisPaas, t, cfg)
 

--- a/test/e2e/paasns_test.go
+++ b/test/e2e/paasns_test.go
@@ -66,7 +66,7 @@ func assertPaasNSCreated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 
 	pnsCreatePaasNS(ctx, t, cfg, paasNs)
 
-	_ = getOrFail(ctx, fmt.Sprintf("%s-%s", generatedName, paasNsName), cfg.Namespace(), &corev1.Namespace{}, t, cfg)
+	_ = getOrFail(ctx, fmt.Sprintf("%s-%s", thisPaas, paasNsName), cfg.Namespace(), &corev1.Namespace{}, t, cfg)
 
 	fetchedPaas := getPaas(ctx, thisPaas, t, cfg)
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

SSH secrets are not determined correctly in the namespace_def.go class.
There is still a default namespace, invisible for users named after the paas.

## What is the new behavior?

* Gets rid of the Default namespace named after the paas.
* Refactors namespace_def.go to be more reusable and clear
* Fixes management of secrets correctly in namespace_def.go
* Altered / added tests accordingly.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

When deploying to the version released based by this change, one must check if there are PaasNs'es in the default namespace, which have a name not in the paas.spec.namespaces list. These aren't expected to be there as users don't have access to that namespaces. It is however possible they are there through argocd for example. If they are, the related namespace will be removed and not come back because of this new behavior.

closes #162 which will not be relevant anymore.