### PR TITLE
fix: Unique rolebinding entries

### DIFF
--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -206,14 +206,16 @@ func (r *PaasReconciler) reconcileNamespaceRolebindings(
 	nsName string,
 ) error {
 	ctx, logger := logging.GetLogComponent(ctx, "rolebinding")
-	roles := map[string][]string{}
+	// Use a map of sets to avoid duplicates
+	roleGroups := map[string]map[string]bool{}
 
 	for _, roleList := range config.GetConfig().Spec.RoleMappings {
 		for _, role := range roleList {
-			roles[role] = []string{}
+			roleGroups[role] = map[string]bool{}
 		}
 	}
-	logger.Info().Any("Rolebindings map", roles).Msg("all roles")
+
+	logger.Info().Any("Rolebindings map", roleGroups).Msg("all roles")
 	paasGroups := paas.Spec.Groups
 	if paasns != nil {
 		paasGroups = paasGroups.Filtered(paasns.Spec.Groups)
@@ -223,13 +225,20 @@ func (r *PaasReconciler) reconcileNamespaceRolebindings(
 		// Convert the groupKey to a groupName to map the rolebinding subjects to a group
 		groupName := paas.GroupKey2GroupName(groupKey)
 		for _, mappedRole := range config.GetConfig().Spec.RoleMappings.Roles(groupRoles) {
-			if groups, exists := roles[mappedRole]; exists {
-				roles[mappedRole] = append(groups, groupName)
-			} else {
-				roles[mappedRole] = []string{groupName}
+			if _, exists := roleGroups[mappedRole]; !exists {
+				roleGroups[mappedRole] = map[string]bool{}
 			}
+			roleGroups[mappedRole][groupName] = true
 		}
 	}
+
+	roles := map[string][]string{}
+	for role, groupSet := range roleGroups {
+		for groupName := range groupSet {
+			roles[role] = append(roles[role], groupName)
+		}
+	}
+
 	logger.Info().Any("Rolebindings map", roles).Msg("creating paas RoleBindings for PAASNS object")
 	for roleName, groupNames := range roles {
 		err := r.reconcileNamespaceRolebinding(ctx, paas, nsName, roleName, groupNames)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When multiple groups with the same name are derived from the paas.groups spec, a rolebinding with duplicate entries will be created. 

Fixes: #595 

## What is the new behavior?

All entries in a rolebinding created by Paas, are unique combinations of groups and roles.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->