### PR TITLE
hotfix(webhook): allow for updating deleted paas resources

### DIFF
--- a/internal/webhook/v1alpha1/paas_webhook.go
+++ b/internal/webhook/v1alpha1/paas_webhook.go
@@ -80,6 +80,10 @@ func (v *PaasCustomValidator) ValidateUpdate(
 		return nil, fmt.Errorf("expected a Paas object for the newObj but got %T", newObj)
 	}
 	ctx, logger := logging.SetWebhookLogger(ctx, paas)
+	if paas.GetDeletionTimestamp() != nil {
+		logger.Info().Msg("paas is being deleted")
+		return nil, nil
+	}
 	logger.Info().Msg("starting validation webhook for update")
 
 	return v.validate(ctx, paas)


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- when deleting a paas which does not meet validations, controller tries to set status and update validation exists with error

## What is the new behavior?

- when deleting a paas which does not meet validations, controller tries to set status, update does not run validations for paas that is being deleted. and controller can continue finalizing the paas

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information