### PR TITLE
chore: Adding code and unittests for managing groups and secrets in paas.Spec.Namespaces{}

### DIFF
--- a/internal/controller/namespace_def.go
+++ b/internal/controller/namespace_def.go
@@ -98,18 +98,26 @@ func (r *PaasReconciler) nsDefsFromPaasNamespaces(
 		secrets := map[string]string{}
 		maps.Copy(secrets, paas.Spec.Secrets)
 		maps.Copy(secrets, nsConfig.Secrets)
-		base := newNamespaceDef(fullNsName, paas.Name, append(paasGroups, nsConfig.Groups...), secrets)
+		paasNsGroups := nsConfig.Groups
+		if len(paasNsGroups) == 0 {
+			paasNsGroups = paasGroups
+		}
+		base := newNamespaceDef(fullNsName, paas.Name, paasNsGroups, secrets)
 		result[base.nsName] = base
 
 		for nsName, paasns := range r.paasNSsFromNs(ctx, base.nsName) {
 			secrets = map[string]string{}
 			maps.Copy(secrets, paas.Spec.Secrets)
 			maps.Copy(secrets, paasns.Spec.Secrets)
+			paasNsGroups = nsConfig.Groups
+			if len(paasNsGroups) == 0 {
+				paasNsGroups = paasGroups
+			}
 			ns := newNamespaceDefFromPaasNS(
 				nsName,
 				&paasns,
 				paas.Name,
-				append(paasGroups, paasns.Spec.Groups...),
+				append(paasGroups, paasNsGroups...),
 				secrets,
 			)
 			result[ns.nsName] = ns

--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -853,7 +853,12 @@ var _ = Describe("Paas Reconcile", Ordered, func() {
 		})
 		It("should have deleted paas secrets", func() {
 			var secret corev1.Secret
-			err := reconciler.Get(ctx, types.NamespacedName{Namespace: ns2Name, Name: ns2SecretHashedName}, &secret)
+			err := reconciler.Get(
+				ctx,
+				types.NamespacedName{Namespace: join(paasName, ns2Name),
+					Name: ns2SecretHashedName},
+				&secret,
+			)
 			Expect(err.Error()).To(Equal("secrets \"" + ns2SecretHashedName + "\" not found"))
 		})
 		It("should have removed paas clusterrolebindings", func() {


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- We have no unittests for groups and secrets in paas.Spec.Namespaces
- Groups and secrets in paas.Spec.Namespaces are not managed

## What is the new behavior?

- We have unittests for groups and secrets in paas.Spec.Namespaces
- Groups and secrets in paas.Spec.Namespaces are managed

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

