### PR TITLE
fix: ArgoCD obsolete fields during conversion

### DIFF
--- a/api/v1alpha1/paas_conversion.go
+++ b/api/v1alpha1/paas_conversion.go
@@ -46,9 +46,15 @@ func (p *Paas) ConvertFrom(srcRaw conversion.Hub) error {
 
 	for name, capability := range src.Spec.Capabilities {
 		fields := capability.DeepCopy().CustomFields
+		gitUrl := fields[gitUrlKey]
+		gitRevision := fields[gitRevisionKey]
+		gitPath := fields[gitPathKey]
 
 		p.Spec.Capabilities[name] = PaasCapability{
 			Enabled:          true,
+			GitURL:           gitUrl,
+			GitRevision:      gitRevision,
+			GitPath:          gitPath,
 			CustomFields:     fields,
 			Quota:            capability.Quota,
 			SSHSecrets:       capability.Secrets,

--- a/api/v1alpha1/paas_conversion.go
+++ b/api/v1alpha1/paas_conversion.go
@@ -46,18 +46,9 @@ func (p *Paas) ConvertFrom(srcRaw conversion.Hub) error {
 
 	for name, capability := range src.Spec.Capabilities {
 		fields := capability.DeepCopy().CustomFields
-		gitUrl := fields[gitUrlKey]
-		gitRevision := fields[gitRevisionKey]
-		gitPath := fields[gitPathKey]
-		delete(fields, gitUrlKey)
-		delete(fields, gitRevisionKey)
-		delete(fields, gitPathKey)
 
 		p.Spec.Capabilities[name] = PaasCapability{
 			Enabled:          true,
-			GitURL:           gitUrl,
-			GitRevision:      gitRevision,
-			GitPath:          gitPath,
 			CustomFields:     fields,
 			Quota:            capability.Quota,
 			SSHSecrets:       capability.Secrets,

--- a/api/v1alpha1/paas_conversion_test.go
+++ b/api/v1alpha1/paas_conversion_test.go
@@ -139,8 +139,13 @@ func TestConvertTo(t *testing.T) {
 
 	err := dst.ConvertFrom(src)
 
+	expectedV1Alpha1 := exV1Alpha1.DeepCopy()
+	expectedFields := expectedV1Alpha1.Spec.Capabilities["argocd"].CustomFields
+	expectedFields["git_url"] = "ssh://git@example.com/some-repo.git"
+	expectedFields["git_revision"] = "main"
+	expectedFields["git_path"] = "."
 	assert.NoError(t, err)
-	assert.Equal(t, exV1Alpha1, dst)
+	assert.Equal(t, expectedV1Alpha1, dst)
 }
 
 // Test conversion FROM v1alpha1 TO v1alpha2

--- a/test/e2e/paas_conversion_test.go
+++ b/test/e2e/paas_conversion_test.go
@@ -100,6 +100,7 @@ func assertV2Created(ctx context.Context, t *testing.T, cfg *envconf.Config) con
 					CustomFields: map[string]string{
 						"git_url":      "ssh://git@scm/repo.git",
 						"git_revision": "main",
+						"git_path": ".",
 					},
 				},
 				"sso": {},

--- a/test/e2e/paas_conversion_test.go
+++ b/test/e2e/paas_conversion_test.go
@@ -100,7 +100,7 @@ func assertV2Created(ctx context.Context, t *testing.T, cfg *envconf.Config) con
 					CustomFields: map[string]string{
 						"git_url":      "ssh://git@scm/repo.git",
 						"git_revision": "main",
-						"git_path": ".",
+						"git_path":     ".",
 					},
 				},
 				"sso": {},

--- a/test/e2e/paas_conversion_test.go
+++ b/test/e2e/paas_conversion_test.go
@@ -130,9 +130,10 @@ func assertV1Conversion(ctx context.Context, t *testing.T, cfg *envconf.Config) 
 	require.NoError(t, cfg.Client().Resources().Get(ctx, paasv2Name, cfg.Namespace(), &paas))
 
 	assert.Len(t, paas.Spec.Capabilities, 3)
-	assert.Len(t, paas.Spec.Capabilities["argocd"].CustomFields, 0)
+	assert.Len(t, paas.Spec.Capabilities["argocd"].CustomFields, 3)
 	assert.Equal(t, "ssh://git@scm/repo.git", paas.Spec.Capabilities["argocd"].GitURL)
 	assert.Equal(t, "main", paas.Spec.Capabilities["argocd"].GitRevision)
+	assert.Equal(t, ".", paas.Spec.Capabilities["argocd"].GitPath)
 	assert.Equal(
 		t,
 		map[string]string{


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- When converting from v1alpha2 to v1alpha1, we remove custom fields and fill in in the obsolete fields instead

## What is the new behavior?

- When converting from v1alpha2 to v1alpha1, we leave custom fields and keep the obsolete fields empty

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

