### PR TITLE
fix: indent issue and default issue in docs/administrators-guide/go-templating.md

### DIFF
--- a/docs/administrators-guide/go-templating.md
+++ b/docs/administrators-guide/go-templating.md
@@ -36,7 +36,7 @@ Depending on the result of the Go Template, one of three things can happen:
 !!! Note
 
     If you need to return a map or list as a single string value in a field, you have the following options:
-    - convert the map to a string representation using toYaml or toJson, and add quoting to make sure it is parsed as one string 
+    - convert the map to a string representation using toYaml or toJson, and add quoting to make sure it is parsed as one string
     - create a map with one key/value pair and set the resulting string as the value
 
 ## Developing Go Templates
@@ -50,6 +50,7 @@ For easier validation and debugging of templates, we recommend using [Repeat It]
 Administrators can define labels to be added to resources managed by a Paas.
 The implementation is based on Go Templating, and has the Paas and Resource as inputs.
 This feature can be used to:
+
 - copy labels (or annotations) from the Paas, (or PaasConfig) to labels on the specific resource
 - use specific fields in the Paas (or PaasConfig) to define extra labels
 
@@ -72,7 +73,7 @@ This feature can be used to:
           "": '{{ range $key, $value := .Paas.Labels }}{{ if ne $key "app.kubernetes.io/instance" }}{{$key}}: {{$value}}\n{{end}}{{end}}'
         namespaceLabels:
           "": '{{ range $key, $value := .Paas.Labels }}{{ if ne $key "app.kubernetes.io/instance" }}{{$key}}: {{$value}}\n{{end}}{{end}}'
-					"argocd.argoproj.io/managed-by": "{{ .Paas.Spec.ManagedByPaas }}-argocd"
+          "argocd.argoproj.io/managed-by": "{{ .Paas.Spec.ManagedByPaas | default .Paas.Name }}-argocd"
         roleBindingLabels:
           "": '{{ range $key, $value := .Paas.Labels }}{{ if ne $key "app.kubernetes.io/instance" }}{{$key}}: {{$value}}\n{{end}}{{end}}'
     ```
@@ -81,7 +82,7 @@ This feature can be used to:
 
 ### Custom fields per capability
 
-The Paas operator allows administrator to define custom fields which can be set by requestors and end up as fields in the list generator 
+The Paas operator allows administrator to define custom fields which can be set by requestors and end up as fields in the list generator
 in the ApplicationSet that defines the Application for the capability for the Paas.
 
 For more info, see [api-guide on capability custom field configuration in the Paas](../administrators-guide/capabilities.md#configuring-custom-fields)
@@ -106,9 +107,9 @@ There are two main differences:
       ...
       templating:
         genericCapabilityFields:
-					requestor: "{{ .Paas.Spec.Requestor }}",
-					service: "{{ (splitn \"-\" 2 .Paas.Name)._0 }}",
-					subservice: "{{ (splitn \"-\" 2 .Paas.Name)._1 }}",
+          requestor: "{{ .Paas.Spec.Requestor }}",
+          service: "{{ (splitn \"-\" 2 .Paas.Name)._0 }}",
+          subservice: "{{ (splitn \"-\" 2 .Paas.Name)._1 }}",
     ```
 
 # Examples
@@ -166,7 +167,7 @@ This would return three key/value pairs. If name of the template would be set to
 
 ## Adding all labels, except for a specific key
 
-Ideally this could be done using the [omit dict function](https://masterminds.github.io/sprig/dicts.html), but unfortunately, 
+Ideally this could be done using the [omit dict function](https://masterminds.github.io/sprig/dicts.html), but unfortunately,
 the dict is implemented as map[string]any, and labels are implemented as `map[string]string` and go does not automatically convert.
 
 We have used a range and if statement to create all key/value pairs one by one.
@@ -179,3 +180,4 @@ This ensures that each key is placed on a separate line, and is thus correctly p
     {{ range $key, $value := .Paas.Labels }}{{ if ne $key "app.kubernetes.io/instance" }}{{$key}}: {{$value}}
     {{end}}{{end}}
     ```
+


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

docs has indedation issues and default issue for setting argocd.argoproj.io/managed-by

## What is the new behavior?

- docs fixed

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

