### PR TITLE
feat: disable paas group users in controller

### DIFF
--- a/internal/controller/groups.go
+++ b/internal/controller/groups.go
@@ -92,10 +92,16 @@ func (r *PaasReconciler) backendGroup(
 	paasGroupKey string,
 	group v1alpha2.PaasGroup,
 ) (*userv1.Group, error) {
+	block := config.GetConfig().Spec.FeatureFlags.GroupUserManagement == "block"
 	logger := log.Ctx(ctx)
 	logger.Debug().Msg("defining group")
 	// We don't manage groups with a query
 	if len(group.Query) != 0 {
+		return nil, nil
+	}
+
+	// Check if feature is enabled
+	if block && len(group.Users) > 0 {
 		return nil, nil
 	}
 
@@ -136,7 +142,7 @@ func (r *PaasReconciler) backendGroups(
 			return nil, err
 		}
 		if beGroup == nil {
-			continue // Skip Query groups
+			continue // Skip nil groups
 		}
 		groups = append(groups, beGroup)
 	}

--- a/internal/controller/groups_test.go
+++ b/internal/controller/groups_test.go
@@ -8,6 +8,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v3/internal/config"
@@ -35,23 +36,6 @@ var _ = Describe("Group controller", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		// Set the PaasConfig so reconcilers know where to find our fixtures
-		myConfig = genericConfig.DeepCopy()
-		myConfig.Spec.Templating.GroupLabels = v1alpha2.ConfigTemplatingItem{
-			//revive:disable-next-line
-			"": "{{ range $key, $value := .Paas.Labels }}{{ if ne $key \"" + kubeInstLabel + "\" }}{{$key}}: {{$value}}\n{{end}}{{end}}",
-		}
-		config.SetConfig(*myConfig)
-
-		paas = &v1alpha2.Paas{ObjectMeta: metav1.ObjectMeta{
-			Name: "my-paas",
-			UID:  "abc", // Needed or owner references fail
-			Labels: map[string]string{
-				lbl1Key:       lbl1Value,
-				lbl2Key:       lbl2Value,
-				kubeInstLabel: "whatever",
-			},
-		}}
 	})
 
 	BeforeEach(func() {
@@ -66,80 +50,133 @@ var _ = Describe("Group controller", Ordered, func() {
 				Name: "test-group",
 			},
 		}
+		// Set the PaasConfig so reconcilers know where to find our fixtures
+		myConfig = genericConfig.DeepCopy()
+		myConfig.Spec.Templating.GroupLabels = v1alpha2.ConfigTemplatingItem{
+			"": "{{ range $key, $value := .Paas.Labels }}{{ if ne $key \"" +
+				kubeInstLabel + "\" }}{{$key}}: {{$value}}\n{{end}}{{end}}",
+		}
+		config.SetConfig(*myConfig)
 	})
 
 	AfterEach(func() {
 		_ = k8sClient.Delete(ctx, group)
 	})
 
-	It("should create the group if it does not exist", func() {
-		group.Users = []string{"hank", "pete"}
-		err := reconciler.ensureGroup(ctx, paas, group)
-		Expect(err).NotTo(HaveOccurred())
-
-		found := &userv1.Group{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: group.Name}, found)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(found.Users).To(Equal(group.Users))
-	})
-
-	It("should update the group if users list changes", func() {
-		// Create the group first
-		err := k8sClient.Create(ctx, group)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Modify users
-		group.Users = []string{"user1", "user2"}
-
-		err = reconciler.ensureGroup(ctx, paas, group)
-		Expect(err).NotTo(HaveOccurred())
-
-		updated := &userv1.Group{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: group.Name}, updated)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(updated.Users).To(Equal(group.Users))
-	})
-
-	It("should set the owner reference if not already set", func() {
-		// Create group without owner reference
-		err := k8sClient.Create(ctx, group)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(group.OwnerReferences).To(BeEmpty())
-
-		err = reconciler.ensureGroup(ctx, paas, group)
-		Expect(err).NotTo(HaveOccurred())
-
-		updated := &userv1.Group{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: group.Name}, updated)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(updated.OwnerReferences).NotTo(BeEmpty())
-		Expect(updated.OwnerReferences[0].UID).To(Equal(paas.UID))
-	})
-
-	It("have set all expected labels", func() {
-		var (
-			expectedLabels = map[string]string{
-				lbl1Key:           lbl1Value,
-				lbl2Key:           lbl2Value,
-				ManagedByLabelKey: paas.Name,
-			}
-		)
-		paas.Spec.Groups = v1alpha2.PaasGroups{
-			group.Name: v1alpha2.PaasGroup{Users: []string{"u1", "u2"}},
-		}
-		err := reconciler.reconcileGroups(ctx, paas)
-		Expect(err).NotTo(HaveOccurred())
-		groups, err := reconciler.backendGroups(ctx, paas)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(groups).To(HaveLen(1))
-
-		for _, group := range groups {
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: group.Name}, group)
+	Context("When creating a paas with users", func() {
+		paas = &v1alpha2.Paas{ObjectMeta: metav1.ObjectMeta{
+			Name: "my-paas",
+			UID:  "abc", // Needed or owner references fail
+			Labels: map[string]string{
+				lbl1Key:       lbl1Value,
+				lbl2Key:       lbl2Value,
+				kubeInstLabel: "whatever",
+			},
+		}}
+		It("should create the group if it does not exist", func() {
+			group.Users = []string{"hank", "pete"}
+			err := reconciler.ensureGroup(ctx, paas, group)
 			Expect(err).NotTo(HaveOccurred())
-			for key, value := range expectedLabels {
-				Expect(group.ObjectMeta.Labels).To(HaveKeyWithValue(key, value))
+
+			found := &userv1.Group{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: group.Name}, found)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found.Users).To(Equal(group.Users))
+		})
+
+		It("should update the group if users list changes", func() {
+			// Create the group first
+			err := k8sClient.Create(ctx, group)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Modify users
+			group.Users = []string{"user1", "user2"}
+
+			err = reconciler.ensureGroup(ctx, paas, group)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &userv1.Group{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: group.Name}, updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Users).To(Equal(group.Users))
+		})
+
+		It("should set the owner reference if not already set", func() {
+			// Create group without owner reference
+			err := k8sClient.Create(ctx, group)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(group.OwnerReferences).To(BeEmpty())
+
+			err = reconciler.ensureGroup(ctx, paas, group)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &userv1.Group{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: group.Name}, updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.OwnerReferences).NotTo(BeEmpty())
+			Expect(updated.OwnerReferences[0].UID).To(Equal(paas.UID))
+		})
+
+		It("have set all expected labels", func() {
+			var (
+				expectedLabels = map[string]string{
+					lbl1Key:           lbl1Value,
+					lbl2Key:           lbl2Value,
+					ManagedByLabelKey: paas.Name,
+				}
+			)
+			paas.Spec.Groups = v1alpha2.PaasGroups{
+				group.Name: v1alpha2.PaasGroup{Users: []string{"u1", "u2"}},
 			}
-			Expect(group.ObjectMeta.Labels).NotTo(HaveKey(kubeInstLabel))
-		}
+			err := reconciler.reconcileGroups(ctx, paas)
+			Expect(err).NotTo(HaveOccurred())
+			groups, err := reconciler.backendGroups(ctx, paas)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(groups).To(HaveLen(1))
+
+			for _, group := range groups {
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: group.Name}, group)
+				Expect(err).NotTo(HaveOccurred())
+				for key, value := range expectedLabels {
+					Expect(group.ObjectMeta.Labels).To(HaveKeyWithValue(key, value))
+				}
+				Expect(group.ObjectMeta.Labels).NotTo(HaveKey(kubeInstLabel))
+			}
+		})
+	})
+	Context("When using feature flags", func() {
+		It("should allow, warn or succeed when groups have users", func() {
+			for setting, expects := range map[string]struct {
+				groups bool
+			}{
+				"":      {groups: true},
+				"allow": {groups: true},
+				"warn":  {groups: true},
+				"block": {},
+			} {
+				paas = &v1alpha2.Paas{ObjectMeta: metav1.ObjectMeta{
+					Name: "my-paas",
+					UID:  "abc", // Needed or owner references fail
+				},
+					Spec: v1alpha2.PaasSpec{
+						Groups: v1alpha2.PaasGroups{
+							"some_group": v1alpha2.PaasGroup{
+								Users: []string{"usr1", "usr2"},
+							},
+						},
+					},
+				}
+				fmt.Fprintf(GinkgoWriter, "DEBUG - Test: %s: %v", setting, expects)
+				myConfig.Spec.FeatureFlags.GroupUserManagement = setting
+				config.SetConfig(*myConfig)
+				groups, err := reconciler.backendGroups(ctx, paas)
+				Expect(err).NotTo(HaveOccurred())
+				if expects.groups {
+					Expect(groups).NotTo(BeEmpty())
+				} else {
+					Expect(groups).To(BeEmpty())
+				}
+			}
+		})
 	})
 })

--- a/internal/controller/groups_test.go
+++ b/internal/controller/groups_test.go
@@ -35,9 +35,6 @@ var _ = Describe("Group controller", Ordered, func() {
 		reconciler *PaasReconciler
 	)
 
-	BeforeAll(func() {
-	})
-
 	BeforeEach(func() {
 		ctx = context.Background()
 		reconciler = &PaasReconciler{


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There is a feature flag to disable groups with users, but it is only blocked in the webhook

## What is the new behavior?

- There is a feature flag to disable groups with users
- it is blocked in the webhook and controller
- when set to `block`, controller will remove groups managed by Paas
- when set to `warn`, controller will add warnings to log and Paas.Status

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

