### PR TITLE
ci: Fixes Kroki docs deploy by using Post method

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,8 @@ plugins:
   - social
   - tags
   - privacy
-  - kroki
+  - kroki:
+      HttpMethod: POST
   - literate-nav:
       nav_file: README.md
       implicit_index: true


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Error during mkDocs build:

Error reading page 'overview/core_concepts/secrets.md': [Errno 36] File name too long: '/home/r...../opr-paas/.cache/plugin/privacy/assets/external/kroki.io/blockdiag/svg/........svg

## What is the new behavior?

Using POST as Kroki httpMethod to store image relative to source

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Based solution on this https://pypi.org/project/mkdocs-kroki-plugin/
https://github.com/asciidoctor/asciidoctor-kroki/issues/375
