### PR TITLE
feat: Optional list generator implementation

### DIFF
--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -100,11 +100,12 @@ type PaasConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	ArgoEnabled bool `json:"argoenabled"`
 
-	// Namespace in which a clusterwide ArgoCD can be found for managing capabilities and appProjects
+	// Namespace in which a clusterwide ArgoCD can be found for managing capabilities
+	// If not set, AppSets list generator will not be managed by the operator
+	//
 	// Deprecated: ArgoCD specific code will be removed from the operator
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Required
-	ClusterWideArgoCDNamespace string `json:"clusterwide_argocd_namespace"`
+	// +kubebuilder:validation:Optional
+	ClusterWideArgoCDNamespace string `json:"clusterwide_argocd_namespace,omitempty"`
 
 	// Label which is added to clusterquotas
 	// +kubebuilder:default:=clusterquotagroup

--- a/api/v1alpha2/paasconfig_types.go
+++ b/api/v1alpha2/paasconfig_types.go
@@ -10,7 +10,7 @@ See LICENSE.md for details.
 package v1alpha2
 
 import (
-	"fmt"
+	"errors"
 	"reflect"
 
 	"github.com/belastingdienst/opr-paas/v3/api"
@@ -75,11 +75,12 @@ type PaasConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	Capabilities ConfigCapabilities `json:"capabilities"`
 
-	// Namespace in which a clusterwide ArgoCD can be found for managing capabilities and appProjects
-	// Deprecated: one must use the ArgoCD plugin generator instead
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Required
-	ClusterWideArgoCDNamespace string `json:"clusterwide_argocd_namespace"`
+	// Namespace in which a clusterwide ArgoCD can be found for managing capabilities
+	// If not set, AppSets list generator will not be managed by the operator
+	//
+	// Deprecated: ArgoCD specific code will be removed from the operator
+	// +kubebuilder:validation:Optional
+	ClusterWideArgoCDNamespace string `json:"clusterwide_argocd_namespace,omitempty"`
 
 	// Label which is added to clusterquotas
 	// +kubebuilder:default:=clusterquotagroup
@@ -161,9 +162,10 @@ type ConfigCapabilities map[string]ConfigCapability
 
 type ConfigCapability struct {
 	// Name of the ArgoCD ApplicationSet which manages this capability
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Required
-	AppSet string `json:"applicationset"`
+	// The AppSet is only managed when `clusterwide_argocd_namespace` is set as well.
+	// If not set, AppSets list generator will not be managed by the operator
+	// +kubebuilder:validation:Optional
+	AppSet string `json:"applicationset,omitempty"`
 
 	// Quota settings for this capability
 	// +kubebuilder:validation:Required
@@ -307,15 +309,24 @@ func (ccp ConfigCapPerm) ServiceAccounts() []string {
 
 // TODO(hikarukin): we probably need to properly determine the namespace name,
 // depends on argocd code removal
-func (pcs PaasConfigSpec) CapabilityK8sName(capName string) (as types.NamespacedName) {
-	if capability, exists := pcs.Capabilities[capName]; exists {
-		as.Name = capability.AppSet
-	} else {
-		as.Name = fmt.Sprintf("paas-%s", capName)
+func (pcs PaasConfigSpec) CapabilityK8sName(capName string) (types.NamespacedName, error) {
+	if pcs.ClusterWideArgoCDNamespace == "" {
+		return types.NamespacedName{}, errors.New("clusterWide ArgoCD Namespace not set")
 	}
-	as.Namespace = pcs.ClusterWideArgoCDNamespace
 
-	return as
+	capability, exists := pcs.Capabilities[capName]
+	if !exists {
+		return types.NamespacedName{}, errors.New("capability not configured")
+	}
+
+	if capability.AppSet == "" {
+		return types.NamespacedName{}, errors.New("capability AppSet not set")
+	}
+
+	return types.NamespacedName{
+		Name:      capability.AppSet,
+		Namespace: pcs.ClusterWideArgoCDNamespace,
+	}, nil
 }
 
 // revive:disable:line-length-limit

--- a/internal/controller/capabilities.go
+++ b/internal/controller/capabilities.go
@@ -52,15 +52,13 @@ func (r *PaasReconciler) ensureAppSetCaps(
 	paas *v1alpha2.Paas,
 ) error {
 	paasConfigSpec := config.GetConfig().Spec
-	if paasConfigSpec.ClusterWideArgoCDNamespace != "" {
-		for capName := range paas.Spec.Capabilities {
-			if _, exists := paasConfigSpec.Capabilities[capName]; !exists {
-				return errors.New("capability not configured")
-			}
+	for capName := range paas.Spec.Capabilities {
+		if _, exists := paasConfigSpec.Capabilities[capName]; !exists {
+			return errors.New("capability not configured")
+		}
 
-			if err := r.ensureAppSetCap(ctx, paas, capName); err != nil {
-				return err
-			}
+		if err := r.ensureAppSetCap(ctx, paas, capName); err != nil {
+			return err
 		}
 	}
 

--- a/internal/controller/capabilities.go
+++ b/internal/controller/capabilities.go
@@ -120,8 +120,8 @@ func (r *PaasReconciler) ensureAppSetCap(
 			return err
 		}
 
-		elements, err := capElementsFromPaas(paas, capName)
-		if err != nil {
+		elements, err2 := capElementsFromPaas(paas, capName)
+		if err2 != nil {
 			return err
 		}
 		patch := client.MergeFrom(appSet.DeepCopy())
@@ -140,8 +140,8 @@ func (r *PaasReconciler) ensureAppSetCap(
 			entry := elements
 			entries[entry.Key()] = entry
 		}
-		jsonentries, err := entries.AsJSON()
-		if err != nil {
+		jsonentries, err3 := entries.AsJSON()
+		if err3 != nil {
 			return err
 		}
 		listGen.List.Elements = jsonentries

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
@@ -180,9 +180,10 @@ spec:
                 type: object
               clusterwide_argocd_namespace:
                 description: |-
-                  Namespace in which a clusterwide ArgoCD can be found for managing capabilities and appProjects
+                  Namespace in which a clusterwide ArgoCD can be found for managing capabilities
+                  If not set, AppSets list generator will not be managed by the operator
+
                   Deprecated: ArgoCD specific code will be removed from the operator
-                minLength: 1
                 type: string
               debug:
                 default: false
@@ -285,7 +286,6 @@ spec:
                   the fields
                 type: object
             required:
-            - clusterwide_argocd_namespace
             - decryptKeySecret
             - groupsynclist
             type: object
@@ -381,9 +381,10 @@ spec:
                 additionalProperties:
                   properties:
                     applicationset:
-                      description: Name of the ArgoCD ApplicationSet which manages
-                        this capability
-                      minLength: 1
+                      description: |-
+                        Name of the ArgoCD ApplicationSet which manages this capability
+                        The AppSet is only managed when `clusterwide_argocd_namespace` is set as well.
+                        If not set, AppSets list generator will not be managed by the operator
                       type: string
                     custom_fields:
                       additionalProperties:
@@ -472,16 +473,16 @@ spec:
                       - defaults
                       type: object
                   required:
-                  - applicationset
                   - quotas
                   type: object
                 description: A map with zero or more ConfigCapability
                 type: object
               clusterwide_argocd_namespace:
                 description: |-
-                  Namespace in which a clusterwide ArgoCD can be found for managing capabilities and appProjects
-                  Deprecated: one must use the ArgoCD plugin generator instead
-                minLength: 1
+                  Namespace in which a clusterwide ArgoCD can be found for managing capabilities
+                  If not set, AppSets list generator will not be managed by the operator
+
+                  Deprecated: ArgoCD specific code will be removed from the operator
                 type: string
               debug:
                 default: false
@@ -586,7 +587,6 @@ spec:
                   the fields
                 type: object
             required:
-            - clusterwide_argocd_namespace
             - decryptKeySecret
             type: object
           status:

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
@@ -385,6 +385,7 @@ spec:
                         Name of the ArgoCD ApplicationSet which manages this capability
                         The AppSet is only managed when `clusterwide_argocd_namespace` is set as well.
                         If not set, AppSets list generator will not be managed by the operator
+                        Deprecated: will be replaced by ArgoCD plugin generator
                       type: string
                     custom_fields:
                       additionalProperties:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

List generator management is baked hardcoded into the operator. Therefore, one is required to configure ClusterWide ArgoCD namespace & appSets per capability.

## What is the new behavior?

Makes both config optional. Only manage list generators in AppSets when both ClusterWideArgoCDNamespace and AppSet are configured in `PaasConfig`. This paves the way to migrate to the Plugingenerator as implemented in #696 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->