### PR TITLE
feat: Reconcile on changes to managed resources

### DIFF
--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -14,7 +14,7 @@ import (
 
 	quotav1 "github.com/openshift/api/quota/v1"
 	userv1 "github.com/openshift/api/user/v1"
-	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -14,7 +14,7 @@ import (
 
 	quotav1 "github.com/openshift/api/quota/v1"
 	userv1 "github.com/openshift/api/user/v1"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -14,7 +14,7 @@ import (
 
 	quotav1 "github.com/openshift/api/quota/v1"
 	userv1 "github.com/openshift/api/user/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
@@ -350,8 +350,8 @@ func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&userv1.Group{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.Namespace{}).
-		Owns(&v1.RoleBinding{}).
-		Owns(&v1.ClusterRoleBinding{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		// TODO(portly-halicore-76):We don't own PaasNS objects correctly yet
 		// Owns(&v1alpha2.PaasNS{}).
 		// TODO(portly-halicore-76): We don't own Rolebinding objects correctly yet

--- a/internal/controller/paas_controller.go
+++ b/internal/controller/paas_controller.go
@@ -12,6 +12,9 @@ import (
 	"fmt"
 	"strings"
 
+	quotav1 "github.com/openshift/api/quota/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
@@ -342,7 +345,17 @@ func (r *PaasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				// Labels updated
 				predicate.LabelChangedPredicate{},
 			))).
-		Owns(&v1alpha2.PaasNS{}).
+		// Reconcile on owned resources changes
+		Owns(&quotav1.ClusterResourceQuota{}).
+		Owns(&userv1.Group{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Namespace{}).
+		Owns(&v1.RoleBinding{}).
+		Owns(&v1.ClusterRoleBinding{}).
+		// TODO(portly-halicore-76):We don't own PaasNS objects correctly yet
+		// Owns(&v1alpha2.PaasNS{}).
+		// TODO(portly-halicore-76): We don't own Rolebinding objects correctly yet
+		// Owns(&rbac.RoleBinding{}).
 		Watches(
 			&v1alpha2.PaasNS{},
 			handler.EnqueueRequestsFromMapFunc(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When owned objects are modified externally, no reconciliation will be triggered. For example if a user deletes a namespaces, which is created by Paas, it will not be recreated before the next reconcilation of the Paas resources.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

By adding: `Owns` reconciliation is triggered when managed resources are modified.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->