### PR TITLE
test: Migrating e2e from v1alpha1 to v1alpha2

### DIFF
--- a/test/e2e/capability-tekton_test.go
+++ b/test/e2e/capability-tekton_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
+	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 	argo "github.com/belastingdienst/opr-paas/v3/internal/stubs/argoproj/v1alpha1"
 	"github.com/belastingdienst/opr-paas/v3/pkg/quota"
 
@@ -32,9 +32,7 @@ func TestCapabilityTekton(t *testing.T) {
 		Requestor: "paas-user",
 		Quota:     make(quota.Quota),
 		Capabilities: api.PaasCapabilities{
-			tektonCapName: api.PaasCapability{
-				Enabled: true,
-			},
+			tektonCapName: api.PaasCapability{},
 		},
 	}
 
@@ -67,7 +65,7 @@ func assertCapTektonCreated(ctx context.Context, t *testing.T, cfg *envconf.Conf
 	assert.Equal(t, paasWithCapabilityTekton, paas.Name)
 
 	// Tekton should be enabled
-	assert.True(t, paas.Spec.Capabilities.IsCap(tektonCapName))
+	assert.Contains(t, paas.Spec.Capabilities, tektonCapName)
 
 	// ApplicationSet exist
 	assert.NotEmpty(t, applicationSet)

--- a/test/e2e/capability_argocd_test.go
+++ b/test/e2e/capability_argocd_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
+	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 	argo "github.com/belastingdienst/opr-paas/v3/internal/stubs/argoproj/v1alpha1"
 	"github.com/belastingdienst/opr-paas/v3/pkg/quota"
 
@@ -38,12 +38,11 @@ func TestCapabilityArgoCD(t *testing.T) {
 		Capabilities: api.PaasCapabilities{
 			argoCapName: api.PaasCapability{
 				CustomFields: map[string]string{
+					"git_path":     paasArgoGitPath,
 					"git_revision": paasArgoGitRevision,
+					"git_url":      paasArgoGitURL,
 				},
-				Enabled:          true,
-				SSHSecrets:       map[string]string{paasArgoGitURL: paasArgoSecret},
-				GitURL:           paasArgoGitURL,
-				GitPath:          paasArgoGitPath,
+				Secrets:          map[string]string{paasArgoGitURL: paasArgoSecret},
 				ExtraPermissions: true,
 			},
 		},
@@ -117,12 +116,13 @@ func assertArgoCapUpdated(ctx context.Context, t *testing.T, cfg *envconf.Config
 	paas := getPaas(ctx, paasWithArgo, t, cfg)
 	paas.Spec.Capabilities = api.PaasCapabilities{
 		argoCapName: api.PaasCapability{
-			Enabled:          true,
-			SSHSecrets:       map[string]string{paasArgoGitURL: paasArgoSecret},
-			GitURL:           paasArgoGitURL,
-			GitPath:          paasArgoGitPath,
-			GitRevision:      updatedRevision,
+			Secrets:          map[string]string{paasArgoGitURL: paasArgoSecret},
 			ExtraPermissions: true,
+			CustomFields: map[string]string{
+				"git_path":     paasArgoGitPath,
+				"git_revision": updatedRevision,
+				"git_url":      paasArgoGitURL,
+			},
 		},
 	}
 	paas.Spec.Groups = api.PaasGroups{

--- a/test/e2e/capability_cap5_test.go
+++ b/test/e2e/capability_cap5_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
+	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 	argo "github.com/belastingdienst/opr-paas/v3/internal/stubs/argoproj/v1alpha1"
 	"github.com/belastingdienst/opr-paas/v3/pkg/quota"
 
@@ -28,7 +28,7 @@ func TestCapabilityCap5(t *testing.T) {
 		Requestor: "paas-user",
 		Quota:     make(quota.Quota),
 		Capabilities: api.PaasCapabilities{
-			"cap5": api.PaasCapability{Enabled: true},
+			"cap5": api.PaasCapability{},
 		},
 	}
 
@@ -56,7 +56,7 @@ func assertCap5Created(ctx context.Context, t *testing.T, cfg *envconf.Config) c
 	assert.Equal(t, paasCap5Ns, namespace.Name)
 
 	// cap5 should be enabled
-	assert.True(t, paas.Spec.Capabilities.IsCap("cap5"))
+	assert.Contains(t, paas.Spec.Capabilities, "cap5")
 
 	// ApplicationSet exist
 	assert.NotEmpty(t, applicationSet)

--- a/test/e2e/capability_sso_test.go
+++ b/test/e2e/capability_sso_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
+	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 	argo "github.com/belastingdienst/opr-paas/v3/internal/stubs/argoproj/v1alpha1"
 	"github.com/belastingdienst/opr-paas/v3/pkg/quota"
 
@@ -29,7 +29,7 @@ func TestCapabilitySSO(t *testing.T) {
 		Requestor: "paas-user",
 		Quota:     make(quota.Quota),
 		Capabilities: api.PaasCapabilities{
-			"sso": api.PaasCapability{Enabled: true},
+			"sso": api.PaasCapability{},
 		},
 	}
 
@@ -57,7 +57,7 @@ func assertCapSSOCreated(ctx context.Context, t *testing.T, cfg *envconf.Config)
 	assert.Equal(t, paasSSO, namespace.Name)
 
 	// SSO should be enabled
-	assert.True(t, paas.Spec.Capabilities.IsCap("sso"))
+	assert.Contains(t, paas.Spec.Capabilities, "sso")
 
 	// ApplicationSet exist
 	assert.NotEmpty(t, applicationSet)

--- a/test/e2e/clusterresourcequota_test.go
+++ b/test/e2e/clusterresourcequota_test.go
@@ -6,7 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
+	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 	quotav1 "github.com/openshift/api/quota/v1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/test/e2e/groupquery_test.go
+++ b/test/e2e/groupquery_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
+	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v3/pkg/quota"
 
 	userv1 "github.com/openshift/api/user/v1"
@@ -27,7 +27,7 @@ const (
 func TestGroupQuery(t *testing.T) {
 	paasSpec := api.PaasSpec{
 		Requestor:  "paas-user",
-		Namespaces: []string{paasGroupQueryNamespace},
+		Namespaces: api.PaasNamespaces{paasGroupQueryNamespace: api.PaasNamespace{}},
 		Quota:      make(quota.Quota),
 		Groups:     api.PaasGroups{groupWithQueryName: api.PaasGroup{Query: groupQuery}},
 	}

--- a/test/e2e/groupusers_test.go
+++ b/test/e2e/groupusers_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
+	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v3/internal/controller"
 	"github.com/belastingdienst/opr-paas/v3/pkg/quota"
 
@@ -29,7 +29,7 @@ func TestGroupUsers(t *testing.T) {
 	groups := api.PaasGroups{groupKey: api.PaasGroup{Users: []string{"foo"}}}
 	paasSpec := api.PaasSpec{
 		Requestor:  paasRequestor,
-		Namespaces: []string{paasNamespace},
+		Namespaces: api.PaasNamespaces{paasNamespace: api.PaasNamespace{}},
 		Quota:      make(quota.Quota),
 		Groups:     groups,
 	}

--- a/test/e2e/paas.go
+++ b/test/e2e/paas.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
+	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"

--- a/test/e2e/steps.go
+++ b/test/e2e/steps.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
+	api "github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- All e2e tests are based on v1alpha1
- e2e action gives a lot of warnings

## What is the new behavior?

- e2e test for conversion is based on v1alpha1
- all other e2e tests are based on v1alpha2
- e2e test only gives v1alpha1 warning on conversion tests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Some conversion tests relied on v1alpha1 methods.
  They have been rewritten as functions in test/e2e/paas_conversion_test.go
- One function to easilly create a Paas is rewritten to v1alpha2 and reimplemented for v1alpha1 in test/e2e/paas_conversion_test.go
