### PR TITLE
fix: Fixing logging implementation

### DIFF
--- a/api/v1alpha1/paasconfig_conversion.go
+++ b/api/v1alpha1/paasconfig_conversion.go
@@ -57,6 +57,7 @@ func (pc *PaasConfig) ConvertFrom(srcRaw conversion.Hub) error {
 	spec.ExcludeAppSetName = ""
 	spec.RoleMappings = convertFromRoleMappings(src.Spec.RoleMappings)
 	spec.Validations = convertFromValidations(src.Spec.Validations)
+	spec.ComponentsDebug = src.Spec.ComponentsDebug
 
 	return nil
 }
@@ -182,6 +183,7 @@ func (pc *PaasConfig) ConvertTo(dstRaw conversion.Hub) error {
 	spec.ManagedBySuffix = pc.Spec.ManagedBySuffix
 	spec.RoleMappings = ConfigRoleMappings{}.convertTo(pc.Spec.RoleMappings)
 	spec.Validations = PaasConfigValidations{}.convertTo(pc.Spec.Validations)
+	spec.ComponentsDebug = pc.Spec.ComponentsDebug
 
 	return nil
 }

--- a/api/v1alpha1/paasconfig_conversion_test.go
+++ b/api/v1alpha1/paasconfig_conversion_test.go
@@ -23,6 +23,10 @@ var paasconfigExV1Alpha1 = &PaasConfig{
 	},
 	Spec: PaasConfigSpec{
 		Debug: true,
+		ComponentsDebug: map[string]bool{
+			"component1": true,
+			"component2": false,
+		},
 		Capabilities: map[string]ConfigCapability{
 			"example": {
 				AppSet: "set",
@@ -78,6 +82,10 @@ var paasconfigExV1Alpha2 = &v1alpha2.PaasConfig{
 	},
 	Spec: v1alpha2.PaasConfigSpec{
 		Debug: true,
+		ComponentsDebug: map[string]bool{
+			"component1": true,
+			"component2": false,
+		},
 		Capabilities: map[string]v1alpha2.ConfigCapability{
 			"example": {
 				AppSet: "set",

--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -69,6 +69,10 @@ type PaasConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	Debug bool `json:"debug"`
 
+	// Switch component debugging on or of for a specific component
+	// +kubebuilder:validation:Optional
+	ComponentsDebug map[string]bool `json:"components_debug"`
+
 	// A map with zero or more ConfigCapability
 	// +kubebuilder:validation:Optional
 	Capabilities ConfigCapabilities `json:"capabilities"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -403,6 +403,13 @@ func (in *PaasConfigList) DeepCopyObject() runtime.Object {
 func (in *PaasConfigSpec) DeepCopyInto(out *PaasConfigSpec) {
 	*out = *in
 	out.DecryptKeysSecret = in.DecryptKeysSecret
+	if in.ComponentsDebug != nil {
+		in, out := &in.ComponentsDebug, &out.ComponentsDebug
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Capabilities != nil {
 		in, out := &in.Capabilities, &out.Capabilities
 		*out = make(ConfigCapabilities, len(*in))

--- a/api/v1alpha2/paasconfig_types.go
+++ b/api/v1alpha2/paasconfig_types.go
@@ -69,6 +69,10 @@ type PaasConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	Debug bool `json:"debug"`
 
+	// Switch component debugging on or of for a specific component
+	// +kubebuilder:validation:Optional
+	ComponentsDebug map[string]bool `json:"components_debug"`
+
 	// A map with zero or more ConfigCapability
 	// +kubebuilder:validation:Optional
 	Capabilities ConfigCapabilities `json:"capabilities"`

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -473,6 +473,13 @@ func (in *PaasConfigList) DeepCopyObject() runtime.Object {
 func (in *PaasConfigSpec) DeepCopyInto(out *PaasConfigSpec) {
 	*out = *in
 	out.DecryptKeysSecret = in.DecryptKeysSecret
+	if in.ComponentsDebug != nil {
+		in, out := &in.ComponentsDebug, &out.ComponentsDebug
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Capabilities != nil {
 		in, out := &in.Capabilities, &out.Capabilities
 		*out = make(ConfigCapabilities, len(*in))

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -157,17 +157,8 @@ func configureLogging(pretty bool, debug bool, componentDebugList string, splitL
 	log.Logger = log.Output(output)
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
-	if debug {
-		if componentDebugList != "" {
-			log.Fatal().Msg("cannot pass --debug and --component-debug simultaneously")
-		}
-	} else if componentDebugList != "" {
-		logging.SetComponentDebug(strings.Split(componentDebugList, ","))
-		log.Logger = log.Level(zerolog.InfoLevel)
-	} else {
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	}
-
+	logging.SetStaticLoggingConfig(debug, strings.Split(componentDebugList, ","))
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	ctrl.SetLogger(zerologr.New(&log.Logger))
 }
 

--- a/internal/config/paas_config_store.go
+++ b/internal/config/paas_config_store.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
 	"github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
+	"github.com/belastingdienst/opr-paas/v3/internal/logging"
 )
 
 // PaasConfigStore is a thread-safe store for the current PaasConfig
@@ -47,12 +48,14 @@ func SetConfig(cfg v1alpha2.PaasConfig) {
 	cnf.mutex.Lock()
 	defer cnf.mutex.Unlock()
 	cnf.store = cfg
+	logging.SetDynamicLoggingConfig(cfg.Spec.Debug, cfg.Spec.ComponentsDebug)
 }
 
 // SetConfigV1 updates the current configuration using a v1alpha1.PaasConfig as input
 func SetConfigV1(cfg v1alpha1.PaasConfig) error {
 	cnf.mutex.Lock()
 	defer cnf.mutex.Unlock()
+	defer logging.SetDynamicLoggingConfig(cfg.Spec.Debug, cfg.Spec.ComponentsDebug)
 
 	return cfg.ConvertTo(&cnf.store)
 	// return (&cnf.store).ConvertFrom(&cfg)

--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -8,6 +8,7 @@ package logging
 
 import (
 	"context"
+	"maps"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
@@ -18,7 +19,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-var debugComponents map[string]bool
+var (
+	// Commandline args will use this to enable all debug logging
+	staticDebug bool
+	// Commandline args can use this to enable logging for a component
+	staticComponents map[string]bool
+	// PaasConfig can set this to enable all debug logging
+	hotDebug bool
+	// PaasConfig can use this to enable logging for a component
+	allComponents map[string]bool
+)
 
 // SetControllerLogger derives a context with a `zerolog` logger configured for a specific controller.
 // To be called once per reconciler.
@@ -63,18 +73,21 @@ func SetWebhookLogger(ctx context.Context, obj client.Object) (context.Context, 
 	return logger.WithContext(ctx), &logger
 }
 
-// ResetComponentDebug can be used to reset the map of Components that have debugging enabled
-func ResetComponentDebug() {
-	debugComponents = make(map[string]bool)
+// SetStaticLoggingConfig configures which components will log debug messages regardless of global log level.
+func SetStaticLoggingConfig(debug bool, components []string) {
+	staticDebug = debug
+	staticComponents = map[string]bool{}
+	for _, component := range components {
+		staticComponents[component] = true
+	}
 }
 
-// SetComponentDebug configures which components will log debug messages regardless of global log level.
-func SetComponentDebug(components []string) {
-	if debugComponents == nil {
-		ResetComponentDebug()
-	}
-	for _, component := range components {
-		debugComponents[component] = true
+// SetHotLoggingConfig configures which components will log debug messages regardless of global log level.
+func SetHotLoggingConfig(debug bool, components map[string]bool) {
+	hotDebug = debug
+	allComponents = maps.Clone(staticComponents)
+	for component, state := range components {
+		allComponents[component] = state
 	}
 }
 
@@ -83,7 +96,7 @@ func GetLogComponent(ctx context.Context, name string) (context.Context, *zerolo
 	logger := log.Ctx(ctx)
 	level := zerolog.InfoLevel
 
-	if _, enabled := debugComponents[name]; enabled {
+	if enabled := allComponents[name]; enabled || staticDebug || hotDebug {
 		level = zerolog.DebugLevel
 	}
 	if logger.GetLevel() != level {

--- a/internal/logging/main_test.go
+++ b/internal/logging/main_test.go
@@ -12,8 +12,6 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/belastingdienst/opr-paas/v3/api/v1alpha1"
-	"github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
-	"github.com/belastingdienst/opr-paas/v3/internal/config"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -112,7 +110,7 @@ func TestSetWebhookLogger(t *testing.T) {
 
 func TestDebuggingStatic(t *testing.T) {
 	const comp1 = "component1"
-	config.SetConfig(v1alpha2.PaasConfig{Spec: v1alpha2.PaasConfigSpec{}})
+	SetDynamicLoggingConfig(false, nil)
 	ctx := context.TODO()
 	// debug false
 	SetStaticLoggingConfig(false, nil)
@@ -133,26 +131,21 @@ func TestDebuggingConfig(t *testing.T) {
 	SetStaticLoggingConfig(false, nil)
 	ctx := context.TODO()
 	// debug false
-	config.SetConfig(v1alpha2.PaasConfig{Spec: v1alpha2.PaasConfigSpec{}})
+	SetDynamicLoggingConfig(false, nil)
 	_, noDebugLogger := GetLogComponent(ctx, comp1)
 	assert.Equal(t, zerolog.InfoLevel, noDebugLogger.GetLevel())
 	// debug true
-	config.SetConfig(v1alpha2.PaasConfig{Spec: v1alpha2.PaasConfigSpec{Debug: true}})
+	SetDynamicLoggingConfig(true, nil)
 	_, allDebugLogger := GetLogComponent(ctx, comp1)
 	assert.Equal(t, zerolog.DebugLevel, allDebugLogger.GetLevel())
 	// debug component on
-	config.SetConfig(v1alpha2.PaasConfig{Spec: v1alpha2.PaasConfigSpec{
-		ComponentsDebug: map[string]bool{comp1: true},
-	}})
+	SetDynamicLoggingConfig(false, map[string]bool{comp1: true})
 	_, componentDebugLogger := GetLogComponent(ctx, comp1)
 	assert.Equal(t, zerolog.DebugLevel, componentDebugLogger.GetLevel())
 
 	// debug component off
 	SetStaticLoggingConfig(true, []string{comp1})
-	config.SetConfig(v1alpha2.PaasConfig{Spec: v1alpha2.PaasConfigSpec{
-		Debug:           true,
-		ComponentsDebug: map[string]bool{comp1: false},
-	}})
+	SetDynamicLoggingConfig(true, map[string]bool{comp1: false})
 	_, componentNoDebugLogger := GetLogComponent(ctx, comp1)
 	assert.Equal(t, zerolog.InfoLevel, componentNoDebugLogger.GetLevel())
 }

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
@@ -185,6 +185,11 @@ spec:
 
                   Deprecated: ArgoCD specific code will be removed from the operator
                 type: string
+              components_debug:
+                additionalProperties:
+                  type: boolean
+                description: Switch component debugging on or of for a specific component
+                type: object
               debug:
                 default: false
                 description: Enable debug information generation or not
@@ -485,6 +490,11 @@ spec:
 
                   Deprecated: ArgoCD specific code will be removed from the operator
                 type: string
+              components_debug:
+                additionalProperties:
+                  type: boolean
+                description: Switch component debugging on or of for a specific component
+                type: object
               debug:
                 default: false
                 description: Enable debug information generation or not


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Logging implementation works for arguments from commandline
- PaasConfig debug option is broken
- Component logging is not implemented in PaasConfig
- Changing logging requires a restart
- Config watcher does not use component logging
- Argocd-plugin-generator does not use component logging

## What is the new behavior?

- Logging implementation still works for arguments from commandline
- PaasConfig debug option works
- Component logging is implemented in PaasConfig
- Changing logging can be done without a restart (PaasConfig debug or component logging)
- Config watcher implemented with component logging
- Argocd-plugin-generator implemented with component logging

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

