### PR TITLE
docs: Small fix on v1alpha2 conversion user docs

### DIFF
--- a/docs/user-guide/99_v1alpha1-conversion.md
+++ b/docs/user-guide/99_v1alpha1-conversion.md
@@ -50,10 +50,15 @@ The following has changed between v1alpha1.Paas and v1alpha2.Paas:
             'ssh://git@my-git-host/my-git-repo.git': >-
               2wkeKe...g==
         # `grafana` is enabled and should stay but with empty definition
-        grafana: {}
+        grafana:
+          enabled: true
         # `tekton` is disabled and should be removed
         tekton:
           enabled: false
+          quota:
+            limits.cpu: '32'
+        # `sso` is disabled and should be removed
+        sso: {}
       # `sshSecrets` should be changed to `secrets`
       sshSecrets:
         'ssh://git@my-git-host/my-git-repo.git': >-
@@ -83,6 +88,7 @@ The following has changed between v1alpha1.Paas and v1alpha2.Paas:
             git_path: .
             git_revision: main
             git_url: https://www.github.com/my-org/my-repo/
+        grafana: {}
       secrets:
         'ssh://git@my-git-host/my-git-repo.git': >-
           2wkeKe...g==


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- docs are wrong (grafana is commented as being enabled, but is disabled
- there are only 2 options, (enabled and disabled), bit visually 4 (`enabled: true with other options`, `just enabled: true`, `enabled: false` and `empty body`) and only two are covered, which is confusing, since the visually look different
  - v1alpha1 `enabled: true` is `cap is enabled` and converts to v1alpha2 `empty body`
  - v1alpha1 `empty body` is `cap is disabled` and converts to `remove from map`

## What is the new behavior?

- docs are correct (grafana is commented as being enabled, and is enabled
- All four options are documented:
  - argocd: `enabled: true with other options`, converts to `remove enabled: true, leave rest
  - grafana:`just enabled: true`, converts to `empty block {}`
  - tekton: `enabled: false`, converts to `remove`
  - sso: `empty body`, converts to `remove`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

