### PR TITLE
hotfix: fail and log error when PaasConfig is not yet initialized

### DIFF
--- a/internal/argocd-plugin-generator/generator_server.go
+++ b/internal/argocd-plugin-generator/generator_server.go
@@ -79,7 +79,7 @@ func (s *GeneratorServer) Start(ctx context.Context) error {
 
 	ln, err := net.Listen("tcp", s.opts.Addr)
 	if err != nil {
-		logger.Error().Msgf("Failed to create listener: %v", err)
+		logger.Error().AnErr("error", err).Msg("Failed to create listener")
 		return err
 	}
 	s.started = true

--- a/internal/argocd-plugin-generator/plugin_generator.go
+++ b/internal/argocd-plugin-generator/plugin_generator.go
@@ -72,7 +72,7 @@ func New(kclient client.Client, bindAddr string) *PluginGenerator {
 // Start satisfies Runnable so that the manager can start the runnable
 func (pg *PluginGenerator) Start(ctx context.Context) error {
 	_, logger := logging.GetLogComponent(ctx, "plugin_generator")
-	logger.Debug().Msg("token")
+	logger.Debug().Msg("started")
 	return pg.server.Start(ctx)
 }
 

--- a/internal/argocd-plugin-generator/plugin_generator.go
+++ b/internal/argocd-plugin-generator/plugin_generator.go
@@ -54,7 +54,7 @@ func New(kclient client.Client, bindAddr string) *PluginGenerator {
 	generatorService := NewService(kclient)
 
 	token := os.Getenv(tokenEnvVar)
-	logger.Debug().Msgf("token: %s", token)
+	logger.Debug().Str("token", token).Msg("token")
 	handler := NewHandler(generatorService, token)
 
 	server := NewServer(ServerOptions{

--- a/internal/argocd-plugin-generator/service.go
+++ b/internal/argocd-plugin-generator/service.go
@@ -55,14 +55,14 @@ func (s *Service) Generate(params map[string]interface{}, appSetName string) ([]
 
 	var paasList v1alpha2.PaasList
 	if err := s.kclient.List(ctx, &paasList); err != nil {
-		logger.Error().Msgf("List error: %v", err)
+		logger.Error().AnErr("error", err).Msg("List error")
 		return nil, err
 	}
 
-	logger.Debug().Msgf("ArgoCD plugin cap, listed: %v Paases", len(paasList.Items))
+	logger.Debug().Int("num_paases", len(paasList.Items)).Msg("ArgoCD plugin cap")
 	capName, ok := params["capability"].(string)
 	if !ok || capName == "" {
-		logger.Error().Msgf("invalid capability param: %v", capName)
+		logger.Error().Str("name", capName).Msg("invalid capability param")
 		return nil, errors.New("missing or invalid capability param")
 	}
 
@@ -70,7 +70,7 @@ func (s *Service) Generate(params map[string]interface{}, appSetName string) ([]
 	for _, paas := range paasList.Items {
 		elements, err := capElementsFromPaas(ctx, &paas, capName)
 		if err != nil {
-			logger.Error().Msgf("failed to get elements for paas %s: %v", paas.Name, err)
+			logger.Error().Str("paas_name", paas.Name).AnErr("error", err).Msg("failed to get elements")
 			continue // skip failed ones
 		}
 		if elements == nil {
@@ -83,7 +83,7 @@ func (s *Service) Generate(params map[string]interface{}, appSetName string) ([]
 		for k, v := range strMap {
 			inf[k] = v
 		}
-		logger.Debug().Msgf("added paas %s with %d elements", paas.Name, len(inf))
+		logger.Debug().Str("paas_name", paas.Name).Int("num_elements", len(inf)).Msg("added paas")
 		results = append(results, inf)
 	}
 
@@ -99,7 +99,7 @@ func capElementsFromPaas(
 	logger := componentLogger.With().Str("paas", paas.Name).Str("capability", capName).Logger()
 	myConfig, err := config.GetConfigWithError()
 	if err != nil {
-		logger.Error().Msgf("%e", err)
+		logger.Error().AnErr("error", err).Msg("getting error failed")
 		return nil, err
 	}
 	templater := templating.NewTemplater(*paas, *myConfig)
@@ -110,19 +110,19 @@ func capElementsFromPaas(
 	}
 	templatedElements, err := applyCustomFieldTemplates(capConfig.CustomFields, templater)
 	if err != nil {
-		logger.Error().Msgf("templating custom fields failed: %v", err)
+		logger.Error().AnErr("error", err).Msg("templating custom fields failed")
 		return nil, err
 	}
 
 	capability, exists := paas.Spec.Capabilities[capName]
 	if !exists {
-		logger.Debug().Msgf("capability not enabled")
+		logger.Debug().Msg("capability not enabled")
 		return nil, nil
 	}
 
 	capElements, err := capability.CapExtraFields(myConfig.Spec.Capabilities[capName].CustomFields)
 	if err != nil {
-		logger.Error().Msgf("getting capability custom fields failed: %v", err)
+		logger.Error().AnErr("error", err).Msg("getting capability custom fields failed")
 		return nil, err
 	}
 	elements = templatedElements.AsFieldElements().Merge(capElements)
@@ -130,7 +130,7 @@ func capElementsFromPaas(
 	for name, tpl := range myConfig.Spec.Templating.GenericCapabilityFields {
 		result, templateErr := templater.TemplateToMap(name, tpl)
 		if templateErr != nil {
-			logger.Error().Msgf("templating %s failed: %v", tpl, templateErr)
+			logger.Error().Str("template", tpl).AnErr("error", templateErr).Msg("templating failed")
 			return nil, fmt.Errorf("failed to run template %s", tpl)
 		}
 		for key, value := range result {
@@ -139,7 +139,7 @@ func capElementsFromPaas(
 	}
 
 	elements["paas"] = paas.Name
-	logger.Debug().Msgf("returning %d elements", len(elements))
+	logger.Debug().Str("paas", paas.Name).Int("num_elements", len(elements)).Msg("returning elements")
 	return elements, nil
 }
 

--- a/internal/argocd-plugin-generator/service.go
+++ b/internal/argocd-plugin-generator/service.go
@@ -97,8 +97,12 @@ func capElementsFromPaas(
 ) (elements fields.Elements, err error) {
 	_, componentLogger := logging.GetLogComponent(ctx, "plugin_generator")
 	logger := componentLogger.With().Str("paas", paas.Name).Str("capability", capName).Logger()
-	myConfig := config.GetConfig()
-	templater := templating.NewTemplater(*paas, myConfig)
+	myConfig, err := config.GetConfigWithError()
+	if err != nil {
+		logger.Error().Msgf("%e", err)
+		return nil, err
+	}
+	templater := templating.NewTemplater(*paas, *myConfig)
 	capConfig, exists := myConfig.Spec.Capabilities[capName]
 	if !exists {
 		logger.Error().Msg("capability is not configured")

--- a/internal/config/informer.go
+++ b/internal/config/informer.go
@@ -48,7 +48,7 @@ func (w *configInformer) Start(ctx context.Context) error {
 
 	logger.Debug().Msg("setting initial paasConfig definition (empty when no PaasConfig is loaded)")
 	if err := w.setInitialConfig(ctx); err != nil {
-		logger.Error().Msgf("error setting initial config: %e", err)
+		logger.Error().AnErr("error", err).Msg("error setting initial config")
 		return err
 	}
 
@@ -84,7 +84,7 @@ func updateHandler(_, newObj interface{}) {
 	defer cancel()
 	_, logger := logging.GetLogComponent(ctx, "config_watcher")
 	if cfg.IsActive() && !reflect.DeepEqual(cfg.Spec, GetConfig().Spec) {
-		logger.Info().Msg("updating config")
+		logger.Debug().Any("config", cfg).Msg("updating config")
 		SetConfig(*cfg)
 	} else {
 		logger.Debug().Msg("config not changed")

--- a/internal/config/informer.go
+++ b/internal/config/informer.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -22,10 +23,34 @@ func SetupPaasConfigInformer(mgr manager.Manager) error {
 	return mgr.Add(&configInformer{mgr: mgr})
 }
 
+func (w *configInformer) setInitialConfig(ctx context.Context) error {
+	var list v1alpha2.PaasConfigList
+
+	if err := w.mgr.GetClient().List(ctx, &list); err != nil {
+		return fmt.Errorf("failed to retrieve PaasConfigs: %w", err)
+	}
+
+	switch len(list.Items) {
+	case 0:
+		SetConfig(v1alpha2.PaasConfig{})
+	case 1:
+		SetConfig(list.Items[0])
+	default:
+		return errors.New("more than one PaasConfig, this should not happen")
+	}
+	return nil
+}
+
 // Start is the runnable for the PaasConfigInformer
 func (w *configInformer) Start(ctx context.Context) error {
 	ctx, logger := logging.GetLogComponent(ctx, "config_watcher")
 	logger.Info().Msg("starting config informer")
+
+	logger.Debug().Msg("setting initial paasConfig definition (empty when no PaasConfig is loaded)")
+	if err := w.setInitialConfig(ctx); err != nil {
+		logger.Error().Msgf("error setting initial config: %e", err)
+		return err
+	}
 
 	informer, err := w.mgr.GetCache().GetInformer(ctx, &v1alpha2.PaasConfig{})
 	if err != nil {

--- a/internal/config/paas_config_store_test.go
+++ b/internal/config/paas_config_store_test.go
@@ -20,7 +20,7 @@ func TestGetConfigWithEmptyConfigStore(t *testing.T) {
 }
 
 func TestGetConfig(t *testing.T) {
-	cnf = &PaasConfigStore{}
+	cnf = PaasConfigStore{}
 	SetConfig(v1alpha2.PaasConfig{
 		Spec: v1alpha2.PaasConfigSpec{
 			Debug: true,

--- a/internal/webhook/v1alpha2/paasns_webhook.go
+++ b/internal/webhook/v1alpha2/paasns_webhook.go
@@ -84,14 +84,21 @@ func (v *PaasNSCustomValidator) ValidateCreate(
 		return w, errs.ToAggregate()
 	}
 
-	myConfig := config.GetConfig()
+	myConfig, err := config.GetConfigWithError()
+	if err != nil {
+		errs = append(errs, field.InternalError(
+			field.NewPath("paasconfig"),
+			fmt.Errorf("unable to retrieve paasconfig: %s", err),
+		))
+	}
+
 	for _, validator := range []paasNsSpecValidator{
 		validatePaasNsName,
 		validatePaasNsGroups,
 		validatePaasNsSecrets,
 	} {
 		var fieldErrs []*field.Error
-		fieldErrs, err = validator(ctx, v.client, myConfig, *paas, *paasns)
+		fieldErrs, err = validator(ctx, v.client, *myConfig, *paas, *paasns)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- PaasConfig is collected by controller logic, which only runs when the LeaderElection has succeeded
- Webhook and Plugin generator run before succesful leader election
- Webhook and Plugin generator receive an empty PaasConfig, but have no other way to tell if it was due to not being collected by controller logic yet

## What is the new behavior?

- A new function GetConfigWithError can be used to collect PaasConfig, but returns an error when it is not yet initialized
- Webhook and Plugin generator use this function and report errors when they run with an unititialized PaasConfig

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

