### PR TITLE
fix: Report generator errors back to plugin Generator

### DIFF
--- a/internal/argocd-plugin-generator/service.go
+++ b/internal/argocd-plugin-generator/service.go
@@ -70,8 +70,8 @@ func (s *Service) Generate(params map[string]interface{}, appSetName string) ([]
 	for _, paas := range paasList.Items {
 		elements, err := capElementsFromPaas(ctx, &paas, capName)
 		if err != nil {
-			logger.Error().Str("paas_name", paas.Name).AnErr("error", err).Msg("failed to get elements")
-			continue // skip failed ones
+			logger.Error().Str("paas_name", paas.Name).AnErr("error", err).Msg("failed to generate elements")
+			return nil, err // return error to caller
 		}
 		if elements == nil {
 			continue
@@ -99,7 +99,7 @@ func capElementsFromPaas(
 	logger := componentLogger.With().Str("paas", paas.Name).Str("capability", capName).Logger()
 	myConfig, err := config.GetConfigWithError()
 	if err != nil {
-		logger.Error().AnErr("error", err).Msg("getting error failed")
+		logger.Error().AnErr("error", err).Msg("get paasConfig failed")
 		return nil, err
 	}
 	templater := templating.NewTemplater(*paas, *myConfig)

--- a/internal/argocd-plugin-generator/service_test.go
+++ b/internal/argocd-plugin-generator/service_test.go
@@ -119,7 +119,8 @@ var _ = Describe("Service", func() {
 				"capability": "nonexistent",
 			}
 			results, err = svc.Generate(params, "some-app-set")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("capability nonexistent is not configured"))
 			Expect(results).To(BeEmpty())
 
 			By("Calling Generate with no param")
@@ -128,6 +129,18 @@ var _ = Describe("Service", func() {
 			_, err = svc.Generate(params, "some-app-set")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("missing or invalid capability param"))
+		})
+		It("returns err when no PaasConfig is set", func() {
+			By("Calling Generate")
+			config.ResetConfig()
+
+			params := map[string]interface{}{
+				"capability": "argocd",
+			}
+			results, err := svc.Generate(params, "some-app-set")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("uninitialized paasconfig"))
+			Expect(results).To(BeEmpty())
 		})
 	})
 })

--- a/internal/config/paas_config_store.go
+++ b/internal/config/paas_config_store.go
@@ -57,7 +57,6 @@ func GetConfigV1() (v1alpha1.PaasConfig, error) {
 	}
 	var v1conf v1alpha1.PaasConfig
 	err := v1conf.ConvertFrom(cnf.store)
-	// err := (&cnf.store).ConvertTo(&v1conf)
 	return v1conf, err
 }
 
@@ -77,5 +76,11 @@ func SetConfigV1(cfg v1alpha1.PaasConfig) error {
 
 	cnf.store = &v1alpha2.PaasConfig{}
 	return cfg.ConvertTo(cnf.store)
-	// return (&cnf.store).ConvertFrom(&cfg)
+}
+
+// ResetConfig resets the configstore
+func ResetConfig() {
+	cnf.mutex.Lock()
+	defer cnf.mutex.Unlock()
+	cnf.store = nil
 }

--- a/internal/config/paas_config_store_test.go
+++ b/internal/config/paas_config_store_test.go
@@ -32,3 +32,31 @@ func TestGetConfig(t *testing.T) {
 	assert.NotEmpty(t, actual)
 	assert.True(t, actual.Spec.Debug)
 }
+
+func TestResetConfig(t *testing.T) {
+	cnf = PaasConfigStore{}
+	SetConfig(v1alpha2.PaasConfig{
+		Spec: v1alpha2.PaasConfigSpec{
+			Capabilities: map[string]v1alpha2.ConfigCapability{
+				"x": {
+					AppSet: "x",
+				},
+			},
+		},
+	})
+
+	actual := GetConfig()
+	assert.NotEmpty(t, actual)
+	assert.False(t, actual.Spec.Debug)
+
+	// Reset Config
+	ResetConfig()
+
+	// Assert get default value when no config is set
+	actual = GetConfig()
+	assert.Equal(t, v1alpha2.PaasConfig{}, actual)
+
+	// Assert error when no config is set via GetConfigWithError
+	_, err := GetConfigWithError()
+	assert.Error(t, err, "uninitialized paasconfig")
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When an error occurs in generating elements for the plugin generator, the error is swallowed, the Paas entry is skipped by the `continue` keyword. In a situation in which for example the PaasConfig is uninitialized, or a Paas is configured with an not existing cap / customField, the `capElementsFromPaas` func returns an error. This error is caught, however, not passed on to the caller as the result is skipped through the `continue` keyword. Therefore the response to ArgoCD is a 200, without elements for the Paas which generates the error. 

This could, in the worst case, remove a Paas entry entirely from ArgoCD. Imagine the situation in which for the first request from ArgoCD was OK. Entries are returned and the AppSet does it's job. In the meantime, the controller is restarted and experiences a situation in which the PaasConfig is unitialized for a while. The next request from ArgoCD to the plugin generator will in that case return a 200, without any elements, removing all entries from ArgoCD AppSet.

## What is the new behavior?

* Instead of swallowing the error, the error is passed to the caller, resulting in a 500 http response to ArgoCD. ArgoCD does, in that case, not remove an existing entry but mentions the error and continues.
* Updates test cases
* Implements a helper, to reset a PaasConfig (mostly to be used internally in the test)
* Removes outdated comments
* Updates appropriate logging messages

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->