### PR TITLE
docs: Updated for adding secrets to a PaasNS

### DIFF
--- a/docs/overview/core_concepts/authorization.md
+++ b/docs/overview/core_concepts/authorization.md
@@ -158,7 +158,6 @@ DevOps engineers could additionally create a PaasNS with the following definitio
       name: adminonly
       namespace: my-paas-argocd
     spec:
-      paas: my-paas
       # The namespace would only contain RoleBindings for the `my-paas-us` group, which drills
       # down to the `admin`, `edit`, `view`, `alert-routing-edit`, and `monitoring-edit` ClusterRoles.
       groups:
@@ -169,5 +168,4 @@ DevOps engineers could additionally create a PaasNS with the following definitio
 
 - All groups will have the permissions as specified in the Paas.
 - Next to permissions on groups and users, there is also capabilities to implement
-  permissions for service accounts. See [extra_permissions](../../administrators-guide/capabilities.md#configuring-permissions) for
-  more info.
+  permissions for service accounts. See [extra_permissions](../../administrators-guide/capabilities.md#configuring-permissions) for more info.

--- a/docs/overview/core_concepts/secrets.md
+++ b/docs/overview/core_concepts/secrets.md
@@ -90,8 +90,7 @@ in the PaasNs. Additionally, `secret`s can also be created in a Paas.
 
 ### Defining secrets in a Paas
 
-The Paas controller only manages secrets in Paas namespaces which can be defined as part of a Paas (generic, capability 
-or namespace), or a PaasNS.
+The Paas controller only manages secrets in Paas namespaces which can be defined as part of a Paas (generic, capability or namespace), or a PaasNS.
 
 secrets can be defined in a Paas on three levels:
 
@@ -152,16 +151,15 @@ original secret is not removed.
       name: my-ns
       namespace: my-paas-argocd
     spec:
-      paas: my-paas
       secrets:
         # Specifying a secret for a specific PaasNs namespace
         "ssh://git@github.com/belastingdienst/paas.git": >-
           2wkeKebCnqgl...L/jDAUmhWG3ng==
     ```
 
-# Usecase 1: SSH secrets
+# Use case 1: SSH secrets
 
-One option (the most common usecase) is to add git credentials for argocd.
+One option (the most common use case) is to add git credentials for argocd.
 
 !!! example
 

--- a/docs/user-guide/02_secrets.md
+++ b/docs/user-guide/02_secrets.md
@@ -46,23 +46,23 @@ Once downloaded, the crypttool has two options for encrypting content:
     echo -e 'private investigations' | ./crypttool --encrypt-from-stdin -paas-name tst-tst -key ~/Downloads/public.bin
     ```
 
-### using cURL against the webservice api
+### Using cURL against the webservice api
 
 !!! example
 
     ```bash
-    ENDPOINT_URL="https://paas-webservice-paas-system.apps.mycluster.example/v1/encrypt"
+    ENDPOINT_URL="https://paas-webservice-paas-system.apps.mycluster.example.com/v1/encrypt"
     JSONTYPE='Content-Type: application/json'
     PAAS=tst-tst
     SECRET=$(awk '{printf "%s\\n", $0}' ~/.ssh/id_rsa)
     curl -X POST "${ENDPOINT_URL}" -H "${JSONTYPE}" -d '{"paas":"'${PAAS}'","secret":"'${SECRET}'"}'
     ```
 
-### other options
+### Other options
 
 Options are endless. Be creative...
 
-## defining secrets
+## Defining secrets
 
 Encrypted Secrets can be specified in multiple places.
 
@@ -105,7 +105,7 @@ be deployed in the namespace belonging to the capability specifically.
               2wkeKe...g==
     ```
 
-By defining the secret as part of a PaasNs, the secret will be deployed in the
+By defining the secret as part of a PaasNs (`PaasNs.spec.secrets`), the secret will be deployed in the
 corresponding namespace only.
 
 !!! example
@@ -113,16 +113,10 @@ corresponding namespace only.
     ```yaml
     ---
     apiVersion: cpet.belastingdienst.nl/v1alpha2
-    kind: Paas
+    kind: PaasNS
     metadata:
       name: tst-tst
     spec:
-      capabilities:
-        # The argocd capability enabled
-        argocd: {}
-      requestor: my-team
-      quota:
-        limits.cpu: "40"
       secrets:
         'ssh://git@my-git-host/my-git-repo.git': >-
           2wkeKe...g==


### PR DESCRIPTION
Updates to documentation related to adding secrets to a `PaasNS` object. Also removed deprecated `paas: my-paas ` attribute from a couple of example v1alpha2 PaasNS'es.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: # (issue)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->