### PR TITLE
refactor: Simplify mergeSecrets code

### DIFF
--- a/internal/controller/main.go
+++ b/internal/controller/main.go
@@ -7,6 +7,7 @@ See LICENSE.md for details.
 package controller
 
 import (
+	"maps"
 	"strings"
 )
 
@@ -31,4 +32,12 @@ func intersect(l1 []string, l2 []string) (li []string) {
 		}
 	}
 	return li
+}
+
+// Helper to merge secrets which returns a new map[string]string
+func mergeSecrets(base, override map[string]string) map[string]string {
+	merged := make(map[string]string, len(base)+len(override))
+	maps.Copy(merged, base)
+	maps.Copy(merged, override)
+	return merged
 }

--- a/internal/controller/main_test.go
+++ b/internal/controller/main_test.go
@@ -7,6 +7,8 @@ See LICENSE.md for details.
 package controller
 
 import (
+	"maps"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,4 +21,63 @@ func TestMain_intersection(t *testing.T) {
 	// Expected to have only all values that exist in list 1 and 2, only once (unique)
 	lExpected := []string{"v2", "v3"}
 	assert.ElementsMatch(t, li, lExpected, "result of intersection not as expected")
+}
+
+func TestMergeSecrets(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     map[string]string
+		override map[string]string
+		want     map[string]string
+	}{
+		{
+			name:     "empty base and override",
+			base:     map[string]string{},
+			override: map[string]string{},
+			want:     map[string]string{},
+		},
+		{
+			name:     "base only",
+			base:     map[string]string{"a1": "1"},
+			override: map[string]string{},
+			want:     map[string]string{"a1": "1"},
+		},
+		{
+			name:     "override only",
+			base:     map[string]string{},
+			override: map[string]string{"b": "b2"},
+			want:     map[string]string{"b": "b2"},
+		},
+		{
+			name:     "override replaces base",
+			base:     map[string]string{"c": "c1"},
+			override: map[string]string{"c": "c2"},
+			want:     map[string]string{"c": "c2"},
+		},
+		{
+			name:     "override adds to base",
+			base:     map[string]string{"a": "1"},
+			override: map[string]string{"b": "2"},
+			want:     map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:     "multiple overrides",
+			base:     map[string]string{"f": "1", "c": "3"},
+			override: map[string]string{"f": "10", "g": "20"},
+			want:     map[string]string{"f": "10", "g": "20", "c": "3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// copy maps to avoid mutating original test cases
+			baseCopy := maps.Clone(tt.base)
+			overrideCopy := maps.Clone(tt.override)
+
+			got := mergeSecrets(baseCopy, overrideCopy)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeSecrets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/controller/namespace_def.go
+++ b/internal/controller/namespace_def.go
@@ -59,18 +59,6 @@ func newNamespaceDefFromPaasNS(nsName string, paasns *v1alpha2.PaasNS,
 	}
 }
 
-// Helper to merge secrets
-func mergeSecrets(base, override map[string]string) map[string]string {
-	merged := make(map[string]string)
-	for k, v := range base {
-		merged[k] = v
-	}
-	for k, v := range override {
-		merged[k] = v
-	}
-	return merged
-}
-
 // paasNSsFromNs gets all PaasNs objects from a namespace and returns a map of all paasNS's.
 // Key of the map is based on the namespaced name of the PaasNS, so that we have uniqueness
 // paasNSsFromNs runs recursively, to collect all PaasNS's in the namespaces of founds PaasNS namespaces too.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Custom code is used for merging secrets

## What is the new behavior?

* Use `maps.Copy` instead of custom code for merging secrets.
* Adds missing tests
* Move func to `main.go` file

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->