### PR TITLE
fix: custom fields that are not string

### DIFF
--- a/internal/argocd-plugin-generator/fields/elements.go
+++ b/internal/argocd-plugin-generator/fields/elements.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Element represents a value for one entry in the list of the listgenerator
@@ -54,7 +56,11 @@ func (es Elements) TryGetElementAsString(key string) (string, error) {
 	if ok {
 		return value, nil
 	}
-	return fmt.Sprintf("%v", element), nil
+	y, err := yaml.Marshal(element)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(y)), nil
 }
 
 // Merge merges all key/value pairs from another Entries on top of this and returns the resulting total Entries set

--- a/internal/argocd-plugin-generator/fields/elements.go
+++ b/internal/argocd-plugin-generator/fields/elements.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	"go.yaml.in/yaml/v3"
 )
 
 // Element represents a value for one entry in the list of the listgenerator
@@ -25,12 +23,12 @@ func ElementsFromJSON(raw []byte) (Elements, error) {
 	return newElements, nil
 }
 
-// GetElementsAsStringMap gets a value and returns as string
+// GetElementsAsAnyMap gets a value and returns as string
 // This should be a method on Element, but a method cannot exist on interface datatypes
-func (es Elements) GetElementsAsStringMap() (values map[string]string) {
-	values = make(map[string]string)
-	for key := range es {
-		values[key] = es.GetElementAsString(key)
+func (es Elements) GetElementsAsAnyMap() (values map[string]any) {
+	values = make(map[string]any)
+	for key, value := range es {
+		values[key] = value
 	}
 	return values
 }
@@ -56,11 +54,11 @@ func (es Elements) TryGetElementAsString(key string) (string, error) {
 	if ok {
 		return value, nil
 	}
-	y, err := yaml.Marshal(element)
+	j, err := json.Marshal(element)
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(y)), nil
+	return string(j), nil
 }
 
 // Merge merges all key/value pairs from another Entries on top of this and returns the resulting total Entries set

--- a/internal/argocd-plugin-generator/fields/elements_test.go
+++ b/internal/argocd-plugin-generator/fields/elements_test.go
@@ -21,10 +21,16 @@ var (
 	key2     = "c"
 	value2   = 6.0
 	key3     = "d"
-	key4     = ""
+	value3   = map[string]string{"k1": "v1", "k2": "v2"}
+	key4     = "e"
+	value4   = []string{"e1", "e2"}
+	key5     = "f"
+	key6     = ""
 	elements = fields.Elements{
 		key1: value1,
 		key2: value2,
+		key3: value3,
+		key4: value4,
 	}
 	properJSON    = []byte(fmt.Sprintf(`{"%s":"%s","%s":%f}`, key1, value1, key2, value2))
 	improperJSONs = [][]byte{
@@ -40,6 +46,8 @@ func TestAsStringMap(t *testing.T) {
 		map[string]string{
 			"a": "b",
 			"c": "6",
+			"d": "k1: v1\nk2: v2",
+			"e": "- e1\n- e2",
 		},
 		elements.GetElementsAsStringMap(),
 	)
@@ -62,7 +70,7 @@ func TestTryGetElementAsString(t *testing.T) {
 
 func TestGetElementAsString(t *testing.T) {
 	require.NotNil(t, elements)
-	for _, key := range []string{key1, key2, key3, key4} {
+	for _, key := range []string{key1, key2, key3, key4, key5, key6} {
 		if _, exists := elements[key]; exists {
 			assert.NotEmpty(t, elements.GetElementAsString(key))
 		} else {
@@ -90,7 +98,7 @@ func TestElementsFromImproperJSON(t *testing.T) {
 }
 
 func TestElementsAsString(t *testing.T) {
-	expected := `{ 'a': 'b', 'c': '6' }`
+	expected := "{ 'a': 'b', 'c': '6', 'd': 'k1: v1\nk2: v2', 'e': '- e1\n- e2' }"
 	require.NotNil(t, elements)
 	assert.Equal(t, expected, elements.String())
 }

--- a/internal/argocd-plugin-generator/fields/elements_test.go
+++ b/internal/argocd-plugin-generator/fields/elements_test.go
@@ -43,13 +43,13 @@ var (
 func TestAsStringMap(t *testing.T) {
 	assert.Equal(
 		t,
-		map[string]string{
+		map[string]interface{}{
 			"a": "b",
-			"c": "6",
-			"d": "k1: v1\nk2: v2",
-			"e": "- e1\n- e2",
+			"c": 6.0,
+			"d": map[string]string{"k1": "v1", "k2": "v2"},
+			"e": []string{"e1", "e2"},
 		},
-		elements.GetElementsAsStringMap(),
+		elements.GetElementsAsAnyMap(),
 	)
 }
 
@@ -98,7 +98,7 @@ func TestElementsFromImproperJSON(t *testing.T) {
 }
 
 func TestElementsAsString(t *testing.T) {
-	expected := "{ 'a': 'b', 'c': '6', 'd': 'k1: v1\nk2: v2', 'e': '- e1\n- e2' }"
+	expected := `{ 'a': 'b', 'c': '6', 'd': '{"k1":"v1","k2":"v2"}', 'e': '["e1","e2"]' }`
 	require.NotNil(t, elements)
 	assert.Equal(t, expected, elements.String())
 }

--- a/internal/argocd-plugin-generator/service.go
+++ b/internal/argocd-plugin-generator/service.go
@@ -83,14 +83,8 @@ func (s *Service) Generate(params map[string]interface{}) ([]map[string]interfac
 			continue
 		}
 
-		strMap := elements.GetElementsAsStringMap()
-
-		inf := make(map[string]interface{}, len(strMap))
-		for k, v := range strMap {
-			inf[k] = v
-		}
-		logger.Debug().Str("paas_name", paas.Name).Int("num_elements", len(inf)).Msg("added paas")
-		results = append(results, inf)
+		logger.Debug().Str("paas_name", paas.Name).Int("num_elements", len(elements)).Msg("added paas")
+		results = append(results, elements.GetElementsAsAnyMap())
 	}
 
 	return results, nil

--- a/internal/controller/capabilities_test.go
+++ b/internal/controller/capabilities_test.go
@@ -161,8 +161,8 @@ g, ` + group2 + `, role:admin`
 				}
 				Expect(entries).To(HaveKey(paasName))
 				elements := entries[paasName]
-				Expect(elements.GetElementsAsStringMap()).To(Equal(
-					map[string]string{
+				Expect(elements.GetElementsAsAnyMap()).To(Equal(
+					map[string]any{
 						customField1Key:         customField1Value,
 						customField2Key:         customField2Value,
 						"paas":                  paasName,

--- a/test/e2e/capability_argocd_test.go
+++ b/test/e2e/capability_argocd_test.go
@@ -66,7 +66,7 @@ func assertArgoCapCreated(ctx context.Context, t *testing.T, cfg *envconf.Config
 
 	assert.Len(t, entries, 1, "ApplicationSet contains one List generator")
 	assert.Contains(t, entries, paasWithArgo)
-	assert.Equal(t, map[string]string{
+	assert.Equal(t, map[string]any{
 		"git_path":     paasArgoGitPath,
 		"git_revision": paasArgoGitRevision,
 		"git_url":      paasArgoGitURL,
@@ -75,7 +75,7 @@ func assertArgoCapCreated(ctx context.Context, t *testing.T, cfg *envconf.Config
 		"requestor":  paasRequestor,
 		"service":    "paas",
 		"subservice": "capability",
-	}, entries[paasWithArgo].GetElementsAsStringMap())
+	}, entries[paasWithArgo].GetElementsAsAnyMap())
 
 	assert.NotNil(
 		t,
@@ -144,7 +144,7 @@ func assertArgoCapUpdated(ctx context.Context, t *testing.T, cfg *envconf.Config
 	// For now this still applies, later we move the git_.. properties to the appSet as well
 	// Assert AppSet entry updated accordingly
 	assert.Len(t, entries, 1, "ApplicationSet contains one List generator")
-	assert.Equal(t, map[string]string{
+	assert.Equal(t, map[string]any{
 		"git_path":     paasArgoGitPath,
 		"git_revision": updatedRevision,
 		"git_url":      paasArgoGitURL,
@@ -152,7 +152,7 @@ func assertArgoCapUpdated(ctx context.Context, t *testing.T, cfg *envconf.Config
 		"requestor":    paasRequestor,
 		"service":      "paas",
 		"subservice":   "capability",
-	}, entries[paasWithArgo].GetElementsAsStringMap(), "ApplicationSet List generator contains the correct parameters")
+	}, entries[paasWithArgo].GetElementsAsAnyMap(), "ApplicationSet List generator contains the correct parameters")
 
 	assert.NotNil(
 		t,


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When we have custom fields that do not return string values, they are added in the result as a %v representation.

## What is the new behavior?

fields that are not string are parsed as yaml 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

