### PR TITLE
fix: proper structs in api/plugin

### DIFF
--- a/api/plugin/main.go
+++ b/api/plugin/main.go
@@ -2,16 +2,19 @@ package plugin
 
 import "github.com/belastingdienst/opr-paas/v3/pkg/fields"
 
-// Input represents the expected request payload for the plug-in generator.
+// Request represents the expected request payload for the plug-in generator.
 //
 // The ApplicationSetName identifies the target ApplicationSet in Argo CD.
 // Input.Parameters is a map of user-provided parameters, where keys are
 // strings and values are strings as well.
-type Input struct {
+type Request struct {
 	ApplicationSetName string `json:"applicationSetName"`
-	Input              struct {
-		Parameters fields.ElementMap `json:"parameters"`
-	} `json:"input"`
+	Input              Input  `json:"input"`
+}
+
+// Input represents the input which is added to a Request
+type Input struct {
+	Parameters fields.ElementMap `json:"parameters"`
 }
 
 // Response represents the response payload returned by the plug-in generator.
@@ -19,7 +22,10 @@ type Input struct {
 // Output.Parameters is a slice of maps, where each map contains a set of
 // key-value pairs representing generated parameters for the ApplicationSet.
 type Response struct {
-	Output struct {
-		Parameters []fields.ElementMap `json:"parameters"`
-	} `json:"output"`
+	Output Output `json:"output"`
+}
+
+// Output represents the output data which is added to a Response
+type Output struct {
+	Parameters []fields.ElementMap `json:"parameters"`
 }

--- a/internal/argocd-plugin-generator/handler.go
+++ b/internal/argocd-plugin-generator/handler.go
@@ -80,14 +80,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var input plugin.Input
-	if err = json.Unmarshal(body, &input); err != nil {
+	var request plugin.Request
+	if err = json.Unmarshal(body, &request); err != nil {
 		logger.Error().Bytes("body", body).Msg("invalid json")
 		http.Error(w, fmt.Sprintf("invalid json: %v", err), http.StatusBadRequest)
 		return
 	}
 
-	result, err := h.service.Generate(ctx, input.Input.Parameters)
+	result, err := h.service.Generate(ctx, request.Input.Parameters)
 	if err != nil {
 		logger.Error().AnErr("error", err).Msg("generation error")
 		http.Error(w, fmt.Sprintf("generation error: %v", err), http.StatusInternalServerError)


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- api/plugin exposes the structs as used by the plugin generator, but the structs contain internal fields which are not exported.
  As such the external structs are still not really properly usable outside of the module.

## What is the new behavior?

- Api / plugin is built entirely from perly defined and externally exposed structs
- Api / plugin is externally properly usable
- Api / plugin is built with proper naming (e.a. Request instead of Input)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Breaking, but only for other software using the plugin/api, and it was exported in the last release and not really usable.
