### PR TITLE
ci(release-drafter): prevent double labeling of issues by only using …

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -51,28 +51,26 @@ version-resolver:
       - 'test'
   default: patch
 autolabeler:
+  # Enforce breaking label
   - label: 'breaking'
     title:
       - '/!:/'
     body:
       - '/BREAKING CHANGE/'
+  # Enforce minor label if manifests are changed
+  - label: 'minor'
+    files:
+      - 'manifests/**/*'
+  # All labels below are set SOLELY on the basis of the title to prevent double labelling
   - label: 'chore'
     title:
       - '/^chore(\(.*\))?!?:/i'
   - label: 'ci'
     title:
       - '/^(ci|build)(\(.*\))?!?:/i'
-    files:
-      - '.github/*'
-      - '.github/**/*'
   - label: 'documentation'
     title:
       - '/^docs(\(.*\))?!?:/i'
-    files:
-      - 'docs/*'
-      - 'docs/**/*'
-      - '*.md'
-      - '**/*.md'
   - label: 'enhancement'
     title:
       - '/^(feat|perf)(\(.*\))?!?:/i'
@@ -91,9 +89,6 @@ autolabeler:
   - label: 'test'
     title:
       - '/^test(\(.*\))?!?:/i'
-  - label: 'minor'
-    files:
-      - 'manifests/**/*'
 template: |
   ## Changes
 


### PR DESCRIPTION
Prevent double labeling of issues by only using PR title to label

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In some cases, PRs are double labeled due to us using both "title" as well as "files".

## What is the new behavior?

Only use title to auto label with notable exception of breaking changes and minor changes.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

