### PR TITLE
feat: check for invalid namespace length from paas, paasns and paas namespace

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -10,7 +10,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+func Join(argv ...string) string {
+	return strings.Join(argv, "-")
+}
 
 // PathToFileList can be fed multiple paths, which it will walk and return a fill list of all files in the path /
 // subdirectories

--- a/internal/webhook/v1alpha2/paas_webhook.go
+++ b/internal/webhook/v1alpha2/paas_webhook.go
@@ -18,6 +18,7 @@ import (
 	"github.com/belastingdienst/opr-paas/v3/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v3/internal/config"
 	"github.com/belastingdienst/opr-paas/v3/internal/logging"
+	"github.com/belastingdienst/opr-paas/v3/internal/utils"
 	"github.com/belastingdienst/opr-paas/v3/pkg/quota"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -281,6 +282,15 @@ func validatePaasNamespaceNames(
 		return nil, nil
 	}
 	for namespace := range paas.Spec.Namespaces {
+		nsName := utils.Join(paas.Name, namespace)
+		if len(nsName) > 63 {
+			errs = append(errs, field.Invalid(
+				field.NewPath("metadata").Key("name"),
+				nsName,
+				"namespace name combined with paasns name too long",
+			))
+		}
+
 		if !nameValidationRE.Match([]byte(namespace)) {
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("namespaces"),

--- a/internal/webhook/v1alpha2/paas_webhook_test.go
+++ b/internal/webhook/v1alpha2/paas_webhook_test.go
@@ -179,14 +179,27 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 			}
 		})
 		It("Should validate namespace names", func() {
+			// 10 chars paas
+			obj.Name = "abcdefghij"
+			const (
+				letters     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+				tooLongName = letters + letters
+			)
+			var (
+				validLength   = 63 - 1 - len(obj.Name)
+				validLongName = tooLongName[0:validLength]
+			)
 			for _, test := range []struct {
 				name       string
 				validation string
 				valid      bool
 			}{
+
 				{name: "valid-name", validation: "^[a-z-]+$", valid: true},
 				{name: "invalid-name", validation: "^[a-z]+$", valid: false},
 				{name: "", validation: "^.$", valid: false},
+				{name: validLongName, validation: "", valid: true},
+				{name: tooLongName, validation: "", valid: false},
 			} {
 				fmt.Fprintf(GinkgoWriter, "DEBUG - Test: %v", test)
 

--- a/internal/webhook/v1alpha2/paasns_webhook.go
+++ b/internal/webhook/v1alpha2/paasns_webhook.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/belastingdienst/opr-paas/v3/internal/config"
+	"github.com/belastingdienst/opr-paas/v3/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
@@ -186,7 +187,7 @@ func validatePaasNsName(
 	_ context.Context,
 	_ client.Client,
 	conf v1alpha2.PaasConfig,
-	_ v1alpha2.Paas,
+	paas v1alpha2.Paas,
 	paasns v1alpha2.PaasNS,
 ) ([]*field.Error, error) {
 	var fieldErrors []*field.Error
@@ -197,6 +198,16 @@ func validatePaasNsName(
 			"paasns name should not contain dots",
 		))
 	}
+
+	nsName := utils.Join(paas.Name, paasns.Name)
+	if len(nsName) > 63 {
+		fieldErrors = append(fieldErrors, field.Invalid(
+			field.NewPath("metadata").Key("name"),
+			nsName,
+			"paas name combined with paasns name too long",
+		))
+	}
+
 	nameValidationRE := conf.GetValidationRE("paasNs", "name")
 	if nameValidationRE == nil {
 		nameValidationRE = conf.GetValidationRE("paas", "namespaceName")

--- a/internal/webhook/v1alpha2/paasns_webhook_test.go
+++ b/internal/webhook/v1alpha2/paasns_webhook_test.go
@@ -242,6 +242,14 @@ var _ = Describe("PaasNS Webhook", Ordered, func() {
 			Expect(err.Error()).To(ContainSubstring("paasns name should not contain dots"))
 		})
 		It("Should validate paasns name", func() {
+			const (
+				letters     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+				tooLongName = letters + letters
+			)
+			var (
+				validLength   = 63 - 1 - len(paasName)
+				validLongName = tooLongName[0:validLength]
+			)
 			for _, test := range []struct {
 				name       string
 				validation string
@@ -249,6 +257,8 @@ var _ = Describe("PaasNS Webhook", Ordered, func() {
 			}{
 				{name: "valid-name", validation: "^[a-z-]+$", valid: true},
 				{name: "invalid-name", validation: "^[a-z]+$", valid: false},
+				{name: validLongName, validation: "", valid: true},
+				{name: tooLongName, validation: "", valid: false},
 				{name: "", validation: "^.$", valid: false},
 			} {
 				conf.Spec.Validations = v1alpha2.PaasConfigValidations{"paasNs": {"name": test.validation}}


### PR DESCRIPTION

## Pull Request type


Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Before you could create a paas with a namespace and/or paasns which resulted in a namespace with more than 63 chars

## What is the new behavior?

When creating a paas with a namespace and/or paasns which results in a namespace with more than 63 chars, webhook will fail

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Only implemented for v1alpha2, as we are sunsetting v1alpha1.
Special thanks to @portly-halicore-76
