### PR TITLE
feat: Checking RFC1123 Label Name requirements on Namespace names

### DIFF
--- a/internal/webhook/v1alpha1/paas_webhook.go
+++ b/internal/webhook/v1alpha1/paas_webhook.go
@@ -262,11 +262,11 @@ func validatePaasallowedQuotas(
 // RFC 1123 Label Names
 // Some resource types require their names to follow the DNS label standard as defined in RFC 1123.
 // This means the name must:
-// contain at most 63 characters
-// contain only lowercase alphanumeric characters or '-'
-// start with an alphabetic character
-// end with an alphanumeric character
-var rfc1123LabelNamesRegex = regexp.MustCompile(`^[a-zA-Z0-9]([-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?$`)
+// - contain at most 63 characters
+// - contain only lowercase alphanumeric characters or '-'
+// - start with an alphabetic character
+// - end with an alphanumeric character
+var rfc1123LabelNamesRegex = regexp.MustCompile(`^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`)
 
 // validatePaasNamespaceNames returns an error for every namespace that does not meet validations.
 func validatePaasNamespaceNames(
@@ -289,7 +289,7 @@ func validatePaasNamespaceNames(
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("namespaces").Index(index),
 				namespace,
-				fmt.Sprintf("paas name does not match with RFC 1123 Label Names`%s`", nameValidationRE.String()),
+				"paas name does not match with RFC 1123 Label Names",
 			))
 		}
 		if nameValidationRE != nil {

--- a/internal/webhook/v1alpha1/paas_webhook.go
+++ b/internal/webhook/v1alpha1/paas_webhook.go
@@ -10,6 +10,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 
 	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
@@ -258,6 +259,15 @@ func validatePaasallowedQuotas(
 	return errs, nil
 }
 
+// RFC 1123 Label Names
+// Some resource types require their names to follow the DNS label standard as defined in RFC 1123.
+// This means the name must:
+// contain at most 63 characters
+// contain only lowercase alphanumeric characters or '-'
+// start with an alphabetic character
+// end with an alphanumeric character
+var rfc1123LabelNamesRegex = regexp.MustCompile(`^[a-zA-Z0-9]([-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?$`)
+
 // validatePaasNamespaceNames returns an error for every namespace that does not meet validations.
 func validatePaasNamespaceNames(
 	_ context.Context,
@@ -273,16 +283,23 @@ func validatePaasNamespaceNames(
 	if nameValidationRE == nil {
 		nameValidationRE = conf.GetValidationRE("paasNs", "name")
 	}
-	if nameValidationRE == nil {
-		return nil, nil
-	}
+
 	for index, namespace := range paas.Spec.Namespaces {
-		if !nameValidationRE.Match([]byte(namespace)) {
+		if !rfc1123LabelNamesRegex.MatchString(namespace) {
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("namespaces").Index(index),
 				namespace,
-				fmt.Sprintf("paas name does not match configured validation regex `%s`", nameValidationRE.String()),
+				fmt.Sprintf("paas name does not match with RFC 1123 Label Names`%s`", nameValidationRE.String()),
 			))
+		}
+		if nameValidationRE != nil {
+			if !nameValidationRE.Match([]byte(namespace)) {
+				errs = append(errs, field.Invalid(
+					field.NewPath("spec").Child("namespaces").Index(index),
+					namespace,
+					fmt.Sprintf("paas name does not match configured validation regex `%s`", nameValidationRE.String()),
+				))
+			}
 		}
 	}
 

--- a/internal/webhook/v1alpha1/paas_webhook_test.go
+++ b/internal/webhook/v1alpha1/paas_webhook_test.go
@@ -171,6 +171,8 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 				{name: "invalid-name", validation: "^[a-z]+$", valid: false},
 				// RFC 1123 Label Names
 				{name: "invalid_name", validation: "", valid: false},
+				{name: "Invalid-name", validation: "", valid: false},
+				{name: "1nvalid-name", validation: "", valid: false},
 				{name: "", validation: "^.$", valid: false},
 			} {
 				// Update PaasConfig

--- a/internal/webhook/v1alpha1/paas_webhook_test.go
+++ b/internal/webhook/v1alpha1/paas_webhook_test.go
@@ -169,6 +169,8 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 			}{
 				{name: "valid-name", validation: "^[a-z-]+$", valid: true},
 				{name: "invalid-name", validation: "^[a-z]+$", valid: false},
+				// RFC 1123 Label Names
+				{name: "invalid_name", validation: "", valid: false},
 				{name: "", validation: "^.$", valid: false},
 			} {
 				// Update PaasConfig

--- a/internal/webhook/v1alpha2/paas_webhook.go
+++ b/internal/webhook/v1alpha2/paas_webhook.go
@@ -267,11 +267,11 @@ func validatePaasallowedQuotas(
 // RFC 1123 Label Names
 // Some resource types require their names to follow the DNS label standard as defined in RFC 1123.
 // This means the name must:
-// contain at most 63 characters
-// contain only lowercase alphanumeric characters or '-'
-// start with an alphabetic character
-// end with an alphanumeric character
-var rfc1123LabelNamesRegex = regexp.MustCompile(`^[a-zA-Z0-9]([-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?$`)
+// - contain at most 63 characters
+// - contain only lowercase alphanumeric characters or '-'
+// - start with an alphabetic character
+// - end with an alphanumeric character
+var rfc1123LabelNamesRegex = regexp.MustCompile(`^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`)
 
 // validatePaasNamespaceNames returns an error for every namespace that does not meet validations.
 func validatePaasNamespaceNames(
@@ -297,7 +297,7 @@ func validatePaasNamespaceNames(
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("namespaces").Key(namespace),
 				namespace,
-				fmt.Sprintf("paas name does not match with RFC 1123 Label Names`%s`", nameValidationRE.String()),
+				"paas name does not match with RFC 1123 Label Names",
 			))
 		}
 		nsName := utils.Join(paas.Name, namespace)

--- a/internal/webhook/v1alpha2/paas_webhook_test.go
+++ b/internal/webhook/v1alpha2/paas_webhook_test.go
@@ -198,6 +198,8 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 				{name: "valid-name", validation: "^[a-z-]+$", valid: true},
 				{name: "invalid-name", validation: "^[a-z]+$", valid: false},
 				{name: "", validation: "^.$", valid: false},
+				// RFC 1123 Label Names
+				{name: "invalid_name", validation: "", valid: false},
 				{name: validLongName, validation: "", valid: true},
 				{name: tooLongName, validation: "", valid: false},
 			} {

--- a/internal/webhook/v1alpha2/paas_webhook_test.go
+++ b/internal/webhook/v1alpha2/paas_webhook_test.go
@@ -182,8 +182,8 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 			// 10 chars paas
 			obj.Name = "abcdefghij"
 			const (
-				letters     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-				tooLongName = letters + letters
+				letters     = "abcdefghijklmnopqrstuvwxyz-"
+				tooLongName = letters + letters + letters + letters
 			)
 			var (
 				validLength   = 63 - 1 - len(obj.Name)
@@ -194,12 +194,13 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 				validation string
 				valid      bool
 			}{
-
 				{name: "valid-name", validation: "^[a-z-]+$", valid: true},
 				{name: "invalid-name", validation: "^[a-z]+$", valid: false},
 				{name: "", validation: "^.$", valid: false},
 				// RFC 1123 Label Names
 				{name: "invalid_name", validation: "", valid: false},
+				{name: "Invalid-name", validation: "", valid: false},
+				{name: "1nvalid-name", validation: "", valid: false},
 				{name: validLongName, validation: "", valid: true},
 				{name: tooLongName, validation: "", valid: false},
 			} {


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

If a namespace is added to the namespace block, and it's name is not according to RFC-1123 Label naming, the webhook finds it valid, while the controller cannot create a namespace accordingly

## What is the new behavior?

If a namespace is added to the namespace block, and it's name is not according to RFC-1123 Label naming, the webhook finds it invalid

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information