### PR TITLE
fix: skip custom field validation in plugin generator

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -335,9 +335,14 @@ type PaasCapability struct {
 	ExtraPermissions bool `json:"extra_permissions"`
 }
 
-// CapExtraFields returns all extra fields that are configured for a capability
+// CapExtraFields returns all extra fields that are configured for a capability.
+// When validate is true, fields are checked against the fieldConfig: unknown fields,
+// regex validation failures, and missing required fields all produce errors.
+// When validate is false, all custom fields are returned as-is without validation,
+// and defaults are still applied for missing non-template fields.
 func (pc *PaasCapability) CapExtraFields(
 	fieldConfig map[string]ConfigCustomField,
+	validate bool,
 ) (elements fields.ElementMap, err error) {
 	// TODO: remove argocd specific fields
 	elements = fields.ElementMap{}
@@ -346,8 +351,12 @@ func (pc *PaasCapability) CapExtraFields(
 	elements["git_path"] = pc.GitPath
 	var issues []error
 	for key, value := range pc.CustomFields {
-		if _, exists := fieldConfig[key]; !exists {
-			issues = append(issues, fmt.Errorf("custom field %s is not configured in capability config", key))
+		if validate {
+			if _, exists := fieldConfig[key]; !exists {
+				issues = append(issues, fmt.Errorf("custom field %s is not configured in capability config", key))
+			} else {
+				elements[key] = value
+			}
 		} else {
 			elements[key] = value
 		}
@@ -355,15 +364,17 @@ func (pc *PaasCapability) CapExtraFields(
 	for key, fieldConf := range fieldConfig {
 		var value string
 		if value, err = elements.TryGetElementAsString(key); err == nil {
-			var matched bool
-			if matched, err = regexp.Match(fieldConf.Validation, []byte(value)); err != nil {
-				issues = append(issues, fmt.Errorf("could not validate value %s: %w", value, err))
-			} else if !matched {
-				issues = append(issues,
-					fmt.Errorf("invalid value %s (does not match %s)", value, fieldConf.Validation),
-				)
+			if validate {
+				var matched bool
+				if matched, err = regexp.Match(fieldConf.Validation, []byte(value)); err != nil {
+					issues = append(issues, fmt.Errorf("could not validate value %s: %w", value, err))
+				} else if !matched {
+					issues = append(issues,
+						fmt.Errorf("invalid value %s (does not match %s)", value, fieldConf.Validation),
+					)
+				}
 			}
-		} else if fieldConf.Required {
+		} else if validate && fieldConf.Required {
 			issues = append(issues, fmt.Errorf("value %s is required", key))
 		} else if fieldConf.Template == "" || fieldConf.Default != "" {
 			elements[key] = fieldConf.Default

--- a/api/v1alpha1/paas_types_test.go
+++ b/api/v1alpha1/paas_types_test.go
@@ -330,7 +330,7 @@ func TestPaasCapabilities_CapExtraFields(t *testing.T) {
 		"git_revision": {},
 		"git_path":     {},
 		"default_key":  {Default: "default_value"},
-	})
+	}, true)
 	require.NoError(t, err, "we should have no errors returned")
 	assert.Equal(t, fields.ElementMap{
 		"git_url":      "https://github.com/org/other-repo",
@@ -345,7 +345,7 @@ func TestPaasCapabilities_CapExtraFields(t *testing.T) {
 			"not_in_config": "breaks",
 		},
 	}
-	elements, err = pc.CapExtraFields(map[string]ConfigCustomField{})
+	elements, err = pc.CapExtraFields(map[string]ConfigCustomField{}, true)
 	assert.Equal(t, "custom field not_in_config is not configured in capability config", err.Error())
 	assert.Nil(t, elements, "not_in_config should return nilmap for fields")
 
@@ -355,7 +355,7 @@ func TestPaasCapabilities_CapExtraFields(t *testing.T) {
 	}
 	elements, err = pc.CapExtraFields(map[string]ConfigCustomField{
 		"required_key": {Required: true},
-	})
+	}, true)
 	assert.Equal(t, "value required_key is required", err.Error())
 	assert.Nil(t, elements, "required_field should return nilmap for fields")
 
@@ -369,7 +369,7 @@ func TestPaasCapabilities_CapExtraFields(t *testing.T) {
 		"invalid_key": {
 			Validation: "^valid_value$",
 		},
-	})
+	}, true)
 	assert.Equal(t, "invalid value invalid_value (does not match ^valid_value$)", err.Error())
 	assert.Nil(t, elements, "invalid_value should return nilmap for fields")
 }

--- a/internal/argocd-plugin-generator/service.go
+++ b/internal/argocd-plugin-generator/service.go
@@ -117,7 +117,7 @@ func capElementsFromPaas(
 		return nil, nil
 	}
 
-	capElements, err := capability.CapExtraFields(paasConfig.Spec.Capabilities[capName].CustomFields)
+	capElements, err := capability.CapExtraFields(paasConfig.Spec.Capabilities[capName].CustomFields, false)
 	if err != nil {
 		logger.Error().AnErr("error", err).Msg("getting capability custom fields failed")
 		return nil, err

--- a/internal/webhook/v1alpha1/paas_webhook.go
+++ b/internal/webhook/v1alpha1/paas_webhook.go
@@ -391,7 +391,7 @@ func validateCustomFields(
 
 	for cname, c := range paas.Spec.Capabilities {
 		// validateCaps() has already ensured the capability configuration exists
-		if _, err := c.CapExtraFields(conf.Spec.Capabilities[cname].CustomFields); err != nil {
+		if _, err := c.CapExtraFields(conf.Spec.Capabilities[cname].CustomFields, true); err != nil {
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("capabilities").Key(cname),
 				"custom_fields",

--- a/internal/webhook/v1alpha2/paas_webhook.go
+++ b/internal/webhook/v1alpha2/paas_webhook.go
@@ -412,7 +412,7 @@ func validateCustomFields(
 
 	for cname, c := range paas.Spec.Capabilities {
 		// validateCaps() has already ensured the capability configuration exists
-		if _, err := c.CapExtraFields(conf.Spec.Capabilities[cname].CustomFields); err != nil {
+		if _, err := c.CapExtraFields(conf.Spec.Capabilities[cname].CustomFields, true); err != nil {
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("capabilities").Key(cname),
 				"custom_fields",


### PR DESCRIPTION

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

CapExtraFields validates custom fields in all contexts, causing the ArgoCD plugin generator to reject PaaSes with invalid data instead of outputting their values.

Fixes: # (issue)

## What is the new behavior?

Add a validate parameter so webhooks still enforce validation on create/edit while the plugin generator passes fields through as-is.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->