### PR TITLE
feat: Add short name to PaasNS

### DIFF
--- a/api/v1alpha2/paasns_types.go
+++ b/api/v1alpha2/paasns_types.go
@@ -46,7 +46,7 @@ type PaasNSSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:conversion:hub
-// +kubebuilder:resource:path=paasns,scope=Namespaced
+// +kubebuilder:resource:path=paasns,shortName=pns,scope=Namespaced
 
 // PaasNS is the Schema for the PaasNS API
 type PaasNS struct {

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paasns.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paasns.yaml
@@ -11,6 +11,8 @@ spec:
     kind: PaasNS
     listKind: PaasNSList
     plural: paasns
+    shortNames:
+    - pns
     singular: paasns
   scope: Namespaced
   versions:


### PR DESCRIPTION
Kubernetes CRD's have the option to provide a short name for people who do not like typing the complete name of the a CRD. For example, `oc get appset` will get you the ArgoCD ApplicationSets. This PR adds a short name voor PaasNS, as I am frequently typing `oc get pns` and not getting any results.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

After typing `oc get paasns` the cluster will respond with the list of PaasNS objects in the current namespace.

Fixes: # (issue)

## What is the new behavior?

After typing `oc get pns` the cluster will respond with the list of PaasNS objects in the current namespace. The current behavior of `oc get paasns` will remain unchanged by this change.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->