### PR TITLE
feat: Adding capability template validations in the webhook

### DIFF
--- a/docs/administrators-guide/go-templating.md
+++ b/docs/administrators-guide/go-templating.md
@@ -17,7 +17,8 @@ This provides flexibility for other organizations using the Paas operator with o
 
 Template options support standard Go Template syntax, allowing all values from the Paas and PaasConfig to be referenced. See more examples below.
 In addition to the default Go Template functions, we've added support for
-[all Sprout](https://docs.atom.codes/sprout/registries/list-of-all-registries) Go Template functions.
+[all Sprout](https://docs.atom.codes/sprout/registries/list-of-all-registries) Go Template functions,
+and [backward](https://docs.atom.codes/sprout/registries/backward) (we want to use the `fail` function.
 
 ## Behavior of multivalued and single valued results
 

--- a/internal/webhook/v1alpha2/paas_webhook.go
+++ b/internal/webhook/v1alpha2/paas_webhook.go
@@ -21,6 +21,7 @@ import (
 	"github.com/belastingdienst/opr-paas/v4/internal/logging"
 	"github.com/belastingdienst/opr-paas/v4/internal/utils"
 	"github.com/belastingdienst/opr-paas/v4/pkg/quota"
+	"github.com/belastingdienst/opr-paas/v4/pkg/templating"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -172,13 +173,19 @@ func validateCaps(
 	}
 
 	for name, capability := range paas.Spec.Capabilities {
-		if _, ok := conf.Spec.Capabilities[name]; !ok {
+		templater := templating.NewTemplater(*paas, conf)
+		if capConfig, ok := conf.Spec.Capabilities[name]; !ok {
 			errs = append(errs, field.Invalid(
 				field.NewPath("spec").Child("capabilities"),
 				name,
 				"capability not configured",
 			))
 		} else {
+			errs = append(errs, applyCustomFieldTemplates(
+				field.NewPath("spec").Child("capabilities").Key(name).Child("custom_fields"),
+				capConfig.CustomFields,
+				templater,
+			)...)
 			errs = append(errs, validateSecrets(
 				capability.Secrets,
 				rsa,
@@ -188,6 +195,27 @@ func validateCaps(
 	}
 
 	return errs, nil
+}
+
+func applyCustomFieldTemplates(
+	fieldPath *field.Path,
+	ccfields map[string]v1alpha2.ConfigCustomField,
+	templater templating.Templater[v1alpha2.Paas, v1alpha2.PaasConfig, v1alpha2.PaasConfigSpec],
+) (errs []*field.Error) {
+	for name, fieldConfig := range ccfields {
+		if fieldConfig.Template != "" {
+			_, err := templater.TemplateToMap(name, fieldConfig.Template)
+			if err != nil {
+				errs = append(errs, field.Invalid(
+					fieldPath,
+					name,
+					err.Error(),
+				))
+			}
+		}
+	}
+
+	return errs
 }
 
 // validatePaasName returns an error if the name of the paas does not meet validations.

--- a/internal/webhook/v1alpha2/paas_webhook_test.go
+++ b/internal/webhook/v1alpha2/paas_webhook_test.go
@@ -455,6 +455,53 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 			))
 		})
 
+		It("Should deny creation when a custom field template fails", func() {
+			const (
+				capName   = "templateerror"
+				fieldName = "errorfield"
+			)
+			// Update PaasConfig
+			latestConf := &v1alpha2.PaasConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: conf.Name}, latestConf)
+			Expect(err).To(Not(HaveOccurred()))
+			latestConf.Spec.Capabilities[capName] = v1alpha2.ConfigCapability{
+				QuotaSettings: v1alpha2.ConfigQuotaSettings{
+					DefQuota: map[corev1.ResourceName]resource.Quantity{"foo": resource.MustParse("1")},
+				},
+				CustomFields: map[string]v1alpha2.ConfigCustomField{
+					fieldName: {Template: `{{- fail "this just always fails" -}}`},
+				},
+			}
+			err = k8sClient.Update(ctx, latestConf)
+			Expect(err).To(Not(HaveOccurred()))
+
+			obj = &v1alpha2.Paas{
+				Spec: v1alpha2.PaasSpec{
+					Capabilities: v1alpha2.PaasCapabilities{
+						capName: v1alpha2.PaasCapability{
+							CustomFields: map[string]string{
+								fieldName: "whatever",
+							},
+						},
+					},
+				},
+			}
+			_, err = validator.ValidateCreate(ctx, obj)
+
+			var serr *apierrors.StatusError
+			Expect(errors.As(err, &serr)).To(BeTrue())
+			causes := serr.Status().Details.Causes
+			Expect(causes).To(HaveLen(1))
+			Expect(causes).To(ContainElements(
+				metav1.StatusCause{
+					Type: metav1.CauseTypeFieldValueInvalid,
+					Message: "Invalid value: \"errorfield\": template: errorfield:1:4: executing \"errorfield\" at " +
+						"<fail \"this just always fails\">: error calling fail: this just always fails",
+					Field: "spec.capabilities[templateerror].custom_fields",
+				},
+			))
+		})
+
 		It("Should deny creation when a namespace group does not match any Paas group", func() {
 			obj = &v1alpha2.Paas{
 				Spec: v1alpha2.PaasSpec{

--- a/pkg/templating/main.go
+++ b/pkg/templating/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-sprout/sprout"
 	"github.com/go-sprout/sprout/group/all"
+	"github.com/go-sprout/sprout/registry/backward"
 
 	"github.com/belastingdienst/opr-paas/v4/api"
 	"github.com/belastingdienst/opr-paas/v4/api/v1alpha2"
@@ -33,8 +34,15 @@ func NewTemplater[P PaasUnion, C api.PaasConfig[S], S any](paas P, config C) Tem
 }
 
 func (t Templater[P, C, S]) getSproutFuncs() (template.FuncMap, error) {
+	var err error
 	handler := sprout.New()
-	err := handler.AddGroups(all.RegistryGroup())
+	// TODO: fail is currently deprecated. We need to check the community.
+	// For using the fail function
+	err = handler.AddRegistry(backward.NewRegistry())
+	if err != nil {
+		return nil, err
+	}
+	err = handler.AddGroups(all.RegistryGroup())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We currently don't verify templates on capability custom fields

## What is the new behavior?

- With this feature we do
- We also enabled the `fail` function

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- The `fail` function is deprecated and the community mentioned:
  **No replacement are scheduled yet. If you need this function, open an issue to clearly explain the usage.**
  We should communicate our usecase to the community.
  And we might run into a situation where we need to implement our own `fail` if they might remove the code entirely
  We have a unittest, so we notice before we merge.