### PR TITLE
fix: set served to false on v1alpha1 resources

### DIFF
--- a/api/v1alpha1/paas_types.go
+++ b/api/v1alpha1/paas_types.go
@@ -447,6 +447,7 @@ func (ps *PaasStatus) GetMessages() []string {
 // +kubebuilder:deprecatedversion:warning="please upgrade to v1alpha2"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=paas,scope=Cluster
+// +kubebuilder:unservedversion
 
 // Paas is the Schema for the paas API
 type Paas struct {

--- a/api/v1alpha1/paasconfig_types.go
+++ b/api/v1alpha1/paasconfig_types.go
@@ -37,6 +37,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="please upgrade to v1alpha2"
 // +kubebuilder:resource:path=paasconfig,scope=Cluster
+// +kubebuilder:unservedversion
 type PaasConfig struct {
 	metav1.TypeMeta   `json:""`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/paasns_types.go
+++ b/api/v1alpha1/paasns_types.go
@@ -48,6 +48,7 @@ type PaasNSSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="please upgrade to v1alpha2"
 // +kubebuilder:resource:path=paasns,scope=Namespaced
+// +kubebuilder:unservedversion
 
 // PaasNS is the Schema for the PaasNS API
 type PaasNS struct {

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paas.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paas.yaml
@@ -242,7 +242,7 @@ spec:
                 type: object
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paasconfig.yaml
@@ -353,7 +353,7 @@ spec:
                 type: array
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/manifests/crd/bases/cpet.belastingdienst.nl_paasns.yaml
+++ b/manifests/crd/bases/cpet.belastingdienst.nl_paasns.yaml
@@ -131,7 +131,7 @@ spec:
                 type: array
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
v1alpha1 resources can still be served by the operator on k8s.

## What is the new behavior?
Sets served to false for deprecated resources. This is in line with k8s documentation on removing old versions: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#overview:~:text=Set%20served,step

## Does this introduce a breaking change?

- [ ] Yes
- [x] No