### PR TITLE
chore(deps): bump to renamed opr-paas-cli v2 and update references to old crypttool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ go.work*
 *~
 /manager
 /crypttool*
+/kubectl-paas*
 /webservice
 
 site/

--- a/docs/administrators-guide/configuration.md
+++ b/docs/administrators-guide/configuration.md
@@ -170,7 +170,7 @@ Example PaasConfig
 !!! note
     .spec.decryptKeySecret.name points to a secret `example-keys`.
     An example secret can be found [here](../../examples/resources/example-keys.yaml).
-    For generating a new secret, please checkout our [crypttool](https://github.com/belastingdienst/opr-paas-crypttool/).
+    For generating a new secret, please checkout our [kubectl-paas](https://github.com/belastingdienst/opr-paas-cli/) tool.
 
 Example denial:
 

--- a/docs/administrators-guide/secrets.md
+++ b/docs/administrators-guide/secrets.md
@@ -18,16 +18,16 @@ or through the web service).
 
 ## Generating new secrets
 
-New keys can be easily generated using the crypttool. You can download the crypttool
-from the [Downloads section of its repository](https://github.com/belastingdienst/opr-paas-crypttool/releases).
+New keys can be easily generated using kubectl-paas. You can download kubectl-paas
+from the [Downloads section of its repository](https://github.com/belastingdienst/opr-paas-cli/releases).
 
-Once downloaded, the crypttool can be used to generate a keypair as follows:
+Once downloaded, kubectl-paas can be used to generate a keypair as follows:
 
 !!! example
 
     ```bash
     cd $(mktemp -d)
-    crypttool generate --privateKeyFile private.bin --publicKeyFile public.bin
+    kubectl-paas generate --privateKeyFile private.bin --publicKeyFile public.bin
     ```
 
 ## Deploying new secrets
@@ -49,7 +49,7 @@ will (also) be tried for decryption.
 ### Directly
 
 Once generated, the public key should be supplied to users that encrypt secrets.
-They can be supplied directly, so that users can use the crypttool for encryption.
+They can be supplied directly, so that users can use kubectl-paas for encryption.
 For more info, please refer to [user docs on Secrets](../user-guide/02_secrets.md).
 
 ### Running the webservice
@@ -83,8 +83,7 @@ k8s changes the mount and the webservice automatically picks up the file changes
 ### Reencryption
 
 A proper encryption product also has options to cycle the encrypted data.
-With the secrets implementation in the operator, this is implemented with the
-crypttool.
+With the secrets implementation in the operator, this is implemented with kubectl-paas.
 
 Steps are:
 
@@ -107,9 +106,9 @@ Steps are:
     cd $(mktemp -d)
     kubectl get paas -o name | while read -r PAAS; do
       kubectl get paas "${PAAS}" > "${PAAS}.yaml"
-      crypttool check-paas --privateKeyFiles ~/Downloads/oldpriv > "${PAAS}.pre.out"
-      crypttool reencrypt --privateKeyFiles ~/Downloads/oldpriv --publicKeyFile ~/Downloads/newpublicKey "${PAAS}.yaml"
-      crypttool check-paas --privateKeyFiles ~/Downloads/oldpriv > "${PAAS}.post.out"
+      kubectl-paas check-paas --privateKeyFiles ~/Downloads/oldpriv > "${PAAS}.pre.out"
+      kubectl-paas reencrypt --privateKeyFiles ~/Downloads/oldpriv --publicKeyFile ~/Downloads/newpublicKey "${PAAS}.yaml"
+      kubectl-paas check-paas --privateKeyFiles ~/Downloads/oldpriv > "${PAAS}.post.out"
       kubectl apply -f "${PAAS}.yaml"
     done
     ```

--- a/docs/overview/core_concepts/secrets.md
+++ b/docs/overview/core_concepts/secrets.md
@@ -34,7 +34,7 @@ comes with additional tooling:
 - A crypt tool, available from a separate repository, that can be used to
   encrypt, re-encrypt, generate key pairs, and inspect encrypted keys;
 
-  You can find the crypt tool at [https://github.com/belastingdienst/opr-paas-crypttool](https://github.com/belastingdienst/opr-paas-crypttool)
+  You can find the crypt tool at [https://github.com/belastingdienst/opr-paas-cli](https://github.com/belastingdienst/opr-paas-cli)
 
 !!! note
 
@@ -42,7 +42,7 @@ comes with additional tooling:
     separately. It was moved into a separate repository after the release of version
     v1.12.0 of the operator.
 
-`opr-paas-crypttool` requires access to the private key to be usable...
+`opr-paas-cli` requires access to the private key to be usable...
 
 ## How it works
 
@@ -59,22 +59,22 @@ comes with additional tooling:
 
 ```kroki-blockdiag
 blockdiag {
-  "decrypted" -> crypttool -> Paas -> operator;
-  "Public key" -> crypttool;
+  "decrypted" -> kubectl-paas -> Paas -> operator;
+  "Public key" -> kubectl-paas;
   "Private key" -> operator;
   operator -> namespace -> secret;
   "decrypted" [color = "greenyellow", shape = flowchart.input, stacked];
   "secret" [color = "greenyellow", stacked];
   "Public key" [color = "pink", shape = flowchart.input];
   "Private key" [color = "pink", shape = flowchart.input];
-  "crypttool" [color = "lightblue"];
+  "kubectl-paas" [color = "lightblue"];
   "operator" [color = "lightblue"];
   group {
       color = "#FF0000";
       shape = line;
       style = dashed;
       orientation = portrait
-      "decrypted", crypttool, Paas, "Public key";
+      "decrypted", kubectl-paas, Paas, "Public key";
    }
   group {
       orientation = portrait
@@ -195,8 +195,8 @@ One option (the most common use case) is to add git credentials for argocd.
 
 ```kroki-blockdiag
 blockdiag {
-  "ssh private key" -> crypttool -> Paas -> operator;
-  "Public key" -> crypttool;
+  "ssh private key" -> kubectl-paas -> Paas -> operator;
+  "Public key" -> kubectl-paas;
   "Private key" -> operator;
   operator -> "ArgoCD quota";
   operator -> "ArgoCD namespace" -> secret -> "ArgoCD repo (secret)";
@@ -206,14 +206,14 @@ blockdiag {
   "secret" [color = "greenyellow", stacked];
   "Public key" [color = "pink", shape = flowchart.input];
   "Private key" [color = "pink", shape = flowchart.input];
-  "crypttool" [color = "lightblue"];
+  "kubectl-paas" [color = "lightblue"];
   "operator" [color = "lightblue"];
   group input {
       color = "#FF0000";
       shape = line;
       style = dashed;
       orientation = portrait
-      "ssh private key", crypttool, Paas, "Public key";
+      "ssh private key", kubectl-paas, Paas, "Public key";
   }
   group operator {
       orientation = portrait

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -25,9 +25,9 @@ This brings down over commit at the expense of the risk of resource sharing.
 
 For more details, see the [relevant details in the administrators section](administrators-guide/cluster-wide-quotas/basic-usage.md)
 
-## Crypttool
+## Kubectl-paas
 
-The crypttool is a small command-line utility that allows a user to perform some
+Kubectl-paas is a small command-line utility that allows a user to perform some
 simple operations in regard to secrets in a Paas.
 
 Basic functionality includes sub-commands for `encrypt`, `decrypt` and `re-encrypt`
@@ -41,7 +41,7 @@ This will allow for key rotation.
 
 It can also be used to `generate` a new public/private key pair.
 
-The crypttool is managed from its own repository on GitHub at [https://github.com/belastingdienst/opr-paas-crypttool](https://github.com/belastingdienst/opr-paas-crypttool).
+The kubectl-paas tool is managed from its own repository on GitHub at [https://github.com/belastingdienst/opr-paas-cli](https://github.com/belastingdienst/opr-paas-cli).
 
 ## Groups [openshift]
 

--- a/docs/user-guide/02_secrets.md
+++ b/docs/user-guide/02_secrets.md
@@ -26,24 +26,24 @@ the [Admin guide on configuring secret encryption](../administrators-guide/secre
 
 ## Encrypting secrets
 
-You can download the crypttool from the
-[Downloads section of its repository](https://github.com/belastingdienst/opr-paas-crypttool/releases).
-Once downloaded, the crypttool has two options for encrypting content:
+You can download the kubectl-paas tool from the
+[Downloads section of its repository](https://github.com/belastingdienst/opr-paas-cli/releases).
+Once downloaded, kubectl-paas has two options for encrypting content:
 
-### Encrypting a file with crypttool
+### Encrypting a file with kubectl-paas
 
 !!! example
 
     ```bash
-    ./crypttool --encrypt-from-file ~/.ssh/id_rsa -paas-name tst-tst -key ~/Downloads/public.bin
+    ./kubectl-paas --encrypt-from-file ~/.ssh/id_rsa -paas-name tst-tst -key ~/Downloads/public.bin
     ```
 
-### Encrypting from stdin with crypttool
+### Encrypting from stdin with kubectl-paas
 
 !!! example
 
     ```bash
-    echo -e 'private investigations' | ./crypttool --encrypt-from-stdin -paas-name tst-tst -key ~/Downloads/public.bin
+    echo -e 'private investigations' | ./kubectl-paas --encrypt-from-stdin -paas-name tst-tst -key ~/Downloads/public.bin
     ```
 
 ### Using cURL against the webservice api

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	github.com/belastingdienst/opr-paas-cli/v2 v2.0.1
 	github.com/go-logr/zerologr v1.2.3
 	github.com/go-sprout/sprout v1.0.3
 	github.com/onsi/ginkgo/v2 v2.28.1
@@ -84,7 +85,6 @@ require (
 )
 
 require (
-	github.com/belastingdienst/opr-paas-crypttool v1.1.0
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/belastingdienst/opr-paas-crypttool v1.1.0 h1:e20Y1NGVfzuBEi4z5kkoc2frQqXeeEZaKXYHMGNK0YE=
-github.com/belastingdienst/opr-paas-crypttool v1.1.0/go.mod h1:NX+7tBzV1nRJ08YUwy+WomtpeeevEQu44y4gTFtmHD0=
+github.com/belastingdienst/opr-paas-cli/v2 v2.0.1 h1:Sv5gHbR0OsSe2Vqdt77vCBlWj844LygVQBkhuDbYxLI=
+github.com/belastingdienst/opr-paas-cli/v2 v2.0.1/go.mod h1:6CKgGyjID4Wkul8gWgWoMHv+UzBEQ2Afmp+Th3EXFj8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
+	"github.com/belastingdienst/opr-paas-cli/v2/pkg/crypt"
 	"github.com/belastingdienst/opr-paas/v5/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v5/internal/config"
 	paasquota "github.com/belastingdienst/opr-paas/v5/pkg/quota"

--- a/internal/controller/rsa_controller.go
+++ b/internal/controller/rsa_controller.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"context"
 
-	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
+	"github.com/belastingdienst/opr-paas-cli/v2/pkg/crypt"
 	"github.com/belastingdienst/opr-paas/v5/internal/config"
 	"github.com/belastingdienst/opr-paas/v5/internal/logging"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/controller/secret_controller_test.go
+++ b/internal/controller/secret_controller_test.go
@@ -9,7 +9,7 @@ package controller
 import (
 	"context"
 
-	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
+	"github.com/belastingdienst/opr-paas-cli/v2/pkg/crypt"
 	"github.com/belastingdienst/opr-paas/v5/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v5/internal/config"
 	paasquota "github.com/belastingdienst/opr-paas/v5/pkg/quota"

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
+	"github.com/belastingdienst/opr-paas-cli/v2/pkg/crypt"
 	"github.com/belastingdienst/opr-paas/v5/api/v1alpha2"
 	// +kubebuilder:scaffold:imports
 )

--- a/internal/webhook/v1alpha2/paas_webhook.go
+++ b/internal/webhook/v1alpha2/paas_webhook.go
@@ -15,7 +15,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
+	"github.com/belastingdienst/opr-paas-cli/v2/pkg/crypt"
 	"github.com/belastingdienst/opr-paas/v5/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v5/internal/config"
 	"github.com/belastingdienst/opr-paas/v5/internal/logging"

--- a/internal/webhook/v1alpha2/paas_webhook_test.go
+++ b/internal/webhook/v1alpha2/paas_webhook_test.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
+	"github.com/belastingdienst/opr-paas-cli/v2/pkg/crypt"
 	"github.com/belastingdienst/opr-paas/v5/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v5/pkg/quota"
 	. "github.com/onsi/ginkgo/v2"

--- a/internal/webhook/v1alpha2/paasns_webhook.go
+++ b/internal/webhook/v1alpha2/paasns_webhook.go
@@ -17,7 +17,7 @@ import (
 	"github.com/belastingdienst/opr-paas/v5/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
+	"github.com/belastingdienst/opr-paas-cli/v2/pkg/crypt"
 	"github.com/belastingdienst/opr-paas/v5/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v5/internal/logging"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/webhook/v1alpha2/paasns_webhook_test.go
+++ b/internal/webhook/v1alpha2/paasns_webhook_test.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
+	"github.com/belastingdienst/opr-paas-cli/v2/pkg/crypt"
 	"github.com/belastingdienst/opr-paas/v5/api/v1alpha2"
 	"github.com/belastingdienst/opr-paas/v5/internal/config"
 	"github.com/belastingdienst/opr-paas/v5/pkg/quota"

--- a/test/e2e/sshsecrets_test.go
+++ b/test/e2e/sshsecrets_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/belastingdienst/opr-paas-crypttool/pkg/crypt"
+	"github.com/belastingdienst/opr-paas-cli/v2/pkg/crypt"
 	"github.com/belastingdienst/opr-paas/v5/pkg/quota"
 	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 


### PR DESCRIPTION
bump to renamed opr-paas-cli v2 and update references to old crypttool

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build-related changes
- [ ] Documentation content changes
- [X] Other (please describe): change references from opr-paas-crypttool to opr-paas-cli v2

## What is the current behavior?

Uses opr-paas-crypttool v1

## What is the new behavior?

Uses opr-paas-cli v2

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
