### PR TITLE
fix: Add issues write permission for autolabeler job (fix label API permission error)

### DIFF
--- a/.github/workflows/draft-release-on-push.yml
+++ b/.github/workflows/draft-release-on-push.yml
@@ -3,7 +3,6 @@ name: Draft release on push to main
 on:
   workflow_dispatch:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - main
     paths-ignore:
@@ -16,6 +15,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Workflow-level minimal permissions
 permissions:
   contents: read
 
@@ -24,20 +24,20 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      # write permission is required for autolabeler
+      # autolabeler needs issues: write to add labels
+      contents: read
+      issues: write
       pull-requests: write
     steps:
-      # Run autolabeler (separate actions since v7)
       - uses: release-drafter/release-drafter/autolabeler@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3 # v7.0.0
 
   update_release_draft:
     permissions:
-      # write permission is required to create a GitHub release
+      # write permission is required to create/update a GitHub release
       contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3 # v7.0.0
         with:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Add "issues: write" permission for autolabeler job (fix label API permission error)

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Autolabeler fails with "Resource not accessible by integration" when attempting to add labels to pull requests due to insufficient token permissions.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Grant issues: write permission to the autolabeler job so it can add labels via the Issues API.
- Keep workflow-level permissions minimal (contents: read) and retain contents: write for the release drafting job.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->