### PR TITLE
fix: autolabeler issues permission

### DIFF
--- a/.github/workflows/draft-release-on-push.yml
+++ b/.github/workflows/draft-release-on-push.yml
@@ -7,12 +7,12 @@ on:
       - main
     paths-ignore:
       - 'catalog/**'
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 # Prevent overlapping runs from corrupting the draft release
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Workflow-level minimal permissions
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   autolabeler:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       # autolabeler needs issues: write to add labels
@@ -32,6 +32,7 @@ jobs:
       - uses: release-drafter/release-drafter/autolabeler@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3 # v7.0.0
 
   update_release_draft:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       # write permission is required to create/update a GitHub release
       contents: write

--- a/.github/workflows/draft-release-on-push.yml
+++ b/.github/workflows/draft-release-on-push.yml
@@ -3,7 +3,6 @@ name: Draft release on push to main
 on:
   workflow_dispatch:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - main
     paths-ignore:
@@ -16,6 +15,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Workflow-level minimal permissions
 permissions:
   contents: read
 
@@ -24,20 +24,20 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      # write permission is required for autolabeler
+      # autolabeler needs issues: write to add labels
+      contents: read
+      issues: write
       pull-requests: write
     steps:
-      # Run autolabeler (separate actions since v7)
       - uses: release-drafter/release-drafter/autolabeler@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3 # v7.0.0
 
   update_release_draft:
     permissions:
-      # write permission is required to create a GitHub release
+      # write permission is required to create/update a GitHub release
       contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3 # v7.0.0
         with:


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The release drafter job also runs on pull request events, which can cause it to try creating or updating a draft release before the PR is merged to `main`.

The autolabeler can also fail to add labels on PR events due to insufficient token permissions.

Fixes: #

## What is the new behavior?

- Run the release drafter job only on `push` to `main` or manual workflow dispatch.
- Run the autolabeler on `pull_request_target` so it can label pull requests with the required permissions.
- Keep workflow permissions scoped per job.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This fixes the `Resource not accessible by integration` errors for release creation during PR runs and label updates by the autolabeler.