### PR TITLE
fix: Fix OLM Promotion PR checks

### DIFF
--- a/.github/workflows/promote-catalog.yml
+++ b/.github/workflows/promote-catalog.yml
@@ -33,11 +33,18 @@ jobs:
       CATALOG_IMG: ghcr.io/belastingdienst/opr-paas-catalog:latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.BD_OPR_PAAS_GITHUB_APP_ID }}
+          private-key: ${{ secrets.BD_OPR_PAAS_GITHUB_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ env.DEFAULT_BRANCH }}
 
       - name: Setup Go
@@ -124,7 +131,7 @@ jobs:
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore(olm): promote opr-paas v${{ env.VERSION }} to ${{ env.TARGET_PHASE }}'
           committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
           author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

OLM catalog promotion PRs are created with `GITHUB_TOKEN`. As a result, required pull request workflows are not triggered and branch protection keeps waiting for expected checks.

Fixes: #

## What is the new behavior?

- The promotion workflow now generates a GitHub App installation token.
- The promotion PR is created with the GitHub App token instead of `GITHUB_TOKEN`.
- The GitHub App token action is pinned to a commit SHA.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Ran `zizmor` against the updated workflow. No findings were reported.