### PR TITLE
chore: replace deprecated app-id input

### DIFF
--- a/.github/workflows/promote-catalog.yml
+++ b/.github/workflows/promote-catalog.yml
@@ -37,7 +37,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.BD_OPR_PAAS_GITHUB_APP_ID }}
+          client-id: ${{ secrets.BD_OPR_PAAS_GITHUB_APP_ID }}
           private-key: ${{ secrets.BD_OPR_PAAS_GITHUB_APP_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
## Pull Request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The GitHub App token action uses the deprecated `app-id` input.

Fixes: #

## What is the new behavior?

- Uses `client-id` for the GitHub App token action.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

-