### PR TITLE
feat: allow configuring plugin generator bind address via env

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -45,7 +45,10 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-const webhookErrMsg = "unable to create webhook"
+const (
+	argocdPluginGeneratorBindAddressEnv = "ARGOCD_PLUGIN_GENERATOR_BIND_ADDRESS"
+	webhookErrMsg                       = "unable to create webhook"
+)
 
 var scheme = runtime.NewScheme()
 
@@ -110,7 +113,7 @@ func configureFlags() *flags {
 	flag.StringVar(&f.metricsCertName, "metrics-cert-name", "tls.crt",
 		"The name of the metrics server certificate file.")
 	flag.StringVar(&f.metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
-	flag.StringVar(&f.argocdPluginGenAddr, "argocd-plugin-generator-bind-address", "0", "The address the argocd plugin generator endpoint binds to. Use :4355 for HTTP, or leave as 0 to disable the argocd plugin generator service.") // nolint:revive
+	flag.StringVar(&f.argocdPluginGenAddr, "argocd-plugin-generator-bind-address", defaultArgocdPluginGeneratorBindAddress(), "The address the argocd plugin generator endpoint binds to. Use :4355 for HTTP, or leave as 0 to disable the argocd plugin generator service.") // nolint:revive
 	flag.BoolVar(&f.enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.BoolVar(&f.pretty, "pretty", false, "Pretty-print logging output")
@@ -125,6 +128,14 @@ func configureFlags() *flags {
 	flag.Parse()
 
 	return f
+}
+
+func defaultArgocdPluginGeneratorBindAddress() string {
+	if value := os.Getenv(argocdPluginGeneratorBindAddressEnv); value != "" {
+		return value
+	}
+
+	return "0"
 }
 
 func configureLogging(pretty bool, debug bool, componentDebugList string, splitLogOutput bool) {

--- a/docs/administrators-guide/olm-installation.md
+++ b/docs/administrators-guide/olm-installation.md
@@ -111,6 +111,11 @@ spec:
 For pre-production clusters, change the channel to `fast`.
 For production clusters, change the channel to `stable`.
 
+To enable the ArgoCD plugin generator when installing through OLM, set
+`ARGOCD_PLUGIN_GENERATOR_BIND_ADDRESS` through `spec.config.env` on the
+`Subscription`, and provide `ARGOCD_GENERATOR_TOKEN` through the operator pod
+environment.
+
 # Airgapped environments
 
 In airgapped environments, mirror the following images into the registry that


### PR DESCRIPTION
## Pull Request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The ArgoCD plugin generator can only be enabled by passing the `--argocd-plugin-generator-bind-address` command-line flag.

## What is the new behavior?

- Adds `ARGOCD_PLUGIN_GENERATOR_BIND_ADDRESS` as an environment-based default for the existing bind-address flag.
- Keeps the plugin generator disabled by default when neither env var nor flag is set.
- Documents how to enable the plugin generator for OLM installations.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Existing command-line flag behavior remains unchanged.