### PR TITLE
fix(olm): create release catalog PR with GitHub App token

### DIFF
--- a/.github/workflows/build-and-release-image-and-olm.yml
+++ b/.github/workflows/build-and-release-image-and-olm.yml
@@ -178,11 +178,18 @@ jobs:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ secrets.BD_OPR_PAAS_GITHUB_APP_ID }}
+          private-key: ${{ secrets.BD_OPR_PAAS_GITHUB_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ env.DEFAULT_BRANCH }}
 
       - name: Install Podman
@@ -222,7 +229,7 @@ jobs:
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore(olm): add opr-paas v${{ env.VERSION }} to candidate channel'
           committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
           author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The release workflow creates the automated OLM catalog pull request with `GITHUB_TOKEN`. As a result, required PR workflows may not be triggered, which can block the PR from being merged.

Fixes: #

## What is the new behavior?

- The release catalog job now generates a GitHub App token.
- The automated OLM catalog PR is created with the GitHub App token.
- The checkout step no longer persists default credentials for the catalog PR flow.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This mirrors the GitHub App token setup already used by the `promote-catalog` workflow.