### PR TITLE
docs: Update OLM installation for operator InstallModeType

### DIFF
--- a/docs/administrators-guide/olm-installation.md
+++ b/docs/administrators-guide/olm-installation.md
@@ -85,9 +85,7 @@ kind: OperatorGroup
 metadata:
   name: opr-paas
   namespace: paas-system
-spec:
-  targetNamespaces:
-    - paas-system
+spec: {}
 ```
 
 ## Subscription


### PR DESCRIPTION
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When installing the operator with the snippets provided on this page, operator installation will fail with:

```
OwnNamespace InstallModeType not supported, cannot configure to watch own namespace
```

Fixes: # (issue)

## What is the new behavior?

This operator does not support OwnNamespace, removing targetNamespace from OperatorGroup to support AllNamespaces installations. The operator will install successfully with this change.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

