### PR TITLE
feat(olm): improve operator deployment

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	argocdplugingenerator "github.com/belastingdienst/opr-paas/v5/internal/argocd-plugin-generator"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
@@ -47,6 +48,8 @@ import (
 
 const (
 	argocdPluginGeneratorBindAddressEnv = "ARGOCD_PLUGIN_GENERATOR_BIND_ADDRESS"
+	metricsBindAddressEnv               = "METRICS_BIND_ADDRESS"
+	metricsSecureEnv                    = "METRICS_SECURE"
 	webhookErrMsg                       = "unable to create webhook"
 )
 
@@ -96,14 +99,19 @@ func main() {
 
 func configureFlags() *flags {
 	f := &flags{}
-	flag.StringVar(&f.metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
-		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
+	flag.StringVar(
+		&f.metricsAddr,
+		"metrics-bind-address",
+		defaultMetricsBindAddress(),
+		"The address the metrics endpoint binds to. "+
+			"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.",
+	)
 	flag.StringVar(&f.probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&f.getVersion, "version", false, "Print version and quit")
 	flag.BoolVar(&f.enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&f.secureMetrics, "metrics-secure", true,
+	flag.BoolVar(&f.secureMetrics, "metrics-secure", defaultMetricsSecure(),
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.StringVar(&f.webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&f.webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
@@ -136,6 +144,28 @@ func defaultArgocdPluginGeneratorBindAddress() string {
 	}
 
 	return "0"
+}
+
+func defaultMetricsBindAddress() string {
+	if value := os.Getenv(metricsBindAddressEnv); value != "" {
+		return value
+	}
+
+	return "0"
+}
+
+func defaultMetricsSecure() bool {
+	value := os.Getenv(metricsSecureEnv)
+	if value == "" {
+		return true
+	}
+
+	secure, err := strconv.ParseBool(value)
+	if err != nil {
+		return true
+	}
+
+	return secure
 }
 
 func configureLogging(pretty bool, debug bool, componentDebugList string, splitLogOutput bool) {

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -25,3 +25,44 @@ func TestDefaultArgocdPluginGeneratorBindAddress(t *testing.T) {
 		}
 	})
 }
+
+func TestDefaultMetricsBindAddress(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Setenv(metricsBindAddressEnv, "")
+
+		if got := defaultMetricsBindAddress(); got != "0" {
+			t.Fatalf("expected default bind address 0, got %q", got)
+		}
+	})
+
+	t.Run("uses environment variable", func(t *testing.T) {
+		t.Setenv(metricsBindAddressEnv, ":8080")
+
+		if got := defaultMetricsBindAddress(); got != ":8080" {
+			t.Fatalf("expected env bind address :8080, got %q", got)
+		}
+	})
+}
+
+func TestDefaultMetricsSecure(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "secure by default", want: true},
+		{name: "secure enabled", value: "true", want: true},
+		{name: "secure disabled", value: "false", want: false},
+		{name: "invalid value keeps secure default", value: "invalid", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(metricsSecureEnv, tt.value)
+
+			if got := defaultMetricsSecure(); got != tt.want {
+				t.Fatalf("expected secure metrics %t, got %t", tt.want, got)
+			}
+		})
+	}
+}

--- a/docs/administrators-guide/olm-installation.md
+++ b/docs/administrators-guide/olm-installation.md
@@ -114,6 +114,22 @@ To enable the ArgoCD plugin generator when installing through OLM, set
 `Subscription`, and provide `ARGOCD_GENERATOR_TOKEN` through the operator pod
 environment.
 
+Metrics remain disabled by default. For a secure HTTPS endpoint, set
+`METRICS_BIND_ADDRESS=:8443` and `METRICS_SECURE=true` through
+`spec.config.env` on the `Subscription`. The scraper must be configured for
+TLS and Kubernetes authentication and authorization. When no metrics
+certificate is configured, controller-runtime generates a self-signed
+certificate.
+
+For a trusted in-cluster scraper, metrics can instead be exposed over HTTP by
+setting `METRICS_BIND_ADDRESS=:8080` and `METRICS_SECURE=false`. Do not expose
+this endpoint outside the trusted cluster network. Command-line flags continue
+to take precedence over these environment-backed defaults.
+
+The OLM-managed operator runs two replicas by default to keep the admission
+webhooks available during pod disruptions and rolling updates. Leader election
+ensures that only one replica actively runs the controllers at a time.
+
 # Airgapped environments
 
 In airgapped environments, mirror the following images into the registry that

--- a/manifests/manager/opr-paas-deployment.yaml
+++ b/manifests/manager/opr-paas-deployment.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: paas-controller-manager
-  replicas: 1
+  replicas: 2 # HA for the admission webhooks
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Improve operator deployment with configurable metrics and webhook HA

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Metrics can only be configured through command-line flags, which cannot be conveniently overridden through an OLM Subscription. Metrics are disabled by default, and the OLM-managed operator runs a single replica.

## What is the new behavior?

- Metrics can be configured using `METRICS_BIND_ADDRESS` and `METRICS_SECURE`.
- Existing defaults and command-line flag precedence remain unchanged.
- The operator runs two replicas for admission webhook availability.
- The OLM documentation describes secure HTTPS and trusted in-cluster HTTP configuration.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

he environment-backed defaults allow OLM configuration through `Subscription.spec.config.env`. Existing installations without these environment variables retain their current metrics behavior.