### PR TITLE
fix: Fix namespace group filtering when reconciling rolebindings

### DIFF
--- a/internal/controller/paas_controller_test.go
+++ b/internal/controller/paas_controller_test.go
@@ -536,7 +536,6 @@ var _ = Describe("Paas Reconcile", Ordered, func() {
 		ns2SecretName            = "my-ns2-secret"
 		ns2SecretHashedName      = fmt.Sprintf("paas-ssh-%s", strings.ToLower(hashData(ns2SecretName)[:8]))
 		userGroupName            = join(paasName, paasGroupName)
-		rolebindings             = []string{techRoleName1, techRoleName2}
 		clusterRolebindings      = map[string][]string{
 			defaultPermSA: {defaultPermCR}, extraPermSA: {extraPermCR},
 		}
@@ -716,7 +715,13 @@ var _ = Describe("Paas Reconcile", Ordered, func() {
 			}
 		})
 		It("should have created paas rolebindings", func() {
-			for _, nsName := range namespaces {
+			expectedRolebindings := map[string][]string{
+				join(paasName, ns1Name):    {techRoleName1},
+				join(paasName, ns2Name):    {techRoleName1, techRoleName2},
+				join(paasName, capName):    {techRoleName1, techRoleName2},
+				join(paasName, paasNSName): {techRoleName1, techRoleName2},
+			}
+			for nsName, rolebindings := range expectedRolebindings {
 				fmt.Fprintf(GinkgoWriter, "DEBUG - Namespace: %v", nsName)
 				for _, rbName := range rolebindings {
 					var rb rbac.RoleBinding

--- a/internal/controller/rolebindings_controller.go
+++ b/internal/controller/rolebindings_controller.go
@@ -214,8 +214,8 @@ func (r *PaasReconciler) reconcileNamespaceRolebinding(
 func (r *PaasReconciler) reconcileNamespaceRolebindings(
 	ctx context.Context,
 	paas *v1alpha2.Paas,
-	paasns *v1alpha2.PaasNS,
 	nsName string,
+	groupKeys []string,
 ) error {
 	ctx, logger := logging.GetLogComponent(ctx, logging.ControllerRoleBindingComponent)
 	// Use a map of sets to avoid duplicates
@@ -233,10 +233,7 @@ func (r *PaasReconciler) reconcileNamespaceRolebindings(
 	}
 
 	logger.Info().Any("Rolebindings map", roleGroups).Msg("all roles")
-	paasGroups := paas.Spec.Groups
-	if paasns != nil {
-		paasGroups = paasGroups.Filtered(paasns.Spec.Groups)
-	}
+	paasGroups := paas.Spec.Groups.Filtered(groupKeys)
 	for groupKey, groupRoles := range paasGroups.Roles() {
 		logger.Info().Msgf("defining Rolebindings for Group %s", groupKey)
 		// Convert the groupKey to a groupName to map the rolebinding subjects to a group
@@ -269,7 +266,7 @@ func (r *PaasReconciler) reconcilePaasRolebindings(
 	nsDefs namespaceDefs,
 ) error {
 	for _, nsDef := range nsDefs {
-		err := r.reconcileNamespaceRolebindings(ctx, paas, nsDef.paasns, nsDef.nsName)
+		err := r.reconcileNamespaceRolebindings(ctx, paas, nsDef.nsName, nsDef.groups)
 		if err != nil {
 			return err
 		}

--- a/internal/controller/rolebindings_controller_test.go
+++ b/internal/controller/rolebindings_controller_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Rolebinding", Ordered, func() {
 		expectedTecRoles := []string{tecRole1, tecRole2}
 
 		It("reconciles successfully", func() {
-			err := reconciler.reconcileNamespaceRolebindings(ctx, paas, nil, ns1)
+			err := reconciler.reconcileNamespaceRolebindings(ctx, paas, ns1, paas.Spec.Groups.Keys())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -138,6 +138,68 @@ var _ = Describe("Rolebinding", Ordered, func() {
 				Expect(rb.ObjectMeta.Labels).To(HaveKeyWithValue(key, value))
 			}
 			Expect(rb.ObjectMeta.Labels).NotTo(HaveKey(kubeInstLabel))
+		})
+	})
+
+	When("namespaces select different groups", func() {
+		It("only binds each namespace's selected groups", func() {
+			const (
+				adminGroupKey = "admin-group"
+				viewGroupKey  = "view-group"
+				adminFuncRole = "admin-role"
+				viewFuncRole  = "view-role"
+			)
+			adminNamespace := join(paasName, "admin-ns")
+			viewNamespace := join(paasName, "view-ns")
+			assureNamespace(ctx, adminNamespace)
+			assureNamespace(ctx, viewNamespace)
+
+			paas.Spec.Groups = v1alpha2.PaasGroups{
+				adminGroupKey: {Roles: []string{adminFuncRole}},
+				viewGroupKey:  {Roles: []string{viewFuncRole}},
+			}
+			myConfig.Spec.RoleMappings = v1alpha2.ConfigRoleMappings{
+				adminFuncRole: {tecRole1},
+				viewFuncRole:  {tecRole2},
+			}
+			ctx = context.WithValue(ctx, config.ContextKeyPaasConfig, myConfig)
+
+			nsDefs := namespaceDefs{
+				adminNamespace: newNamespaceDef(adminNamespace, paasName, []string{adminGroupKey}, nil),
+				viewNamespace:  newNamespaceDef(viewNamespace, paasName, []string{viewGroupKey}, nil),
+			}
+			Expect(reconciler.reconcilePaasRolebindings(ctx, paas, nsDefs)).To(Succeed())
+
+			var adminBinding rbac.RoleBinding
+			Expect(reconciler.Get(ctx, types.NamespacedName{
+				Name:      join("paas", tecRole1),
+				Namespace: adminNamespace,
+			}, &adminBinding)).To(Succeed())
+			Expect(adminBinding.Subjects).To(ConsistOf(rbac.Subject{
+				Kind:     "Group",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     paas.GroupKey2GroupName(adminGroupKey),
+			}))
+
+			var viewBinding rbac.RoleBinding
+			Expect(reconciler.Get(ctx, types.NamespacedName{
+				Name:      join("paas", tecRole2),
+				Namespace: viewNamespace,
+			}, &viewBinding)).To(Succeed())
+			Expect(viewBinding.Subjects).To(ConsistOf(rbac.Subject{
+				Kind:     "Group",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     paas.GroupKey2GroupName(viewGroupKey),
+			}))
+
+			Expect(reconciler.Get(ctx, types.NamespacedName{
+				Name:      join("paas", tecRole2),
+				Namespace: adminNamespace,
+			}, &rbac.RoleBinding{})).To(MatchError(ContainSubstring("not found")))
+			Expect(reconciler.Get(ctx, types.NamespacedName{
+				Name:      join("paas", tecRole1),
+				Namespace: viewNamespace,
+			}, &rbac.RoleBinding{})).To(MatchError(ContainSubstring("not found")))
 		})
 	})
 })


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Rolebindings are reconciled for all PaaS groups in every namespace, even when a namespace only references specific groups.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Rolebindings now respect the groups configured on each namespace.
- Only the rolebindings for the selected namespace groups are created.
- Tests have been updated to cover namespace-specific group filtering.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->