### PR TITLE
docs: remove block on thin storage

### DIFF
--- a/docs/administrators-guide/capabilities.md
+++ b/docs/administrators-guide/capabilities.md
@@ -77,7 +77,6 @@ Below example shows all configuration required to configure a capability.
               requests.cpu: "16"
               requests.memory: 16Gi
               requests.storage: "10Gi"
-              thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
             ratio: 0.1
     ```
 

--- a/docs/administrators-guide/configuration.md
+++ b/docs/administrators-guide/configuration.md
@@ -110,7 +110,6 @@ Example PaasConfig
               requests.cpu: "4"
               requests.memory: 5Gi
               requests.storage: "5Gi"
-              thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
             min: {}
             max: {}
             ratio: 0
@@ -126,7 +125,6 @@ Example PaasConfig
               requests.cpu: "1"
               requests.memory: 1Gi
               requests.storage: "2Gi"
-              thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
             min: {}
             max: {}
             ratio: 0
@@ -145,7 +143,6 @@ Example PaasConfig
               requests.cpu: "1"
               requests.memory: 2Gi
               requests.storage: "100Gi"
-              thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
             min: {}
             max: {}
             ratio: 0.1
@@ -161,7 +158,6 @@ Example PaasConfig
               requests.cpu: "2"
               requests.memory: 2Gi
               requests.storage: "5Gi"
-              thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
             min: {}
             max: {}
             ratio: 0

--- a/examples/resources/_v1alpha1_paas.yaml
+++ b/examples/resources/_v1alpha1_paas.yaml
@@ -37,7 +37,6 @@ spec:
     requests.cpu: '10'
     requests.memory: 32Gi
     requests.storage: 1024Gi
-    thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
   capabilities:
     argocd:
       enabled: true
@@ -47,7 +46,6 @@ spec:
         requests.cpu: '1'
         requests.memory: 4Gi
         requests.storage: 20Gi
-        thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
       gitUrl: https://
     tekton:
       quota:
@@ -56,4 +54,3 @@ spec:
         requests.cpu: '1'
         requests.memory: 4Gi
         requests.storage: 20Gi
-        thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'

--- a/examples/resources/_v1alpha1_paasconfig.yaml
+++ b/examples/resources/_v1alpha1_paasconfig.yaml
@@ -28,7 +28,6 @@ spec:
           requests.cpu: '1'
           requests.memory: 1Gi
           requests.storage: '0'
-          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
         ratio: 0
     tekton:
       applicationset: tektonas
@@ -47,7 +46,6 @@ spec:
           requests.cpu: '1'
           requests.memory: 2Gi
           requests.storage: '100Gi'
-          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
         min:
           limits.cpu: '5'
           limits.memory: 4Gi
@@ -67,7 +65,6 @@ spec:
           requests.cpu: '100m'
           requests.memory: 128Mi
           requests.storage: '0'
-          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
         ratio: 0
     grafana:
       applicationset: grafanaas
@@ -81,7 +78,6 @@ spec:
           requests.cpu: '500m'
           requests.memory: 512Mi
           requests.storage: '2Gi'
-          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
         ratio: 0
   debug: false
   decryptKeySecret:

--- a/examples/resources/_v1alpha2_paas.yaml
+++ b/examples/resources/_v1alpha2_paas.yaml
@@ -38,7 +38,6 @@ spec:
     requests.cpu: '10'
     requests.memory: 32Gi
     requests.storage: 1024Gi
-    thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
   capabilities:
     argocd:
       quota:

--- a/examples/resources/_v1alpha2_paasconfig.yaml
+++ b/examples/resources/_v1alpha2_paasconfig.yaml
@@ -29,7 +29,6 @@ spec:
           requests.cpu: '1'
           requests.memory: 1Gi
           requests.storage: '0'
-          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
         ratio: 0
     grafana:
       applicationset: grafanaas
@@ -41,7 +40,6 @@ spec:
           requests.cpu: 500m
           requests.memory: 512Mi
           requests.storage: 2Gi
-          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
         ratio: 0
     sso:
       applicationset: ssoas
@@ -53,7 +51,6 @@ spec:
           requests.cpu: 100m
           requests.memory: 128Mi
           requests.storage: '0'
-          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
         ratio: 0
     tekton:
       applicationset: tektonas
@@ -72,7 +69,6 @@ spec:
           requests.cpu: '1'
           requests.memory: 2Gi
           requests.storage: 100Gi
-          thin.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
         max:
           requests.cpu: '10'
           requests.memory: 10Gi

--- a/internal/webhook/v1alpha2/paas_webhook_test.go
+++ b/internal/webhook/v1alpha2/paas_webhook_test.go
@@ -779,14 +779,12 @@ var _ = Describe("Paas Webhook", Ordered, func() {
 					"requests.cpu",
 					"requests.memory",
 					"requests.storage",
-					"thin.storageclass.storage.k8s.io/persistentvolumeclaims",
 				}
 				validQuotas = quota.Quota{
 					"limits.memory":    resource.MustParse("100M"),
 					"requests.cpu":     resource.MustParse("1.1"),
 					"requests.memory":  resource.MustParse("100M"),
 					"requests.storage": resource.MustParse("10G"),
-					"thin.storageclass.storage.k8s.io/persistentvolumeclaims": resource.MustParse("10G"),
 				}
 				validation       = fmt.Sprintf("(%s)", strings.Join(validResourceKeys, "|"))
 				validationConfig = v1alpha2.PaasConfigValidations{

--- a/internal/webhook/v1alpha2/paasconfig_webhook_test.go
+++ b/internal/webhook/v1alpha2/paasconfig_webhook_test.go
@@ -290,14 +290,12 @@ var _ = Describe("Creating a PaasConfig", Ordered, func() {
 					"requests.cpu",
 					"requests.memory",
 					"requests.storage",
-					"thin.storageclass.storage.k8s.io/persistentvolumeclaims",
 				}
 				validQuotas = map[corev1.ResourceName]resourcev1.Quantity{
 					"limits.memory":    resourcev1.MustParse("100M"),
 					"requests.cpu":     resourcev1.MustParse("1.1"),
 					"requests.memory":  resourcev1.MustParse("100M"),
 					"requests.storage": resourcev1.MustParse("10G"),
-					"thin.storageclass.storage.k8s.io/persistentvolumeclaims": resourcev1.MustParse("10G"),
 				}
 				validation    = fmt.Sprintf("(%s)", strings.Join(validResourceKeys, "|"))
 				invalidQuotas = map[corev1.ResourceName]resourcev1.Quantity{

--- a/test/e2e/capability_argocd_test.go
+++ b/test/e2e/capability_argocd_test.go
@@ -100,12 +100,11 @@ func assertArgoCapCreated(ctx context.Context, t *testing.T, cfg *envconf.Config
 		"Quota selects ArgoCD namespace via selector set to `quota_label` configuration",
 	)
 	assert.Equal(t, corev1.ResourceList{
-		corev1.ResourceLimitsCPU:                                  resource.MustParse("5"),
-		corev1.ResourceRequestsCPU:                                resource.MustParse("1"),
-		corev1.ResourceLimitsMemory:                               resource.MustParse("4Gi"),
-		corev1.ResourceRequestsMemory:                             resource.MustParse("1Gi"),
-		corev1.ResourceRequestsStorage:                            resource.MustParse("0"),
-		"thin.storageclass.storage.k8s.io/persistentvolumeclaims": resource.MustParse("0"),
+		corev1.ResourceLimitsCPU:       resource.MustParse("5"),
+		corev1.ResourceRequestsCPU:     resource.MustParse("1"),
+		corev1.ResourceLimitsMemory:    resource.MustParse("4Gi"),
+		corev1.ResourceRequestsMemory:  resource.MustParse("1Gi"),
+		corev1.ResourceRequestsStorage: resource.MustParse("0"),
 	}, crq.Spec.Quota.Hard, "Quota conforms to defaults from Paas config")
 
 	return ctx

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -58,10 +58,6 @@ var (
 							corev1.ResourceRequestsCPU:     resourcev1.MustParse("1"),
 							corev1.ResourceRequestsMemory:  resourcev1.MustParse("1Gi"),
 							corev1.ResourceRequestsStorage: resourcev1.MustParse("0"),
-							// revive:disable-next-line
-							corev1.ResourceName("thin.storageclass.storage.k8s.io/persistentvolumeclaims"): resourcev1.MustParse(
-								"0",
-							),
 						},
 					},
 					CustomFields: map[string]v1alpha2.ConfigCustomField{
@@ -89,10 +85,6 @@ var (
 							corev1.ResourceRequestsCPU:     resourcev1.MustParse("5"),
 							corev1.ResourceRequestsMemory:  resourcev1.MustParse("6Gi"),
 							corev1.ResourceRequestsStorage: resourcev1.MustParse("0"),
-							// revive:disable-next-line
-							corev1.ResourceName("thin.storageclass.storage.k8s.io/persistentvolumeclaims"): resourcev1.MustParse(
-								"0",
-							),
 						},
 					},
 				},
@@ -112,10 +104,6 @@ var (
 							corev1.ResourceRequestsCPU:     resourcev1.MustParse("1"),
 							corev1.ResourceRequestsMemory:  resourcev1.MustParse("2Gi"),
 							corev1.ResourceRequestsStorage: resourcev1.MustParse("100Gi"),
-							// revive:disable-next-line
-							corev1.ResourceName("thin.storageclass.storage.k8s.io/persistentvolumeclaims"): resourcev1.MustParse(
-								"0",
-							),
 						},
 						MinQuotas: map[corev1.ResourceName]resourcev1.Quantity{
 							corev1.ResourceLimitsCPU:    resourcev1.MustParse("5"),
@@ -138,10 +126,6 @@ var (
 							corev1.ResourceRequestsCPU:     resourcev1.MustParse("100m"),
 							corev1.ResourceRequestsMemory:  resourcev1.MustParse("128Mi"),
 							corev1.ResourceRequestsStorage: resourcev1.MustParse("0"),
-							// revive:disable-next-line
-							corev1.ResourceName("thin.storageclass.storage.k8s.io/persistentvolumeclaims"): resourcev1.MustParse(
-								"0",
-							),
 						},
 					},
 				},
@@ -154,10 +138,6 @@ var (
 							corev1.ResourceRequestsCPU:     resourcev1.MustParse("500m"),
 							corev1.ResourceRequestsMemory:  resourcev1.MustParse("512Mi"),
 							corev1.ResourceRequestsStorage: resourcev1.MustParse("2Gi"),
-							// revive:disable-next-line
-							corev1.ResourceName("thin.storageclass.storage.k8s.io/persistentvolumeclaims"): resourcev1.MustParse(
-								"0",
-							),
 						},
 					},
 				},


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In docs and examples the `quota:` block almost always contains `thin.storageclass.storage.k8s.io/persistentvolumeclaims: "0"`, effectively blocking a specific StorageClass named "thin". As there is no reason within this project to dislike "thin" and there's no educational value in it, I would propose to remove it. 

## What is the new behavior?

The same examples, without blocking of "thin"

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

