### PR TITLE
fix: quota label validation

### DIFF
--- a/internal/webhook/v1alpha2/paasconfig_webhook.go
+++ b/internal/webhook/v1alpha2/paasconfig_webhook.go
@@ -174,6 +174,7 @@ func validatePaasConfigSpec(
 		)...)
 	}
 
+	allErrs = append(allErrs, validateQuotaLabelField(spec, childPath)...)
 	allErrs = append(allErrs, validateDecryptKeysSecretExists(ctx, k8sClient, spec.DecryptKeysSecret, childPath)...)
 	allErrs = append(allErrs, validateValidationFields(spec.Validations, childPath)...)
 	allErrs = append(allErrs, validateConfigCapabilityNames(spec, childPath)...)
@@ -188,6 +189,39 @@ func validatePaasConfigSpec(
 	}
 
 	return warn, allErrs
+}
+
+// Valid label keys
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+// Labels are key/value pairs.
+// Valid label keys have two segments: an optional prefix and name, separated by a slash (/).
+// The name segment is required and must be 63 characters or less, beginning and ending with an alphanumeric character
+// ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between.
+// The prefix is optional. If specified, the prefix must be a DNS subdomain: a series of DNS labels separated by dots
+// (.), not longer than 253 characters in total, followed by a slash (/).
+//
+// If the prefix is omitted, the label Key is presumed to be private to the user.
+// Automated system components (e.g. kube-scheduler, kube-controller-manager, kube-apiserver, kubectl,
+// or other third-party automation) which add labels to end-user objects must specify a prefix.
+//
+//revive:disable-next-line
+var labelKeyValidationRegex = regexp.MustCompile(`^(([a-z0-9]([-a-z0-9]*[a-z0-9])?\.)*[a-z0-9]([-a-z0-9]*[a-z0-9])?\/)?[a-zA-Z0-9]([-_./a-zA-Z0-9]{0,61}[a-zA-Z0-9])?$`)
+
+func validateQuotaLabelField(
+	spec v1alpha2.PaasConfigSpec,
+	rootPath *field.Path,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	if spec.QuotaLabel != "" && !labelKeyValidationRegex.MatchString(spec.QuotaLabel) {
+		allErrs = append(allErrs, field.Invalid(
+			rootPath.Child("quota_label"),
+			spec.QuotaLabel,
+			fmt.Sprintf("quota label is invalid (`%s` does not comply to re: `%s`)", spec.QuotaLabel,
+				labelKeyValidationRegex.String()),
+		))
+	}
+
+	return allErrs
 }
 
 func validateConfigCapabilities(

--- a/internal/webhook/v1alpha2/paasconfig_webhook_test.go
+++ b/internal/webhook/v1alpha2/paasconfig_webhook_test.go
@@ -79,6 +79,14 @@ var _ = Describe("Creating a PaasConfig", Ordered, func() {
 				Expect(warn, err).Error().NotTo(HaveOccurred())
 			})
 		})
+		Context("with invalid label definition", func() {
+			It("should raise an error", func() {
+				obj.Spec.QuotaLabel = "$"
+				_, err := validator.ValidateCreate(ctx, obj)
+				Expect(err).Error().To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`quota label is invalid`))
+			})
+		})
 		Context("with invalid Validation regular expressions", func() {
 			It("should raise an error", func() {
 				obj.Spec.Validations["paas"]["groupName"] = ".*)"


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Fixes: #1038

## What is the new behavior?

- We validate label keys when quota_label is set in a paas config

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

For now we have decided not to fix the issue for clusterQuotaLabels, as:
- this is not a direct key, rather a go-template
- validating the result might depend on values in a paas, thus we should validate this in paas webhook, but users might not be able to resolve it (as they cannot edit paas config)
- impact is minimal, as this is usually used to copy labels from paas to quota and/or other resources