### PR TITLE
ci: let trivy continue when the db is not present

### DIFF
--- a/.github/workflows/build-and-release-image-and-olm.yml
+++ b/.github/workflows/build-and-release-image-and-olm.yml
@@ -92,9 +92,6 @@ jobs:
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           severity: 'MEDIUM,HIGH,CRITICAL'
           scanners: 'vuln'
-        env:
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Add SBOM to release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The GitHub Action "Build and release image + OLM and add to ghcr.io upon release" failed during release of v5.10.0 (see run https://github.com/belastingdienst/opr-paas/actions/runs/33794982644). The failure was caused by a combination of these  events:

* The Trivy database was downloaded at midnight (by https://github.com/belastingdienst/opr-paas/actions/runs/33701888727)
* The cache usage for this project is currently high (see [here](https://github.com/belastingdienst/opr-paas/actions/caches)), approaching the total storage limit of 10GB. 
* GitHub will start evicting based on least recently used. The Trivy cache is only used by the nightly update and the OLM pipeline that only runs on releases
* So when the pipeline ran in the evening the cache was already evicted. The action sets `TRIVY_SKIP_DB_UPDATE: true` so when the cache is not present, Trivy will fail.


## What is the new behavior?

In this change the `TRIVY_SKIP_DB_UPDATE: true` env's have been removed. This will cause the following:

* If the cache has been expired, the action will download the databases
* If the cache is present, Trivy will check if the cache still holds the most recent version. If not, it will update the cached database first.

The database is released every 6 hours, so there's a chance it will update the cached database. As the action is only used on the release workflows that run infrequently, I would propose to let it update the cache so the workflow will continue.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->